### PR TITLE
🔧 Configure signing for Wear & refine Sonar exclusions

### DIFF
--- a/buildSrc/src/main/kotlin/sonarqube.gradle.kts
+++ b/buildSrc/src/main/kotlin/sonarqube.gradle.kts
@@ -26,8 +26,14 @@ subprojects {
                 filesSafeProperty("sonar.tests", "$projectDir/src/test/java")
 
                 // Exclude specific classes from coverage reports using KoverConfig settings.
-                property("sonar.exclusions", "**/libraries/chart/**, **/libraries/chart/**/*")
-                property("sonar.coverage.exclusions", "**/libraries/chart/**, **/libraries/chart/**/*")
+                property(
+                    "sonar.exclusions",
+                    KoverConfig.koverReportExclusionsClasses.joinToString(separator = ",")
+                )
+                property(
+                    "sonar.coverage.exclusions",
+                    KoverConfig.koverReportExclusionsClasses.joinToString(separator = ",")
+                )
 
                 // Specify the coverage plugin.
                 property("sonar.java.coveragePlugin", "jacoco")


### PR DESCRIPTION
- Added signing configurations for Wear module.
- Adjusted SonarQube exclusions to align with Kover settings for better consistency in coverage reports.

# Description

 - Added signing configurations for the Wear module to ensure proper signing during builds.
 - Adjusted SonarQube exclusions to align with Kover settings, ensuring consistent coverage reporting.

## Motivation and Context

These changes improve the build process by ensuring the Wear module has the correct signing setup while refining Sonar and Kover coverage configurations to exclude unnecessary files, leading to more accurate analysis and reporting.

**Related Issue:** N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Minor change / Task
- [ ] Documentation update

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual tests
- [ ] Other (please describe):

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's coding style.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes do not produce any new warnings.
- [ ] I have added tests that prove my fix or feature works.
- [x] All new and existing tests pass locally.
- [] Any dependent changes have been merged and published in downstream modules.

## Additional Context

No breaking changes expected. These adjustments improve maintainability and ensure consistency across modules.
