### PR TITLE
Tranche 2: dashboard home and subtler pacing feedback

### DIFF
--- a/apps/mobile/src/main/java/com/feragusper/smokeanalytics/MainActivity.kt
+++ b/apps/mobile/src/main/java/com/feragusper/smokeanalytics/MainActivity.kt
@@ -266,18 +266,18 @@ private fun MainScreenNavigationConfigurations(
 
 @Composable
 private fun ElapsedTone.containerColor() = when (this) {
-    ElapsedTone.Urgent -> MaterialTheme.colorScheme.error
-    ElapsedTone.Warning -> MaterialTheme.colorScheme.tertiary
-    ElapsedTone.Caution -> MaterialTheme.colorScheme.secondary
-    ElapsedTone.Calm -> MaterialTheme.colorScheme.primary
+    ElapsedTone.Urgent -> MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.72f)
+    ElapsedTone.Warning -> MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.64f)
+    ElapsedTone.Caution -> MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.56f)
+    ElapsedTone.Calm -> MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.52f)
 }
 
 @Composable
 private fun ElapsedTone.contentColor() = when (this) {
-    ElapsedTone.Urgent -> MaterialTheme.colorScheme.onError
-    ElapsedTone.Warning -> MaterialTheme.colorScheme.onTertiary
-    ElapsedTone.Caution -> MaterialTheme.colorScheme.onSecondary
-    ElapsedTone.Calm -> MaterialTheme.colorScheme.onPrimary
+    ElapsedTone.Urgent -> MaterialTheme.colorScheme.onErrorContainer
+    ElapsedTone.Warning -> MaterialTheme.colorScheme.onTertiaryContainer
+    ElapsedTone.Caution -> MaterialTheme.colorScheme.onSecondaryContainer
+    ElapsedTone.Calm -> MaterialTheme.colorScheme.onPrimaryContainer
 }
 
 /**

--- a/features/history/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/history/presentation/HistoryWebScreen.kt
+++ b/features/history/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/history/presentation/HistoryWebScreen.kt
@@ -265,12 +265,24 @@ private fun HistorySmokeList(
             val hh = local.hour.toString().padStart(2, '0')
             val mm = local.minute.toString().padStart(2, '0')
             val timeLabel = "$hh:$mm"
-            val subtitle = local.date.toUiDate()
+            val subtitle = smoke.timeElapsedSincePreviousSmoke.let { (h, m) ->
+                if (h > 0) "After ${h}h ${m}m" else "After ${m}m"
+            }
+            val toneClass = when (elapsedToneFrom(
+                smoke.timeElapsedSincePreviousSmoke.first,
+                smoke.timeElapsedSincePreviousSmoke.second,
+            )) {
+                ElapsedTone.Urgent -> SmokeWebStyles.listRowUrgent
+                ElapsedTone.Warning -> SmokeWebStyles.listRowWarning
+                ElapsedTone.Caution -> SmokeWebStyles.listRowCaution
+                ElapsedTone.Calm -> SmokeWebStyles.listRowCalm
+            }
 
             if (!isEditing) {
                 SmokeRow(
                     time = timeLabel,
                     subtitle = subtitle,
+                    toneClass = toneClass,
                     onEdit = {
                         editing[id] = true
                         draftDateTime[id] = smoke.date.toHtmlDateTimeLocal(tz)
@@ -324,6 +336,23 @@ private fun HistorySmokeList(
                 }
             }
         }
+    }
+}
+
+private enum class ElapsedTone {
+    Urgent,
+    Warning,
+    Caution,
+    Calm,
+}
+
+private fun elapsedToneFrom(hours: Long, minutes: Long): ElapsedTone {
+    val totalMinutes = (hours * 60L + minutes).toInt()
+    return when {
+        totalMinutes >= 180 -> ElapsedTone.Calm
+        totalMinutes >= 90 -> ElapsedTone.Caution
+        totalMinutes >= 45 -> ElapsedTone.Warning
+        else -> ElapsedTone.Urgent
     }
 }
 

--- a/features/home/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/domain/HomeInsights.kt
+++ b/features/home/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/domain/HomeInsights.kt
@@ -32,10 +32,20 @@ data class FinancialSummary(
     val currencySymbol: String,
 )
 
-fun elapsedToneFrom(hours: Long, minutes: Long): ElapsedTone = when {
-    hours >= 4 -> ElapsedTone.Calm
-    hours >= 2 || minutes >= 30 -> ElapsedTone.Caution
-    hours >= 1 || minutes >= 30 -> ElapsedTone.Warning
+data class RateSummary(
+    val latestIntervalMinutes: Int?,
+    val averageIntervalMinutesToday: Int?,
+    val averageSmokesPerDayWeek: Double,
+    val averageSmokesPerDayMonth: Double,
+)
+
+fun elapsedToneFrom(hours: Long, minutes: Long): ElapsedTone =
+    elapsedToneFromMinutes((hours * 60L + minutes).toInt())
+
+fun elapsedToneFromMinutes(totalMinutes: Int): ElapsedTone = when {
+    totalMinutes >= 180 -> ElapsedTone.Calm
+    totalMinutes >= 90 -> ElapsedTone.Caution
+    totalMinutes >= 45 -> ElapsedTone.Warning
     else -> ElapsedTone.Urgent
 }
 
@@ -68,6 +78,22 @@ fun financialSummary(
         spentWeek = weekCount * price,
         spentMonth = monthCount * price,
         currencySymbol = preferences.currencySymbol,
+    )
+}
+
+fun rateSummary(smokeCountListResult: SmokeCountListResult): RateSummary {
+    val intervals = smokeCountListResult.todaysSmokes
+        .map { smoke -> smoke.timeElapsedSincePreviousSmoke.totalMinutes() }
+        .filter { it > 0 }
+
+    return RateSummary(
+        latestIntervalMinutes = smokeCountListResult.lastSmoke
+            ?.timeElapsedSincePreviousSmoke
+            ?.totalMinutes()
+            ?.takeIf { it > 0 },
+        averageIntervalMinutesToday = intervals.takeIf { it.isNotEmpty() }?.average()?.toInt(),
+        averageSmokesPerDayWeek = smokeCountListResult.countByWeek / 7.0,
+        averageSmokesPerDayMonth = smokeCountListResult.countByMonth / 30.0,
     )
 }
 
@@ -127,3 +153,5 @@ fun SmokeCountListResult.toWidgetSnapshot(preferences: UserPreferences): WidgetS
         spentToday = financial.spentToday,
     )
 }
+
+private fun Pair<Long, Long>.totalMinutes(): Int = (first * 60L + second).toInt()

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/HomeViewModel.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/HomeViewModel.kt
@@ -95,6 +95,7 @@ class HomeViewModel @Inject constructor(
                 smokesPerWeek = 0,
                 smokesPerMonth = 0,
                 timeSinceLastCigarette = 0L to 0L,
+                lastSmoke = null,
                 canStartNewDay = false,
             )
 
@@ -126,10 +127,12 @@ class HomeViewModel @Inject constructor(
                     smokesPerWeek = result.smokeCountListResult.countByWeek,
                     smokesPerMonth = result.smokeCountListResult.countByMonth,
                     latestSmokes = result.smokeCountListResult.todaysSmokes,
+                    lastSmoke = result.smokeCountListResult.lastSmoke,
                     timeSinceLastCigarette = result.smokeCountListResult.timeSinceLastCigarette,
                     greetingTitle = result.greetingState.title,
                     greetingMessage = result.greetingState.message,
                     financialSummary = result.financialSummary,
+                    rateSummary = result.rateSummary,
                     gamificationSummary = result.gamificationSummary,
                     canStartNewDay = result.canStartNewDay,
                     elapsedTone = elapsedToneFrom(
@@ -141,7 +144,12 @@ class HomeViewModel @Inject constructor(
 
             is UpdateTimeSinceLastCigarette -> {
                 previous.copy(
-                    timeSinceLastCigarette = result.timeSinceLastCigarette
+                    timeSinceLastCigarette = result.timeSinceLastCigarette,
+                    lastSmoke = result.lastSmoke,
+                    elapsedTone = elapsedToneFrom(
+                        result.timeSinceLastCigarette.first,
+                        result.timeSinceLastCigarette.second,
+                    ),
                 )
             }
 

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/HomeResult.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/HomeResult.kt
@@ -4,8 +4,10 @@ import com.feragusper.smokeanalytics.features.home.domain.SmokeCountListResult
 import com.feragusper.smokeanalytics.features.home.domain.FinancialSummary
 import com.feragusper.smokeanalytics.features.home.domain.GamificationSummary
 import com.feragusper.smokeanalytics.features.home.domain.GreetingState
+import com.feragusper.smokeanalytics.features.home.domain.RateSummary
 import com.feragusper.smokeanalytics.libraries.architecture.presentation.mvi.MVIResult
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
 
 /**
  * Represents the possible outcomes of processing [HomeIntent] actions.
@@ -86,6 +88,7 @@ sealed interface HomeResult : MVIResult {
         val preferences: UserPreferences,
         val greetingState: GreetingState,
         val financialSummary: FinancialSummary,
+        val rateSummary: RateSummary,
         val gamificationSummary: GamificationSummary,
         val canStartNewDay: Boolean,
     ) : HomeResult
@@ -102,6 +105,7 @@ sealed interface HomeResult : MVIResult {
      * represented as a pair of hours and minutes.
      */
     data class UpdateTimeSinceLastCigarette(
-        val timeSinceLastCigarette: Pair<Long, Long>
+        val timeSinceLastCigarette: Pair<Long, Long>,
+        val lastSmoke: Smoke?,
     ) : HomeResult
 }

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
@@ -12,17 +12,19 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
@@ -50,16 +52,13 @@ import com.feragusper.smokeanalytics.features.home.presentation.mvi.HomeResult
 import com.feragusper.smokeanalytics.features.home.domain.ElapsedTone
 import com.feragusper.smokeanalytics.features.home.domain.FinancialSummary
 import com.feragusper.smokeanalytics.features.home.domain.GamificationSummary
