### PR TITLE
Improve swipe-to-dismiss with RevealSwipe v2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # Smoke Analytics
 
 [![CI](https://github.com/feragusper/SmokeAnalytics/actions/workflows/deployment_artifact.yml/badge.svg?branch=master)](https://github.com/feragusper/SmokeAnalytics/actions/workflows/deployment_artifact.yml)
-
 [![CI](https://github.com/feragusper/SmokeAnalytics/actions/workflows/deployment_playstore.yml/badge.svg?branch=master)](https://github.com/feragusper/SmokeAnalytics/actions/workflows/deployment_playstore.yml)
-
 [![CI](https://github.com/feragusper/SmokeAnalytics/actions/workflows/integration.yml/badge.svg?branch=master)](https://github.com/feragusper/SmokeAnalytics/actions/workflows/integration.yml)
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=feragusper_SmokeAnalytics&metric=alert_status)](https://sonarcloud.io/dashboard?id=feragusper_SmokeAnalytics>)

--- a/features/history/presentation/src/main/java/com/feragusper/smokeanalytics/features/history/presentation/mvi/compose/HistoryViewState.kt
+++ b/features/history/presentation/src/main/java/com/feragusper/smokeanalytics/features/history/presentation/mvi/compose/HistoryViewState.kt
@@ -240,7 +240,7 @@ data class HistoryViewState(
                                 date = smoke.date,
                                 timeElapsedSincePreviousSmoke = smoke.timeElapsedSincePreviousSmoke,
                                 onDelete = { intent(HistoryIntent.DeleteSmoke(smoke.id)) },
-                                fullDateTimeEdit = false,
+                                fullDateTimeEdit = true,
                                 onEdit = { date -> intent(HistoryIntent.EditSmoke(smoke.id, date)) }
                             )
                             HorizontalDivider()

--- a/features/home/presentation/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
+++ b/features/home/presentation/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
@@ -337,7 +337,7 @@ private fun LatestSmokesSection(
 @Composable
 private fun HomeViewLoadingPreview() {
     SmokeAnalyticsTheme {
-//        HomeViewState(displayLoading = true).Compose {}
+        HomeViewState(displayLoading = true).Compose({ _, _ -> }, {})
     }
 }
 
@@ -345,6 +345,6 @@ private fun HomeViewLoadingPreview() {
 @Composable
 private fun HomeViewPreview() {
     SmokeAnalyticsTheme {
-//        HomeViewState().Compose {}
+        HomeViewState().Compose({ _, _ -> }, {})
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ navVersion = "2.8.8"
 playServicesWearable = "19.0.0"
 protolayoutCore = "1.2.1"
 protolayoutMaterial = "1.2.1"
+revealswipe = "2.2.0"
 sonarqubeGradlePlugin = "4.0.0.2929"
 tiles = "1.4.1"
 tilesMaterial = "1.4.1"
@@ -92,6 +93,7 @@ material3 = { module = "androidx.compose.material3:material3", version.ref = "ma
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockkAndroid = { module = "io.mockk:mockk-android", version.ref = "mockk" }
 play-services-wearable = { module = "com.google.android.gms:play-services-wearable", version.ref = "playServicesWearable" }
+revealswipe = { module = "de.charlex.compose:revealswipe", version.ref = "revealswipe" }
 sonarqube-gradle-plugin = { module = "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin", version.ref = "sonarqubeGradlePlugin" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 vico-compose = { group = "com.patrykandpatrick.vico", name = "compose", version.ref = "vico" }

--- a/libraries/smokes/presentation/build.gradle.kts
+++ b/libraries/smokes/presentation/build.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
     // Include the architecture domain module for shared domain logic.
     implementation(project(":libraries:architecture:domain"))
 
+    implementation(libs.revealswipe)
+
     // Use the Compose BOM for consistent Compose library versions.
     implementation(platform(libs.androidx.compose.bom))
     // Include a bundle of Jetpack Compose libraries.


### PR DESCRIPTION
# Description

This PR refactors the existing swipe-to-dismiss logic in the home screen by integrating the [RevealSwipe](https://github.com/charlex/reveal-swipe) library (v2.2.0).
It enables swipe gestures in both directions and improves the visual and interaction feedback for smoke events.

## Motivation and Context

Replaces the deprecated SwipeToDismissBox with a modern, more customizable solution.
Allows swiping to the start (left → right) to edit a smoke.
Allows swiping to the end (right → left) to delete a smoke.
Adds proper ripple feedback for both actions.
Ensures swipe thresholds are respected to avoid accidental deletions.

**Related Issue:** #92

## Type of Change

<!-- Select all that apply: -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Minor change / Task
- [ ] Documentation update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Provide instructions so reviewers can reproduce the tests and include any relevant test configurations. -->

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests
- [ ] Other (please describe):

## Screenshots (if applicable)

N/A

## Checklist

<!-- Go over all the following points, and put an 'x' in all the boxes that apply. -->

- [x] My code follows the project's coding style.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation as needed.
- [x] My changes do not produce any new warnings.
- [x] I have added tests that prove my fix or feature works.
- [x] All new and existing tests pass locally.
- [x] Any dependent changes have been merged and published in downstream modules.

## Additional Context

This prepares the swipe behavior for a more dynamic and user-friendly home screen experience.
The edit and delete actions are now visually aligned with Material Design guidelines.