+import com.feragusper.smokeanalytics.features.home.domain.RateSummary
 import com.feragusper.smokeanalytics.libraries.architecture.presentation.mvi.MVIViewState
 import com.feragusper.smokeanalytics.libraries.design.compose.CombinedPreviews
 import com.feragusper.smokeanalytics.libraries.design.compose.theme.SmokeAnalyticsTheme
 import com.feragusper.smokeanalytics.libraries.preferences.domain.formatMoney
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
-import com.feragusper.smokeanalytics.libraries.smokes.presentation.compose.EmptySmokes
-import com.feragusper.smokeanalytics.libraries.smokes.presentation.compose.Stat
-import com.feragusper.smokeanalytics.libraries.smokes.presentation.compose.SwipeToDismissRow
 import com.valentinilk.shimmer.shimmer
-import kotlinx.datetime.Instant
 
 /**
  * Represents the state of the Home screen in the application, encapsulating all UI-related data.
@@ -72,9 +71,11 @@ data class HomeViewState(
     internal val smokesPerMonth: Int? = null,
     internal val timeSinceLastCigarette: Pair<Long, Long>? = null,
     internal val latestSmokes: List<Smoke>? = null,
+    internal val lastSmoke: Smoke? = null,
     internal val greetingTitle: String? = null,
     internal val greetingMessage: String? = null,
     internal val financialSummary: FinancialSummary? = null,
+    internal val rateSummary: RateSummary? = null,
     internal val gamificationSummary: GamificationSummary? = null,
     internal val canStartNewDay: Boolean = false,
     internal val elapsedTone: ElapsedTone = ElapsedTone.Urgent,
@@ -145,10 +146,10 @@ data class HomeViewState(
                 smokesPerWeek = smokesPerWeek,
                 smokesPerMonth = smokesPerMonth,
                 timeSinceLastCigarette = timeSinceLastCigarette,
-                latestSmokes = latestSmokes,
                 greetingTitle = greetingTitle,
                 greetingMessage = greetingMessage,
                 financialSummary = financialSummary,
+                rateSummary = rateSummary,
                 gamificationSummary = gamificationSummary,
                 canStartNewDay = canStartNewDay,
                 elapsedTone = elapsedTone,
@@ -166,89 +167,51 @@ private fun HomeContent(
     smokesPerWeek: Int?,
     smokesPerMonth: Int?,
     timeSinceLastCigarette: Pair<Long, Long>?,
-    latestSmokes: List<Smoke>?,
     greetingTitle: String?,
     greetingMessage: String?,
     financialSummary: FinancialSummary?,
+    rateSummary: RateSummary?,
     gamificationSummary: GamificationSummary?,
     canStartNewDay: Boolean,
     elapsedTone: ElapsedTone,
     isLoading: Boolean,
     intent: (HomeIntent) -> Unit
 ) {
-    Column(
+    LazyColumn(
         modifier = Modifier
+            .fillMaxSize()
+            .nestedScroll(nestedScrollConnection)
             .padding(horizontal = 16.dp)
-            .padding(top = 16.dp)
+            .padding(top = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        GreetingSection(
-            greetingTitle = greetingTitle,
-            greetingMessage = greetingMessage,
-            financialSummary = financialSummary,
-            gamificationSummary = gamificationSummary,
-            canStartNewDay = canStartNewDay,
-            onStartNewDay = { intent(HomeIntent.StartNewDay) },
-            isLoading = isLoading,
-        )
-        StatsSection(
-            smokesPerDay = smokesPerDay,
-            smokesPerWeek = smokesPerWeek,
-            smokesPerMonth = smokesPerMonth,
-            isLoading = isLoading,
-            onHistoryClick = { intent(HomeIntent.OnClickHistory) }
-        )
-
-        TimeSinceLastCigaretteSection(
-            timeSinceLastCigarette = timeSinceLastCigarette,
-            isLoading = isLoading,
-            elapsedTone = elapsedTone,
-        )
-
-        LatestSmokesSection(
-            latestSmokes = latestSmokes,
-            nestedScrollConnection = nestedScrollConnection,
-            isLoading = isLoading,
-            onEdit = { id, instant -> intent(HomeIntent.EditSmoke(id, instant)) },
-            onDelete = { id -> intent(HomeIntent.DeleteSmoke(id)) }
-        )
-    }
-}
-
-@Composable
-private fun StatsSection(
-    smokesPerDay: Int?,
-    smokesPerWeek: Int?,
-    smokesPerMonth: Int?,
-    isLoading: Boolean,
-    onHistoryClick: () -> Unit
-) {
-    Column(
-        modifier = Modifier.background(color = MaterialTheme.colorScheme.background)
-    ) {
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            Stat(
-                modifier = Modifier
-                    .weight(1f)
-                    .clickable { onHistoryClick() },
-                titleResourceId = R.string.home_label_per_day,
-                count = smokesPerDay,
-                isLoading = isLoading
+        item {
+            GreetingSection(
+                greetingTitle = greetingTitle,
+                greetingMessage = greetingMessage,
+                canStartNewDay = canStartNewDay,
+                onStartNewDay = { intent(HomeIntent.StartNewDay) },
+                onHistoryClick = { intent(HomeIntent.OnClickHistory) },
+                isLoading = isLoading,
             )
-            Stat(
-                modifier = Modifier
-                    .weight(1f)
-                    .clickable { onHistoryClick() },
-                titleResourceId = R.string.home_label_per_week,
-                count = smokesPerWeek,
-                isLoading = isLoading
+        }
+        item {
+            TimeSinceLastCigaretteSection(
+                timeSinceLastCigarette = timeSinceLastCigarette,
+                isLoading = isLoading,
+                elapsedTone = elapsedTone,
             )
-            Stat(
-                modifier = Modifier
-                    .weight(1f)
-                    .clickable { onHistoryClick() },
-                titleResourceId = R.string.home_label_per_month,
-                count = smokesPerMonth,
-                isLoading = isLoading
+        }
+        item {
+            DashboardMetricGrid(
+                smokesPerDay = smokesPerDay,
+                smokesPerWeek = smokesPerWeek,
+                smokesPerMonth = smokesPerMonth,
+                financialSummary = financialSummary,
+                rateSummary = rateSummary,
+                gamificationSummary = gamificationSummary,
+                isLoading = isLoading,
+                onHistoryClick = { intent(HomeIntent.OnClickHistory) },
             )
         }
     }
@@ -309,6 +272,7 @@ private fun TimeSinceLastCigaretteSection(
             }
         }
         Image(
+            modifier = Modifier.size(96.dp),
             painter = painterResource(id = R.drawable.il_cigarette_background),
             contentDescription = null
         )
@@ -319,58 +283,58 @@ private fun TimeSinceLastCigaretteSection(
 private fun GreetingSection(
     greetingTitle: String?,
     greetingMessage: String?,
-    financialSummary: FinancialSummary?,
-    gamificationSummary: GamificationSummary?,
     canStartNewDay: Boolean,
     onStartNewDay: () -> Unit,
+    onHistoryClick: () -> Unit,
     isLoading: Boolean,
 ) {
-    if (greetingTitle == null && financialSummary == null && gamificationSummary == null) return
-    Box(
+    if (greetingTitle == null && greetingMessage == null && !canStartNewDay) return
+    Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.surfaceVariant, MaterialTheme.shapes.medium)
-            .padding(16.dp)
+            .clip(MaterialTheme.shapes.medium),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        tonalElevation = 1.dp,
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
             greetingTitle?.let {
                 Text(text = it, style = MaterialTheme.typography.titleMedium)
             }
             greetingMessage?.let {
                 Text(text = it, style = MaterialTheme.typography.bodyMedium)
             }
-            financialSummary?.let {
-                Text(
-                    text = "Spent today ${it.spentToday.formatMoney(it.currencySymbol)}",
-                    style = MaterialTheme.typography.bodySmall,
-                )
-            }
-            gamificationSummary?.let {
-                Text(
-                    text = "Points ${it.points}",
-                    style = MaterialTheme.typography.bodySmall,
-                )
-            }
-            if (canStartNewDay) {
-                androidx.compose.material3.TextButton(
-                    onClick = onStartNewDay,
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                TextButton(
+                    onClick = onHistoryClick,
                     enabled = !isLoading,
                 ) {
-                    Text(text = "Start new day")
+                    Text(text = "Open history")
+                }
+                if (canStartNewDay) {
+                    TextButton(
+                        onClick = onStartNewDay,
+                        enabled = !isLoading,
+                        colors = ButtonDefaults.textButtonColors(
+                            contentColor = MaterialTheme.colorScheme.primary
+                        ),
+                    ) {
+                        Text(text = "Start new day")
+                    }
                 }
             }
         }
     }
-
-    Spacer(modifier = Modifier.height(16.dp))
 }
 
 @Composable
 private fun ElapsedTone.containerColor(): Color = when (this) {
-    ElapsedTone.Urgent -> MaterialTheme.colorScheme.errorContainer
-    ElapsedTone.Warning -> MaterialTheme.colorScheme.tertiaryContainer
-    ElapsedTone.Caution -> MaterialTheme.colorScheme.secondaryContainer
-    ElapsedTone.Calm -> MaterialTheme.colorScheme.primaryContainer
+    ElapsedTone.Urgent -> MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.68f)
+    ElapsedTone.Warning -> MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.58f)
+    ElapsedTone.Caution -> MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.46f)
+    ElapsedTone.Calm -> MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.42f)
 }
 
 @Composable
@@ -382,61 +346,139 @@ private fun ElapsedTone.contentColor(): Color = when (this) {
 }
 
 @Composable
-private fun LatestSmokesSection(
-    latestSmokes: List<Smoke>?,
-    nestedScrollConnection: NestedScrollConnection,
+private fun DashboardMetricGrid(
+    smokesPerDay: Int?,
+    smokesPerWeek: Int?,
+    smokesPerMonth: Int?,
+    financialSummary: FinancialSummary?,
+    rateSummary: RateSummary?,
+    gamificationSummary: GamificationSummary?,
     isLoading: Boolean,
-    onEdit: (String, Instant) -> Unit,
-    onDelete: (String) -> Unit
+    onHistoryClick: () -> Unit,
 ) {
-    Text(
-        modifier = Modifier.padding(vertical = 12.dp),
-        text = stringResource(id = R.string.home_smoked_today),
-        style = MaterialTheme.typography.titleSmall,
-    )
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            DashboardMetricCard(
+                modifier = Modifier.weight(1f),
+                title = "Today",
+                value = smokesPerDay?.toString(),
+                supporting = "Current day bucket",
+                isLoading = isLoading,
+                onClick = onHistoryClick,
+            )
+            DashboardMetricCard(
+                modifier = Modifier.weight(1f),
+                title = "Week",
+                value = smokesPerWeek?.toString(),
+                supporting = rateSummary?.let { "%.1f / day".format(it.averageSmokesPerDayWeek) },
+                isLoading = isLoading,
+                onClick = onHistoryClick,
+            )
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            DashboardMetricCard(
+                modifier = Modifier.weight(1f),
+                title = "Month",
+                value = smokesPerMonth?.toString(),
+                supporting = rateSummary?.let { "%.1f / day".format(it.averageSmokesPerDayMonth) },
+                isLoading = isLoading,
+                onClick = onHistoryClick,
+            )
+            DashboardMetricCard(
+                modifier = Modifier.weight(1f),
+                title = "Avg gap today",
+                value = rateSummary?.averageIntervalMinutesToday?.toGapLabel(),
+                supporting = rateSummary?.latestIntervalMinutes?.let { "Latest ${it.toGapLabel()}" },
+                isLoading = isLoading,
+                tone = rateSummary?.averageIntervalMinutesToday?.let(::elapsedToneFromMinutes),
+            )
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            DashboardMetricCard(
+                modifier = Modifier.weight(1f),
+                title = "Spent today",
+                value = financialSummary?.spentToday?.formatMoney(financialSummary.currencySymbol),
+                supporting = financialSummary?.let {
+                    "Week ${it.spentWeek.formatMoney(it.currencySymbol)}"
+                },
+                isLoading = isLoading,
+            )
+            DashboardMetricCard(
+                modifier = Modifier.weight(1f),
+                title = "Points",
+                value = gamificationSummary?.points?.toString(),
+                supporting = gamificationSummary?.let { "Next ${it.nextMilestoneHours}h" },
+                isLoading = isLoading,
+            )
+        }
+    }
+}
 
-    if (isLoading) {
-        LazyColumn(
+@Composable
+private fun DashboardMetricCard(
+    title: String,
+    value: String?,
+    supporting: String?,
+    modifier: Modifier = Modifier,
+    isLoading: Boolean,
+    tone: ElapsedTone? = null,
+    onClick: (() -> Unit)? = null,
+) {
+    Surface(
+        modifier = modifier
+            .aspectRatio(1.15f)
+            .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier),
+        color = tone?.containerColor()?.copy(alpha = 0.58f) ?: MaterialTheme.colorScheme.surfaceVariant,
+        shape = MaterialTheme.shapes.medium,
+        tonalElevation = 1.dp,
+    ) {
+        Column(
             modifier = Modifier
-                .padding(top = 32.dp)
-                .fillMaxSize(),
-            verticalArrangement = Arrangement.spacedBy(24.dp),
+                .fillMaxSize()
+                .padding(14.dp),
+            verticalArrangement = Arrangement.SpaceBetween,
         ) {
-            items(3) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.labelMedium,
+                color = tone?.contentColor()?.copy(alpha = 0.8f) ?: MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (isLoading) {
                 Box(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .height(58.dp)
+                        .size(96.dp, 24.dp)
                         .clip(RoundedCornerShape(8.dp))
                         .shimmer()
-                        .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f))
+                        .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f))
+                )
+            } else {
+                Text(
+                    text = value ?: "--",
+                    style = MaterialTheme.typography.headlineMedium,
+                    color = tone?.contentColor() ?: MaterialTheme.colorScheme.onSurface,
+                )
+            }
+            supporting?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = tone?.contentColor()?.copy(alpha = 0.8f) ?: MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
         }
-    } else if (!latestSmokes.isNullOrEmpty()) {
-        LazyColumn(
-            modifier = Modifier
-                .padding(top = 16.dp)
-                .fillMaxSize()
-                .nestedScroll(nestedScrollConnection),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            items(latestSmokes) { smoke ->
-                SwipeToDismissRow(
-                    date = smoke.date,
-                    timeElapsedSincePreviousSmoke = smoke.timeElapsedSincePreviousSmoke,
-                    onDelete = { onDelete(smoke.id) },
-                    fullDateTimeEdit = false,
-                    onEdit = { editedInstant ->
-                        onEdit(smoke.id, editedInstant)
-                    }
-                )
-                HorizontalDivider()
-            }
-        }
-    } else {
-        EmptySmokes()
     }
+}
+
+private fun Int.toGapLabel(): String = when {
+    this >= 60 -> "${this / 60}h ${this % 60}m"
+    else -> "${this}m"
+}
+
+private fun elapsedToneFromMinutes(minutes: Int): ElapsedTone = when {
+    minutes >= 180 -> ElapsedTone.Calm
+    minutes >= 90 -> ElapsedTone.Caution
+    minutes >= 45 -> ElapsedTone.Warning
+    else -> ElapsedTone.Urgent
 }
 
 @CombinedPreviews

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
@@ -4,6 +4,7 @@ import com.feragusper.smokeanalytics.features.home.domain.FetchSmokeCountListUse
 import com.feragusper.smokeanalytics.features.home.domain.financialSummary
 import com.feragusper.smokeanalytics.features.home.domain.gamificationSummary
 import com.feragusper.smokeanalytics.features.home.domain.greetingStateFor
+import com.feragusper.smokeanalytics.features.home.domain.rateSummary
 import com.feragusper.smokeanalytics.features.home.domain.toWidgetSnapshot
 import com.feragusper.smokeanalytics.features.home.presentation.mvi.HomeIntent
 import com.feragusper.smokeanalytics.features.home.presentation.mvi.HomeResult
@@ -103,6 +104,7 @@ class HomeProcessHolder @Inject constructor(
                             monthCount = smokeCounts.countByMonth,
                             preferences = preferences,
                         ),
+                        rateSummary = rateSummary(smokeCounts),
                         gamificationSummary = gamificationSummary(smokeCounts.todaysSmokes),
                         canStartNewDay = shouldOfferStartNewDay(
                             dayStartHour = preferences.dayStartHour,
@@ -159,7 +161,8 @@ class HomeProcessHolder @Inject constructor(
         flow {
             emit(
                 HomeResult.UpdateTimeSinceLastCigarette(
-                    intent.lastCigarette?.date?.timeElapsedSinceNow() ?: (0L to 0L)
+                    timeSinceLastCigarette = intent.lastCigarette?.date?.timeElapsedSinceNow() ?: (0L to 0L),
+                    lastSmoke = intent.lastCigarette,
                 )
             )
         }

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeViewState.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeViewState.kt
@@ -3,6 +3,7 @@ package com.feragusper.smokeanalytics.features.home.presentation.web
 import com.feragusper.smokeanalytics.features.home.domain.ElapsedTone
 import com.feragusper.smokeanalytics.features.home.domain.FinancialSummary
 import com.feragusper.smokeanalytics.features.home.domain.GamificationSummary
+import com.feragusper.smokeanalytics.features.home.domain.RateSummary
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
 
 /**
@@ -25,9 +26,11 @@ data class HomeViewState(
     val smokesPerMonth: Int? = null,
     val timeSinceLastCigarette: Pair<Long, Long>? = null,
     val latestSmokes: List<Smoke>? = null,
+    val lastSmoke: Smoke? = null,
     val greetingTitle: String? = null,
     val greetingMessage: String? = null,
     val financialSummary: FinancialSummary? = null,
+    val rateSummary: RateSummary? = null,
     val gamificationSummary: GamificationSummary? = null,
     val currencySymbol: String = "€",
     val canStartNewDay: Boolean = false,

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeWebScreen.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeWebScreen.kt
@@ -4,18 +4,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
 import com.feragusper.smokeanalytics.features.home.presentation.web.mvi.HomeIntent
 import com.feragusper.smokeanalytics.features.home.presentation.web.mvi.HomeWebStore
-import com.feragusper.smokeanalytics.libraries.design.EmptyStateCard
 import com.feragusper.smokeanalytics.libraries.design.GhostButton
 import com.feragusper.smokeanalytics.libraries.design.InlineErrorCard
 import com.feragusper.smokeanalytics.libraries.design.LoadingSkeletonCard
 import com.feragusper.smokeanalytics.libraries.design.LoadingSkeletonList
 import com.feragusper.smokeanalytics.libraries.design.PageSectionHeader
 import com.feragusper.smokeanalytics.libraries.design.PrimaryButton
-import com.feragusper.smokeanalytics.libraries.design.SmokeRow
 import com.feragusper.smokeanalytics.libraries.design.SmokeWebStyles
 import com.feragusper.smokeanalytics.libraries.design.StatCard
 import com.feragusper.smokeanalytics.libraries.design.StatusTone
@@ -28,9 +25,7 @@ import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
-import org.jetbrains.compose.web.attributes.disabled
 import org.jetbrains.compose.web.dom.Div
-import org.jetbrains.compose.web.dom.Input
 import org.jetbrains.compose.web.dom.Text
 
 @Composable
@@ -58,9 +53,6 @@ fun HomeWebScreen(
 fun HomeViewState.Render(
     onIntent: (HomeIntent) -> Unit,
 ) {
-    val tz = remember { TimeZone.currentSystemDefault() }
-    val editing = remember { mutableStateMapOf<String, Boolean>() }
-    val draftTime = remember { mutableStateMapOf<String, String>() }
     val showingInitialSkeleton = error == null && (
         displayLoading ||
             (latestSmokes == null &&
@@ -125,7 +117,7 @@ fun HomeViewState.Render(
             LoadingSkeletonCard(heightPx = 110, lineWidths = listOf("28%", "42%"))
             LoadingSkeletonList(rows = 4)
         } else {
-            if (greetingTitle != null || financialSummary != null || gamificationSummary != null) {
+            if (greetingTitle != null || financialSummary != null || rateSummary != null || gamificationSummary != null) {
                 SurfaceCard {
                     greetingTitle?.let { title ->
                         Div(attrs = { classes(SmokeWebStyles.pageHeroTitle) }) { Text(title) }
@@ -133,25 +125,32 @@ fun HomeViewState.Render(
                     greetingMessage?.let { message ->
                         Div(attrs = { classes(SmokeWebStyles.sectionBody) }) { Text(message) }
                     }
-                    if (financialSummary != null || gamificationSummary != null) {
+                    if (financialSummary != null || rateSummary != null || gamificationSummary != null) {
                         Div(attrs = { classes(SmokeWebStyles.summaryMetricGrid) }) {
                             financialSummary?.let { summary ->
                                 MetricSummary(
                                     label = "Spent today",
                                     value = summary.spentToday.formatMoney(summary.currencySymbol),
+                                    meta = "Week ${summary.spentWeek.formatMoney(summary.currencySymbol)}",
+                                )
+                            }
+                            rateSummary?.let { summary ->
+                                MetricSummary(
+                                    label = "Average gap today",
+                                    value = summary.averageIntervalMinutesToday?.toGapLabel() ?: "--",
+                                    meta = summary.latestIntervalMinutes?.let { "Latest ${it.toGapLabel()}" },
+                                )
+                                MetricSummary(
+                                    label = "Average pace",
+                                    value = "${summary.averageSmokesPerDayWeek.formatOneDecimal()} / day",
+                                    meta = "Month ${summary.averageSmokesPerDayMonth.formatOneDecimal()} / day",
                                 )
                             }
                             gamificationSummary?.let { summary ->
                                 MetricSummary(
                                     label = "Recovery points",
                                     value = summary.points.toString(),
-                                    meta = if (summary.points == 0) "Build them by delaying the next smoke." else null,
-                                )
-                                MetricSummary(
-                                    label = "Current streak",
-                                    value = "${summary.currentStreakHours}h",
                                     meta = "Next milestone ${summary.nextMilestoneHours}h",
-                                    tooltip = "Streak is the time since the last logged cigarette in the current cycle.",
                                 )
                             }
                         }
@@ -189,6 +188,10 @@ fun HomeViewState.Render(
                     value = smokesPerMonth?.toString() ?: "--",
                     onClick = { onIntent(HomeIntent.OnClickHistory) }
                 )
+                StatCard(
+                    title = "Avg gap today",
+                    value = rateSummary?.averageIntervalMinutesToday?.toGapLabel() ?: "--",
+                )
             }
 
             Div(
@@ -218,110 +221,35 @@ fun HomeViewState.Render(
                 } ?: "--"
 
                 Div(attrs = { classes(SmokeWebStyles.sinceValue) }) {
+                    Text(since)
+                }
+                Div(attrs = { classes(SmokeWebStyles.helperText) }) {
                     Text(
                         when (elapsedTone) {
-                            com.feragusper.smokeanalytics.features.home.domain.ElapsedTone.Urgent -> "Now $since"
-                            com.feragusper.smokeanalytics.features.home.domain.ElapsedTone.Warning -> "Careful at $since"
-                            com.feragusper.smokeanalytics.features.home.domain.ElapsedTone.Caution -> "Holding $since"
-                            com.feragusper.smokeanalytics.features.home.domain.ElapsedTone.Calm -> "Clear for $since"
+                            com.feragusper.smokeanalytics.features.home.domain.ElapsedTone.Urgent -> "The last interval is still fresh."
+                            com.feragusper.smokeanalytics.features.home.domain.ElapsedTone.Warning -> "You are close to the recent pace."
+                            com.feragusper.smokeanalytics.features.home.domain.ElapsedTone.Caution -> "The cadence is opening up."
+                            com.feragusper.smokeanalytics.features.home.domain.ElapsedTone.Calm -> "This gap is comfortably above the recent pace."
                         }
                     )
                 }
-                if (displayRefreshLoading) {
-                    Div(attrs = { classes(SmokeWebStyles.helperText) }) { Text("Refreshing...") }
-                }
             }
 
-            Div(attrs = { classes(SmokeWebStyles.sectionHeader) }) {
-                Div(attrs = { classes(SmokeWebStyles.sectionHeaderText) }) {
-                    Div(attrs = { classes(SmokeWebStyles.sectionTitle) }) { Text("Smoked today") }
+            SurfaceCard {
+                Div(attrs = { classes(SmokeWebStyles.sectionHeader) }) {
+                    Div(attrs = { classes(SmokeWebStyles.sectionHeaderText) }) {
+                        Div(attrs = { classes(SmokeWebStyles.sectionTitle) }) { Text("History holds the full log") }
+                        Div(attrs = { classes(SmokeWebStyles.sectionBody) }) {
+                            Text("Use History for the full list, edits, and cadence-colored smoke entries.")
+                        }
+                    }
                 }
-            }
-
-            when {
-                latestSmokes.isNullOrEmpty() -> EmptyStateCard(
-                    title = "No smokes logged today",
-                    message = "When you add the next entry it will appear here immediately, with quick edit and delete controls.",
-                    actionLabel = "Add smoke",
-                    onAction = { onIntent(HomeIntent.AddSmoke) },
-                )
-
-                else -> Div(
-                    attrs = {
-                        classes(SmokeWebStyles.list)
-                        if (displayRefreshLoading) classes(SmokeWebStyles.surfaceMuted)
-                    }
-                ) {
-                    latestSmokes.forEach { smoke ->
-                        val id = smoke.id
-                        val isEditing = editing[id] == true
-                        val local = smoke.date.toLocalDateTime(tz)
-                        val hh = local.hour.toString().padStart(2, '0')
-                        val mm = local.minute.toString().padStart(2, '0')
-                        val timeLabel = "$hh:$mm"
-                        val subtitle = smoke.timeElapsedSincePreviousSmoke.let { (h, m) ->
-                            if (h > 0) "After $h hours and $m minutes" else "After $m minutes"
-                        }
-
-                        if (!isEditing) {
-                            SmokeRow(
-                                time = timeLabel,
-                                subtitle = subtitle,
-                                onEdit = {
-                                    editing[id] = true
-                                    draftTime[id] = smoke.date.toTimeInputValue(tz)
-                                },
-                                onDelete = { onIntent(HomeIntent.DeleteSmoke(id)) }
-                            )
-                        } else {
-                            val draft = draftTime[id] ?: smoke.date.toTimeInputValue(tz)
-
-                            SurfaceCard {
-                                Div(attrs = { classes(SmokeWebStyles.sectionTitle) }) {
-                                    Text("Edit smoke time")
-                                }
-
-                                Input(
-                                    type = org.jetbrains.compose.web.attributes.InputType.Time,
-                                    attrs = {
-                                        classes(SmokeWebStyles.dateInput)
-                                        value(draft)
-                                        if (displayLoading || displayRefreshLoading) disabled()
-                                        onInput { ev -> draftTime[id] = ev.value }
-                                    }
-                                )
-
-                                Div(attrs = { classes(SmokeWebStyles.sectionActions) }) {
-                                    PrimaryButton(
-                                        text = "Apply",
-                                        enabled = !displayLoading && !displayRefreshLoading,
-                                        onClick = {
-                                            val newTime = draftTime[id] ?: return@PrimaryButton
-                                            val dateValue = smoke.date.toDateInputValue(tz)
-
-                                            val newInstant = dateTimeInputsToInstant(
-                                                dateValue = dateValue,
-                                                timeValue = newTime,
-                                                timeZone = tz,
-                                            )
-
-                                            onIntent(HomeIntent.EditSmoke(id, newInstant))
-                                            editing[id] = false
-                                            draftTime.remove(id)
-                                        }
-                                    )
-                                    GhostButton(
-                                        text = "Cancel",
-                                        enabled = !displayLoading && !displayRefreshLoading,
-                                        onClick = {
-                                            editing[id] = false
-                                            draftTime.remove(id)
-                                        }
-                                    )
-                                }
-                            }
-                        }
-                    }
+                Div(attrs = { classes(SmokeWebStyles.sectionActions) }) {
+                    GhostButton(
+                        text = "Open history",
+                        onClick = { onIntent(HomeIntent.OnClickHistory) },
+                        enabled = !displayLoading && !displayRefreshLoading,
+                    )
                 }
             }
         }
@@ -378,4 +306,16 @@ internal fun dateTimeInputsToInstant(
         nanosecond = 0,
     )
     return ldt.toInstant(timeZone)
+}
+
+private fun Int.toGapLabel(): String = when {
+    this >= 60 -> "${this / 60}h ${this % 60}m"
+    else -> "${this}m"
+}
+
+private fun Double.formatOneDecimal(): String {
+    val rounded = (this * 10).toInt() / 10.0
+    val whole = rounded.toInt()
+    val decimal = ((rounded - whole) * 10).toInt()
+    return "$whole.$decimal"
 }

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeResult.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeResult.kt
@@ -4,7 +4,9 @@ import com.feragusper.smokeanalytics.features.home.domain.SmokeCountListResult
 import com.feragusper.smokeanalytics.features.home.domain.FinancialSummary
 import com.feragusper.smokeanalytics.features.home.domain.GamificationSummary
 import com.feragusper.smokeanalytics.features.home.domain.GreetingState
+import com.feragusper.smokeanalytics.features.home.domain.RateSummary
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
 
 sealed interface HomeResult {
 
@@ -36,6 +38,7 @@ sealed interface HomeResult {
         val preferences: UserPreferences,
         val greetingState: GreetingState,
         val financialSummary: FinancialSummary,
+        val rateSummary: RateSummary,
         val gamificationSummary: GamificationSummary,
         val canStartNewDay: Boolean,
     ) : HomeResult
@@ -43,6 +46,7 @@ sealed interface HomeResult {
     data object FetchSmokesError : HomeResult
 
     data class UpdateTimeSinceLastCigarette(
-        val timeSinceLastCigarette: Pair<Long, Long>
+        val timeSinceLastCigarette: Pair<Long, Long>,
+        val lastSmoke: Smoke?,
     ) : HomeResult
 }

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeWebStore.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeWebStore.kt
@@ -5,8 +5,10 @@ import com.feragusper.smokeanalytics.features.home.presentation.web.process.Home
 import com.feragusper.smokeanalytics.features.home.domain.elapsedToneFrom
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -27,12 +29,21 @@ class HomeWebStore(
         intents.trySend(intent)
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun start() {
         scope.launch {
             intents
                 .receiveAsFlow()
                 .flatMapLatest { intent -> processHolder.processIntent(intent) }
                 .collect { result -> reduce(result) }
+        }
+
+        scope.launch {
+            while (true) {
+                delay(60_000)
+                val lastSmoke = _state.value.lastSmoke ?: continue
+                send(HomeIntent.TickTimeSinceLastCigarette(lastSmoke))
+            }
         }
 
         // bootstrap
@@ -63,6 +74,7 @@ class HomeWebStore(
                 smokesPerMonth = 0,
                 timeSinceLastCigarette = 0L to 0L,
                 latestSmokes = emptyList(),
+                lastSmoke = null,
                 canStartNewDay = false,
             )
 
@@ -74,10 +86,12 @@ class HomeWebStore(
                 smokesPerWeek = result.smokeCountListResult.countByWeek,
                 smokesPerMonth = result.smokeCountListResult.countByMonth,
                 latestSmokes = result.smokeCountListResult.todaysSmokes,
+                lastSmoke = result.smokeCountListResult.lastSmoke,
                 timeSinceLastCigarette = result.smokeCountListResult.timeSinceLastCigarette,
                 greetingTitle = result.greetingState.title,
                 greetingMessage = result.greetingState.message,
                 financialSummary = result.financialSummary,
+                rateSummary = result.rateSummary,
                 gamificationSummary = result.gamificationSummary,
                 currencySymbol = result.preferences.currencySymbol,
                 canStartNewDay = result.canStartNewDay,
@@ -88,7 +102,12 @@ class HomeWebStore(
             )
 
             is HomeResult.UpdateTimeSinceLastCigarette -> previous.copy(
-                timeSinceLastCigarette = result.timeSinceLastCigarette
+                timeSinceLastCigarette = result.timeSinceLastCigarette,
+                lastSmoke = result.lastSmoke,
+                elapsedTone = elapsedToneFrom(
+                    result.timeSinceLastCigarette.first,
+                    result.timeSinceLastCigarette.second,
+                ),
             )
 
             HomeResult.AddSmokeSuccess,

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/process/HomeProcessHolder.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/process/HomeProcessHolder.kt
@@ -4,6 +4,7 @@ import com.feragusper.smokeanalytics.features.home.domain.FetchSmokeCountListUse
 import com.feragusper.smokeanalytics.features.home.domain.financialSummary
 import com.feragusper.smokeanalytics.features.home.domain.gamificationSummary
 import com.feragusper.smokeanalytics.features.home.domain.greetingStateFor
+import com.feragusper.smokeanalytics.features.home.domain.rateSummary
 import com.feragusper.smokeanalytics.features.home.presentation.web.mvi.HomeIntent
 import com.feragusper.smokeanalytics.features.home.presentation.web.mvi.HomeResult
 import com.feragusper.smokeanalytics.libraries.architecture.domain.LocationCaptureService
@@ -62,7 +63,8 @@ class HomeProcessHolder(
         is HomeIntent.TickTimeSinceLastCigarette -> flow {
             emit(
                 HomeResult.UpdateTimeSinceLastCigarette(
-                    intent.lastCigarette?.date?.timeElapsedSinceNow() ?: (0L to 0L)
+                    timeSinceLastCigarette = intent.lastCigarette?.date?.timeElapsedSinceNow() ?: (0L to 0L),
+                    lastSmoke = intent.lastCigarette,
                 )
             )
         }
@@ -105,6 +107,7 @@ class HomeProcessHolder(
                                 monthCount = smokeCounts.countByMonth,
                                 preferences = preferences,
                             ),
+                            rateSummary = rateSummary(smokeCounts),
                             gamificationSummary = gamificationSummary(smokeCounts.todaysSmokes),
                             canStartNewDay = shouldOfferStartNewDay(
                                 dayStartHour = preferences.dayStartHour,

--- a/libraries/design/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/libraries/design/SmokeWebStyles.kt
+++ b/libraries/design/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/libraries/design/SmokeWebStyles.kt
@@ -590,6 +590,26 @@ object SmokeWebStyles : StyleSheet() {
         }
     }
 
+    val listRowUrgent by style {
+        backgroundColor(Color("rgba(186,26,26,0.05)"))
+        property("border-color", "rgba(186,26,26,0.12)")
+    }
+
+    val listRowWarning by style {
+        backgroundColor(Color("rgba(154,91,0,0.05)"))
+        property("border-color", "rgba(154,91,0,0.12)")
+    }
+
+    val listRowCaution by style {
+        backgroundColor(Color("rgba(0,106,106,0.045)"))
+        property("border-color", "rgba(0,106,106,0.10)")
+    }
+
+    val listRowCalm by style {
+        backgroundColor(Color("rgba(0,106,106,0.06)"))
+        property("border-color", "rgba(0,106,106,0.14)")
+    }
+
     val timeText by style {
         fontSize(15.px)
         fontWeight(700)
@@ -637,23 +657,27 @@ object SmokeWebStyles : StyleSheet() {
     }
 
     val buttonPrimaryUrgent by style {
-        backgroundColor(Color("#BA1A1A"))
-        color(Color("#FFFFFF"))
+        backgroundColor(Color("rgba(186,26,26,0.14)"))
+        color(Color("#7D1212"))
+        property("border", "1px solid rgba(186,26,26,0.16)")
     }
 
     val buttonPrimaryWarning by style {
-        backgroundColor(Color("#9A5B00"))
-        color(Color("#FFFFFF"))
+        backgroundColor(Color("rgba(154,91,0,0.12)"))
+        color(Color("#764700"))
+        property("border", "1px solid rgba(154,91,0,0.14)")
     }
 
     val buttonPrimaryCaution by style {
-        backgroundColor(Color("#B26A00"))
-        color(Color("#FFFFFF"))
+        backgroundColor(Color("rgba(0,106,106,0.10)"))
+        color(Color("var(--sa-color-primary)"))
+        property("border", "1px solid rgba(0,106,106,0.14)")
     }
 
     val buttonPrimaryCalm by style {
-        backgroundColor(Color("var(--sa-color-primary)"))
-        color(Color("var(--sa-color-onPrimary)"))
+        backgroundColor(Color("rgba(0,106,106,0.12)"))
+        color(Color("var(--sa-color-primary)"))
+        property("border", "1px solid rgba(0,106,106,0.16)")
     }
 
     val buttonDanger by style {
@@ -864,23 +888,23 @@ object SmokeWebStyles : StyleSheet() {
     }
 
     val elapsedCardUrgent by style {
-        backgroundColor(Color("rgba(186,26,26,0.08)"))
-        property("border-color", "rgba(186,26,26,0.18)")
+        backgroundColor(Color("rgba(186,26,26,0.06)"))
+        property("border-color", "rgba(186,26,26,0.14)")
     }
 
     val elapsedCardWarning by style {
-        backgroundColor(Color("rgba(154,91,0,0.10)"))
-        property("border-color", "rgba(154,91,0,0.18)")
+        backgroundColor(Color("rgba(154,91,0,0.07)"))
+        property("border-color", "rgba(154,91,0,0.14)")
     }
 
     val elapsedCardCaution by style {
-        backgroundColor(Color("rgba(178,106,0,0.10)"))
-        property("border-color", "rgba(178,106,0,0.18)")
+        backgroundColor(Color("rgba(0,106,106,0.06)"))
+        property("border-color", "rgba(0,106,106,0.12)")
     }
 
     val elapsedCardCalm by style {
-        backgroundColor(Color("var(--sa-color-success-soft)"))
-        property("border-color", "rgba(0,106,106,0.18)")
+        backgroundColor(Color("rgba(0,106,106,0.08)"))
+        property("border-color", "rgba(0,106,106,0.16)")
     }
 
     init {

--- a/libraries/design/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/libraries/design/SurfaceCard.kt
+++ b/libraries/design/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/libraries/design/SurfaceCard.kt
@@ -85,10 +85,14 @@ fun DangerButton(
 fun SmokeRow(
     time: String,
     subtitle: String,
+    toneClass: String? = null,
     onEdit: (() -> Unit)?,
     onDelete: (() -> Unit)?,
 ) {
-    Div(attrs = { classes(SmokeWebStyles.listRow) }) {
+    Div(attrs = {
+        classes(SmokeWebStyles.listRow)
+        toneClass?.let { classes(it) }
+    }) {
         Div {
             Div(attrs = { classes(SmokeWebStyles.timeText) }) { Text(time) }
             Div(attrs = { classes(SmokeWebStyles.subText) }) { Text(subtitle) }

--- a/libraries/smokes/presentation/src/main/java/com/feragusper/smokeanalytics/libraries/smokes/presentation/compose/SwipeToDismissRow.kt
+++ b/libraries/smokes/presentation/src/main/java/com/feragusper/smokeanalytics/libraries/smokes/presentation/compose/SwipeToDismissRow.kt
@@ -127,6 +127,10 @@ fun SwipeToDismissRow(
             date = date,
             timeZone = timeZone,
             timeAfterPrevious = timeElapsedSincePreviousSmoke,
+            tone = elapsedToneFrom(
+                timeElapsedSincePreviousSmoke.first,
+                timeElapsedSincePreviousSmoke.second,
+            ),
         )
     }
 
@@ -182,12 +186,14 @@ private fun SmokeItem(
     date: Instant,
     timeZone: TimeZone,
     timeAfterPrevious: Pair<Long, Long>,
+    tone: ElapsedTone,
 ) {
     val local = date.toLocalDateTime(timeZone)
 
     Row(
         modifier = Modifier
-            .background(color = MaterialTheme.colorScheme.background)
+            .background(color = tone.rowContainerColor(), shape = MaterialTheme.shapes.medium)
+            .padding(horizontal = 12.dp)
             .height(72.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -198,7 +204,7 @@ private fun SmokeItem(
             Text(
                 text = "%02d:%02d".format(local.hour, local.minute),
                 style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onBackground
+                color = tone.rowContentColor()
             )
 
             val (hours, minutes) = timeAfterPrevious
@@ -218,9 +224,42 @@ private fun SmokeItem(
                     ).joinToString(" and ")
                 }",
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onBackground
+                color = tone.rowContentColor()
             )
         }
+    }
+}
+
+@Composable
+private fun ElapsedTone.rowContainerColor(): Color = when (this) {
+    ElapsedTone.Urgent -> MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.48f)
+    ElapsedTone.Warning -> MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.42f)
+    ElapsedTone.Caution -> MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.34f)
+    ElapsedTone.Calm -> MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.30f)
+}
+
+@Composable
+private fun ElapsedTone.rowContentColor(): Color = when (this) {
+    ElapsedTone.Urgent -> MaterialTheme.colorScheme.onErrorContainer
+    ElapsedTone.Warning -> MaterialTheme.colorScheme.onTertiaryContainer
+    ElapsedTone.Caution -> MaterialTheme.colorScheme.onSecondaryContainer
+    ElapsedTone.Calm -> MaterialTheme.colorScheme.onPrimaryContainer
+}
+
+private enum class ElapsedTone {
+    Urgent,
+    Warning,
+    Caution,
+    Calm,
+}
+
+private fun elapsedToneFrom(hours: Long, minutes: Long): ElapsedTone {
+    val totalMinutes = (hours * 60L + minutes).toInt()
+    return when {
+        totalMinutes >= 180 -> ElapsedTone.Calm
+        totalMinutes >= 90 -> ElapsedTone.Caution
+        totalMinutes >= 45 -> ElapsedTone.Warning
+        else -> ElapsedTone.Urgent
     }
 }
 


### PR DESCRIPTION
## Summary
- reframe Home on mobile and web as a dashboard-first overview instead of a smoke list
- add cadence-derived rate insights and apply pacing colors to smoke rows
- soften elapsed-time feedback across cards and add-smoke actions while keeping live recalculation on timer ticks

## What changed
- added shared RateSummary derivation and updated elapsed-tone thresholds in Home domain
- updated Home mobile and web state/process/store flows to carry cadence insights and recalculate tone on ticking elapsed time
- rebuilt Home mobile into a dashboard layout with summary cards, cadence metrics, and history as the place for the detailed log
- refreshed Home web to the same dashboard role, removing the embedded smoke list and surfacing dashboard metrics instead
- applied cadence-aware coloring to smoke rows and softened web/mobile urgency styling for cards and actions

## Verification
- ./gradlew :features:home:presentation:mobile:testDebugUnitTest
- ./gradlew :apps:mobile:assembleStagingDebug
- ./gradlew :apps:web:jsBrowserDevelopmentWebpack
- ./gradlew check

## Issues
- closes #146
- closes #151
- closes #152
