### PR TITLE
Tranche 3: mobile map and wear sync

### DIFF
--- a/apps/mobile/src/main/java/com/feragusper/smokeanalytics/MainActivity.kt
+++ b/apps/mobile/src/main/java/com/feragusper/smokeanalytics/MainActivity.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
@@ -62,6 +63,7 @@ import com.feragusper.smokeanalytics.features.settings.presentation.navigation.s
 import com.feragusper.smokeanalytics.features.stats.presentation.navigation.StatsNavigator
 import com.feragusper.smokeanalytics.features.stats.presentation.navigation.statsNavigationGraph
 import com.feragusper.smokeanalytics.libraries.design.compose.theme.SmokeAnalyticsTheme
+import com.feragusper.smokeanalytics.map.MapMobileRoute
 import dagger.hilt.android.AndroidEntryPoint
 
 /**
@@ -116,6 +118,7 @@ private fun MainContainerScreen(
     val bottomNavigationItems = listOf(
         BottomNavigationScreens.Home,
         BottomNavigationScreens.Stats,
+        BottomNavigationScreens.Map,
         BottomNavigationScreens.Chatbot,
         BottomNavigationScreens.Settings,
     )
@@ -259,6 +262,9 @@ private fun MainScreenNavigationConfigurations(
             onFabConfigChanged = onFabConfigChanged,
         )
         statsNavigationGraph(StatsNavigator())
+        composable(route = BottomNavigationScreens.Map.route) {
+            MapMobileRoute()
+        }
         chatbotNavigationGraph(ChatbotNavigator())
         settingsNavigationGraph(settingsNavigator)
     }
@@ -323,6 +329,11 @@ private sealed class BottomNavigationScreens(
     data object Chatbot : BottomNavigationScreens(
         ChatbotNavigator.ROUTE,
         R.drawable.ic_chatbot
+    )
+
+    data object Map : BottomNavigationScreens(
+        route = "map",
+        iconId = R.drawable.ic_map,
     )
 
     /**

--- a/apps/mobile/src/main/java/com/feragusper/smokeanalytics/map/MapMobileScreen.kt
+++ b/apps/mobile/src/main/java/com/feragusper/smokeanalytics/map/MapMobileScreen.kt
@@ -1,0 +1,294 @@
+package com.feragusper.smokeanalytics.map
+
+import android.annotation.SuppressLint
+import android.webkit.WebSettings
+import android.webkit.WebView
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeMapCluster
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeMapPeriod
+
+@Composable
+fun MapMobileRoute(
+    modifier: Modifier = Modifier,
+    viewModel: MapMobileViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    MapMobileScreen(
+        modifier = modifier,
+        state = state,
+        onPeriodChange = viewModel::onPeriodChange,
+        onSelectCluster = viewModel::onSelectCluster,
+        onRetry = viewModel::refresh,
+    )
+}
+
+@Composable
+private fun MapMobileScreen(
+    modifier: Modifier = Modifier,
+    state: MapMobileState,
+    onPeriodChange: (SmokeMapPeriod) -> Unit,
+    onSelectCluster: (SmokeMapCluster) -> Unit,
+    onRetry: () -> Unit,
+) {
+    when {
+        state.isLoading -> LoadingState(modifier = modifier)
+        state.error -> ErrorState(modifier = modifier, onRetry = onRetry)
+        !state.preferences.orDefault().locationTrackingEnabled -> DisabledState(modifier = modifier)
+        state.clusters.isEmpty() -> EmptyState(modifier = modifier)
+        else -> LoadedState(
+            modifier = modifier,
+            state = state,
+            onPeriodChange = onPeriodChange,
+            onSelectCluster = onSelectCluster,
+        )
+    }
+}
+
+@Composable
+private fun LoadingState(modifier: Modifier) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        CircularProgressIndicator(modifier = Modifier.size(32.dp))
+    }
+}
+
+@Composable
+private fun LoadedState(
+    modifier: Modifier,
+    state: MapMobileState,
+    onPeriodChange: (SmokeMapPeriod) -> Unit,
+    onSelectCluster: (SmokeMapCluster) -> Unit,
+) {
+    val activeCluster = state.selectedCluster ?: state.clusters.first()
+    LazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp, vertical = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        item {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = "Map",
+                    style = MaterialTheme.typography.headlineSmall,
+                )
+                Text(
+                    text = "Approximate smoking areas based on tracked locations.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    SmokeMapPeriod.entries.forEach { period ->
+                        AssistChip(
+                            onClick = { onPeriodChange(period) },
+                            label = { Text(period.name) },
+                            colors = if (period == state.period) {
+                                AssistChipDefaults.assistChipColors(
+                                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                                    labelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                                )
+                            } else {
+                                AssistChipDefaults.assistChipColors()
+                            }
+                        )
+                    }
+                }
+            }
+        }
+
+        item {
+            Card(
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    Text(
+                        text = activeCluster.label,
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    Text(
+                        text = "${activeCluster.count} smokes grouped in an approximate ${activeCluster.radiusMeters} m area.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    MapEmbed(point = activeCluster.point)
+                }
+            }
+        }
+
+        item {
+            Text(
+                text = "Areas",
+                style = MaterialTheme.typography.titleMedium,
+            )
+        }
+
+        items(state.clusters) { cluster ->
+            Card(
+                colors = CardDefaults.cardColors(
+                    containerColor = if (cluster == activeCluster) {
+                        MaterialTheme.colorScheme.secondaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.surfaceContainerLow
+                    }
+                ),
+                onClick = { onSelectCluster(cluster) },
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        Text(
+                            text = cluster.label,
+                            style = MaterialTheme.typography.titleSmall,
+                        )
+                        Text(
+                            text = "${cluster.count} smokes in this area",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    Text(
+                        text = if (cluster == activeCluster) "Viewing" else "View",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = if (cluster == activeCluster) {
+                            MaterialTheme.colorScheme.onSecondaryContainer
+                        } else {
+                            MaterialTheme.colorScheme.primary
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DisabledState(modifier: Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = "Location tracking is off",
+            style = MaterialTheme.typography.headlineSmall,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "Enable location tracking in Settings to unlock map insights.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun EmptyState(modifier: Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = "No mapped smokes yet",
+            style = MaterialTheme.typography.headlineSmall,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "Track a few smokes with location enabled to start seeing areas here.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun ErrorState(
+    modifier: Modifier,
+    onRetry: () -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = "Map could not be loaded",
+            style = MaterialTheme.typography.headlineSmall,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "Try refreshing in a moment.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        TextButton(onClick = onRetry) {
+            Text("Retry")
+        }
+    }
+}
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+private fun MapEmbed(point: GeoPoint) {
+    AndroidView(
+        factory = { context ->
+            WebView(context).apply {
+                settings.javaScriptEnabled = true
+                settings.cacheMode = WebSettings.LOAD_DEFAULT
+                loadUrl(point.googleEmbedUrl())
+            }
+        },
+        update = { it.loadUrl(point.googleEmbedUrl()) },
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(280.dp),
+    )
+}
+
+private fun GeoPoint.googleEmbedUrl(): String =
+    "https://www.google.com/maps?q=$latitude,$longitude&z=14&output=embed"
+
+private fun UserPreferences?.orDefault(): UserPreferences = this ?: UserPreferences()

--- a/apps/mobile/src/main/java/com/feragusper/smokeanalytics/map/MapMobileViewModel.kt
+++ b/apps/mobile/src/main/java/com/feragusper/smokeanalytics/map/MapMobileViewModel.kt
@@ -1,0 +1,75 @@
+package com.feragusper.smokeanalytics.map
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.feragusper.smokeanalytics.libraries.preferences.domain.FetchUserPreferencesUseCase
+import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeMapCluster
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeMapPeriod
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.clusterSmokesForMap
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.smokeMapRange
+import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.FetchSmokesUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MapMobileViewModel @Inject constructor(
+    private val fetchSmokesUseCase: FetchSmokesUseCase,
+    private val fetchUserPreferencesUseCase: FetchUserPreferencesUseCase,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(MapMobileState())
+    val state: StateFlow<MapMobileState> = _state.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    fun onPeriodChange(period: SmokeMapPeriod) {
+        _state.value = _state.value.copy(period = period)
+        refresh()
+    }
+
+    fun onSelectCluster(cluster: SmokeMapCluster) {
+        _state.value = _state.value.copy(selectedCluster = cluster)
+    }
+
+    fun refresh() {
+        viewModelScope.launch {
+            val previous = _state.value
+            _state.value = previous.copy(isLoading = true, error = false)
+            runCatching {
+                val preferences = fetchUserPreferencesUseCase()
+                val (start, end) = smokeMapRange(
+                    period = previous.period,
+                    dayStartHour = preferences.dayStartHour,
+                    manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
+                )
+                val smokes = fetchSmokesUseCase(start, end)
+                val clusters = clusterSmokesForMap(smokes, previous.period)
+                previous.copy(
+                    isLoading = false,
+                    preferences = preferences,
+                    clusters = clusters,
+                    selectedCluster = clusters.firstOrNull(),
+                    error = false,
+                )
+            }.getOrElse {
+                previous.copy(isLoading = false, error = true)
+            }.also { _state.value = it }
+        }
+    }
+}
+
+data class MapMobileState(
+    val isLoading: Boolean = true,
+    val error: Boolean = false,
+    val period: SmokeMapPeriod = SmokeMapPeriod.Week,
+    val preferences: UserPreferences? = null,
+    val clusters: List<SmokeMapCluster> = emptyList(),
+    val selectedCluster: SmokeMapCluster? = null,
+)

--- a/apps/mobile/src/main/res/drawable/ic_map.xml
+++ b/apps/mobile/src/main/res/drawable/ic_map.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M15,5.5L9,3L3,5.5V20.5L9,18L15,20.5L21,18V3.5L15,5.5ZM14,18.05L10,16.38V5.95L14,7.62V18.05ZM5,6.83L8,5.58V16.17L5,17.42V6.83ZM19,16.67L16,17.92V7.33L19,6.08V16.67Z" />
+</vector>

--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/MainTileService.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/MainTileService.kt
@@ -51,7 +51,12 @@ class MainTileService : SuspendingTileService() {
         // Observe the state changes and request a tile update on state changes
         lifecycleScope.launch {
             viewModel.states()
-                .distinctUntilChanged { old, new -> old.smokesPerDay == new.smokesPerDay }
+                .distinctUntilChanged { old, new ->
+                    old.smokesPerDay == new.smokesPerDay &&
+                        old.smokesPerWeek == new.smokesPerWeek &&
+                        old.smokesPerMonth == new.smokesPerMonth &&
+                        old.lastSmokeTimestamp == new.lastSmokeTimestamp
+                }
                 .collect {
                     Timber.d("onCreate: collect: $it")
                     tileUpdateRequester.requestUpdate(MainTileService::class.java)
@@ -115,18 +120,22 @@ class MainTileService : SuspendingTileService() {
 
         // Format last smoke time
         val lastSmokeText = formatLastSmokeTime(state.lastSmokeTimestamp)
+        val summaryText = getString(
+            R.string.stats_summary,
+            state.smokesPerWeek ?: 0,
+            state.smokesPerMonth ?: 0,
+        )
 
-        // Create text elements for displaying statistics and last smoke time
-        val statsText = Text.Builder(this, getString(R.string.stats_today, state.smokesPerDay ?: 0))
+        val statsText = Text.Builder(this, getString(R.string.stats_today_short, state.smokesPerDay ?: 0))
             .setTypography(Typography.TYPOGRAPHY_TITLE3)
             .setColor(androidx.wear.protolayout.ColorBuilders.argb(0xFF00897B.toInt()))
             .setMaxLines(1)
             .build()
 
-        val lastSmoke = Text.Builder(this, lastSmokeText)
+        val content = Text.Builder(this, "$summaryText\n$lastSmokeText")
             .setTypography(Typography.TYPOGRAPHY_BODY2)
             .setColor(androidx.wear.protolayout.ColorBuilders.argb(0xFF00897B.toInt()))
-            .setMaxLines(1)
+            .setMaxLines(3)
             .build()
 
         // Create the "Add Smoke" chip button
@@ -147,7 +156,7 @@ class MainTileService : SuspendingTileService() {
             .setRoot(
                 PrimaryLayout.Builder(deviceParameters)
                     .setPrimaryLabelTextContent(statsText)
-                    .setContent(lastSmoke)
+                    .setContent(content)
                     .setPrimaryChipContent(addSmokeChip)
                     .setResponsiveContentInsetEnabled(true)
                     .build()

--- a/apps/wear/src/main/res/values/strings.xml
+++ b/apps/wear/src/main/res/values/strings.xml
@@ -1,8 +1,9 @@
 <resources>
-    <string name="last_smoke_na">Last Smoke: N/A</string>
-    <string name="last_smoke_just_now">Last Smoke: Just now</string>
-    <string name="last_smoke_minutes_ago">Last Smoke: %1$d min ago</string>
-    <string name="last_smoke_hours_ago">Last Smoke: %1$d h ago</string>
-    <string name="last_smoke_days_ago">Last Smoke: %1$d d ago</string>
-    <string name="stats_today">Today: %1$d</string>
+    <string name="last_smoke_na">Last smoke unknown</string>
+    <string name="last_smoke_just_now">Last smoke just now</string>
+    <string name="last_smoke_minutes_ago">Last smoke %1$d min ago</string>
+    <string name="last_smoke_hours_ago">Last smoke %1$d h ago</string>
+    <string name="last_smoke_days_ago">Last smoke %1$d d ago</string>
+    <string name="stats_today_short">Today %1$d</string>
+    <string name="stats_summary">Week %1$d · Month %2$d</string>
 </resources>

--- a/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/AppRoot.kt
+++ b/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/AppRoot.kt
@@ -110,6 +110,7 @@ fun AppRoot(graph: WebAppGraph) {
 
             WebRoute.Map -> MapWebScreen(
                 fetchSmokesUseCase = graph.fetchSmokesUseCase,
+                fetchUserPreferencesUseCase = graph.fetchUserPreferencesUseCase,
             )
 
             WebRoute.Coach -> CoachWebScreen(

--- a/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/apps/web/MapWebScreen.kt
+++ b/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/apps/web/MapWebScreen.kt
@@ -11,45 +11,36 @@ import com.feragusper.smokeanalytics.libraries.design.PageSectionHeader
 import com.feragusper.smokeanalytics.libraries.design.PrimaryButton
 import com.feragusper.smokeanalytics.libraries.design.SmokeWebStyles
 import com.feragusper.smokeanalytics.libraries.design.SurfaceCard
+import com.feragusper.smokeanalytics.libraries.preferences.domain.FetchUserPreferencesUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
-import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeMapCluster
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeMapPeriod
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.clusterSmokesForMap
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.smokeMapRange
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.FetchSmokesUseCase
-import kotlinx.datetime.Clock
-import kotlinx.datetime.DateTimeUnit
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.minus
 import org.jetbrains.compose.web.dom.Div
 import org.jetbrains.compose.web.dom.Iframe
 import org.jetbrains.compose.web.dom.Text
-import kotlin.math.pow
-import kotlin.math.round
-
-private enum class MapPeriod(val label: String, val days: Int) {
-    Day("Day", 1),
-    Week("Week", 7),
-    Month("Month", 31),
-}
-
-private data class MapCluster(
-    val point: GeoPoint,
-    val count: Int,
-    val label: String,
-)
 
 @Composable
 fun MapWebScreen(
     fetchSmokesUseCase: FetchSmokesUseCase,
+    fetchUserPreferencesUseCase: FetchUserPreferencesUseCase,
 ) {
-    var period by remember { mutableStateOf(MapPeriod.Week) }
-    var clusters by remember { mutableStateOf<List<MapCluster>>(emptyList()) }
-    var selectedCluster by remember { mutableStateOf<MapCluster?>(null) }
+    var period by remember { mutableStateOf(SmokeMapPeriod.Week) }
+    var clusters by remember { mutableStateOf<List<SmokeMapCluster>>(emptyList()) }
+    var selectedCluster by remember { mutableStateOf<SmokeMapCluster?>(null) }
     var loading by remember { mutableStateOf(true) }
 
     LaunchedEffect(period) {
         loading = true
-        val end = Clock.System.now()
-        val start = end.minus(period.days, DateTimeUnit.DAY, TimeZone.currentSystemDefault())
-        clusters = clusterSmokes(fetchSmokesUseCase(start, end), period)
+        val preferences = fetchUserPreferencesUseCase()
+        val (start, end) = smokeMapRange(
+            period = period,
+            dayStartHour = preferences.dayStartHour,
+            manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
+        )
+        clusters = clusterSmokesForMap(fetchSmokesUseCase(start, end), period)
         selectedCluster = clusters.maxByOrNull { it.count }
         loading = false
     }
@@ -60,9 +51,9 @@ fun MapWebScreen(
             eyebrow = "Locations",
             badgeText = "${clusters.sumOf { it.count }} smokes",
             actions = {
-                MapPeriod.entries.forEach { candidate ->
+                SmokeMapPeriod.entries.forEach { candidate ->
                     PrimaryButton(
-                        text = candidate.label,
+                        text = candidate.name,
                         onClick = { period = candidate },
                         enabled = !loading && candidate != period,
                     )
@@ -85,7 +76,7 @@ fun MapWebScreen(
                 SurfaceCard {
                     Div(attrs = { classes(SmokeWebStyles.sectionTitle) }) { Text(activeCluster.label) }
                     Div(attrs = { classes(SmokeWebStyles.helperText) }) {
-                        Text("${activeCluster.count} smokes grouped in this approximate area.")
+                        Text("${activeCluster.count} smokes grouped in an approximate ${activeCluster.radiusMeters} m area.")
                     }
                     Iframe(attrs = {
                         attr("src", googleEmbedUrl(activeCluster.point))
@@ -125,42 +116,6 @@ fun MapWebScreen(
             }
         }
     }
-}
-
-private fun clusterSmokes(
-    smokes: List<Smoke>,
-    period: MapPeriod,
-): List<MapCluster> {
-    val precision = when (period) {
-        MapPeriod.Day -> 2
-        MapPeriod.Week -> 1
-        MapPeriod.Month -> 0
-    }
-
-    return smokes
-        .mapNotNull { it.location }
-        .groupBy { point ->
-            val scale = 10.0.pow(precision.toDouble())
-            val lat = round(point.latitude * scale) / scale
-            val lon = round(point.longitude * scale) / scale
-            lat to lon
-        }
-        .entries
-        .sortedByDescending { it.value.size }
-        .mapIndexed { index, (_, points) ->
-            val centerLat = points.map { it.latitude }.average()
-            val centerLon = points.map { it.longitude }.average()
-            MapCluster(
-                point = GeoPoint(centerLat, centerLon),
-                count = points.size,
-                label = when (index) {
-                    0 -> "Top area"
-                    1 -> "Second area"
-                    2 -> "Third area"
-                    else -> "Area ${index + 1}"
-                },
-            )
-        }
 }
 
 private fun googleEmbedUrl(point: GeoPoint): String =

--- a/libraries/architecture/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/architecture/domain/DateExtensions.kt
+++ b/libraries/architecture/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/architecture/domain/DateExtensions.kt
@@ -69,6 +69,65 @@ fun nextDayStartInstant(
     manualDayStartEpochMillis = manualDayStartEpochMillis,
 ).plus(1, DateTimeUnit.DAY).atStartOfDayIn(timeZone).plus(dayStartHour, DateTimeUnit.HOUR, timeZone)
 
+fun currentWeekStartInstant(
+    timeZone: TimeZone = defaultTimeZone,
+    dayStartHour: Int = 0,
+    manualDayStartEpochMillis: Long? = null,
+): Instant {
+    val today = currentBucketDate(
+        timeZone = timeZone,
+        dayStartHour = dayStartHour,
+        manualDayStartEpochMillis = manualDayStartEpochMillis,
+    )
+    val monday = today.minus(today.dayOfWeek.isoDayNumber - 1, DateTimeUnit.DAY)
+    return monday.atStartOfDayIn(timeZone).plus(dayStartHour, DateTimeUnit.HOUR, timeZone)
+}
+
+fun nextWeekStartInstant(
+    timeZone: TimeZone = defaultTimeZone,
+    dayStartHour: Int = 0,
+    manualDayStartEpochMillis: Long? = null,
+): Instant = currentWeekStartInstant(
+    timeZone = timeZone,
+    dayStartHour = dayStartHour,
+    manualDayStartEpochMillis = manualDayStartEpochMillis,
+).plus(7, DateTimeUnit.DAY, timeZone)
+
+fun currentMonthStartInstant(
+    timeZone: TimeZone = defaultTimeZone,
+    dayStartHour: Int = 0,
+    manualDayStartEpochMillis: Long? = null,
+): Instant {
+    val current = currentBucketDate(
+        timeZone = timeZone,
+        dayStartHour = dayStartHour,
+        manualDayStartEpochMillis = manualDayStartEpochMillis,
+    )
+    return LocalDate(
+        year = current.year,
+        monthNumber = current.monthNumber,
+        dayOfMonth = 1,
+    ).atStartOfDayIn(timeZone).plus(dayStartHour, DateTimeUnit.HOUR, timeZone)
+}
+
+fun nextMonthStartInstant(
+    timeZone: TimeZone = defaultTimeZone,
+    dayStartHour: Int = 0,
+    manualDayStartEpochMillis: Long? = null,
+): Instant {
+    val current = currentBucketDate(
+        timeZone = timeZone,
+        dayStartHour = dayStartHour,
+        manualDayStartEpochMillis = manualDayStartEpochMillis,
+    )
+    val nextMonth = LocalDate(
+        year = if (current.monthNumber == 12) current.year + 1 else current.year,
+        monthNumber = if (current.monthNumber == 12) 1 else current.monthNumber + 1,
+        dayOfMonth = 1,
+    )
+    return nextMonth.atStartOfDayIn(timeZone).plus(dayStartHour, DateTimeUnit.HOUR, timeZone)
+}
+
 fun lastInstantToday(timeZone: TimeZone = defaultTimeZone): Instant =
     todayLocalDate(timeZone).plus(1, DateTimeUnit.DAY).atStartOfDayIn(timeZone)
 

--- a/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeMap.kt
+++ b/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeMap.kt
@@ -1,0 +1,108 @@
+package com.feragusper.smokeanalytics.libraries.smokes.domain.model
+
+import com.feragusper.smokeanalytics.libraries.architecture.domain.currentDayStartInstant
+import com.feragusper.smokeanalytics.libraries.architecture.domain.currentMonthStartInstant
+import com.feragusper.smokeanalytics.libraries.architecture.domain.currentWeekStartInstant
+import com.feragusper.smokeanalytics.libraries.architecture.domain.nextDayStartInstant
+import com.feragusper.smokeanalytics.libraries.architecture.domain.nextMonthStartInstant
+import com.feragusper.smokeanalytics.libraries.architecture.domain.nextWeekStartInstant
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlin.math.pow
+import kotlin.math.round
+
+enum class SmokeMapPeriod {
+    Day,
+    Week,
+    Month,
+}
+
+data class SmokeMapCluster(
+    val point: GeoPoint,
+    val count: Int,
+    val label: String,
+    val radiusMeters: Int,
+)
+
+fun smokeMapRange(
+    period: SmokeMapPeriod,
+    timeZone: TimeZone = TimeZone.currentSystemDefault(),
+    dayStartHour: Int = 0,
+    manualDayStartEpochMillis: Long? = null,
+    now: Instant = Clock.System.now(),
+): Pair<Instant, Instant> = when (period) {
+    SmokeMapPeriod.Day -> currentDayStartInstant(
+        timeZone = timeZone,
+        dayStartHour = dayStartHour,
+        manualDayStartEpochMillis = manualDayStartEpochMillis,
+    ) to nextDayStartInstant(
+        timeZone = timeZone,
+        dayStartHour = dayStartHour,
+        manualDayStartEpochMillis = manualDayStartEpochMillis,
+    )
+
+    SmokeMapPeriod.Week -> currentWeekStartInstant(
+        timeZone = timeZone,
+        dayStartHour = dayStartHour,
+        manualDayStartEpochMillis = manualDayStartEpochMillis,
+    ) to nextWeekStartInstant(
+        timeZone = timeZone,
+        dayStartHour = dayStartHour,
+        manualDayStartEpochMillis = manualDayStartEpochMillis,
+    )
+
+    SmokeMapPeriod.Month -> currentMonthStartInstant(
+        timeZone = timeZone,
+        dayStartHour = dayStartHour,
+        manualDayStartEpochMillis = manualDayStartEpochMillis,
+    ) to nextMonthStartInstant(
+        timeZone = timeZone,
+        dayStartHour = dayStartHour,
+        manualDayStartEpochMillis = manualDayStartEpochMillis,
+    )
+}
+
+fun clusterSmokesForMap(
+    smokes: List<Smoke>,
+    period: SmokeMapPeriod,
+): List<SmokeMapCluster> {
+    val decimals = when (period) {
+        SmokeMapPeriod.Day -> 3
+        SmokeMapPeriod.Week -> 2
+        SmokeMapPeriod.Month -> 1
+    }
+    val radiusMeters = when (period) {
+        SmokeMapPeriod.Day -> 120
+        SmokeMapPeriod.Week -> 350
+        SmokeMapPeriod.Month -> 900
+    }
+
+    return smokes
+        .mapNotNull { it.location }
+        .groupBy { point -> point.rounded(decimals) }
+        .entries
+        .sortedByDescending { it.value.size }
+        .mapIndexed { index, (_, points) ->
+            val centerLat = points.map { it.latitude }.average()
+            val centerLon = points.map { it.longitude }.average()
+            SmokeMapCluster(
+                point = GeoPoint(centerLat, centerLon),
+                count = points.size,
+                label = when (index) {
+                    0 -> "Top area"
+                    1 -> "Second area"
+                    2 -> "Third area"
+                    else -> "Area ${index + 1}"
+                },
+                radiusMeters = radiusMeters,
+            )
+        }
+}
+
+private fun GeoPoint.rounded(decimals: Int): Pair<Double, Double> {
+    val scale = 10.0.pow(decimals.toDouble())
+    val roundedLat = round(latitude * scale) / scale
+    val roundedLon = round(longitude * scale) / scale
+    return roundedLat to roundedLon
+}

--- a/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeMapTest.kt
+++ b/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeMapTest.kt
@@ -1,0 +1,43 @@
+package com.feragusper.smokeanalytics.libraries.smokes.domain.model
+
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SmokeMapTest {
+
+    @Test
+    fun `clusterSmokesForMap groups nearby points more tightly for day period`() {
+        val smokes = listOf(
+            smoke("1", 40.4168, -3.7038),
+            smoke("2", 40.41681, -3.70381),
+            smoke("3", 40.4189, -3.7090),
+        )
+
+        val clusters = clusterSmokesForMap(smokes, SmokeMapPeriod.Day)
+
+        assertEquals(2, clusters.size)
+        assertEquals(2, clusters.first().count)
+        assertEquals(120, clusters.first().radiusMeters)
+    }
+
+    @Test
+    fun `clusterSmokesForMap uses broader grouping for month period`() {
+        val smokes = listOf(
+            smoke("1", 40.4168, -3.7038),
+            smoke("2", 40.4174, -3.7041),
+        )
+
+        val clusters = clusterSmokesForMap(smokes, SmokeMapPeriod.Month)
+
+        assertEquals(1, clusters.size)
+        assertEquals(2, clusters.first().count)
+        assertEquals(900, clusters.first().radiusMeters)
+    }
+
+    private fun smoke(id: String, latitude: Double, longitude: Double) = Smoke(
+        id = id,
+        date = Instant.fromEpochMilliseconds(0),
+        location = GeoPoint(latitude, longitude),
+    )
+}

--- a/libraries/wear/data/build.gradle.kts
+++ b/libraries/wear/data/build.gradle.kts
@@ -10,6 +10,7 @@ android {
 
 dependencies {
     implementation(project(":libraries:smokes:domain"))
+    implementation(project(":libraries:preferences:domain"))
     implementation(project(":libraries:architecture:domain"))
     implementation(project(":libraries:architecture:common"))
     implementation(project(":libraries:wear:domain"))

--- a/libraries/wear/data/src/main/java/com/feragusper/smokeanalytics/libraries/wear/data/WearSyncManagerImpl.kt
+++ b/libraries/wear/data/src/main/java/com/feragusper/smokeanalytics/libraries/wear/data/WearSyncManagerImpl.kt
@@ -3,6 +3,7 @@ package com.feragusper.smokeanalytics.libraries.wear.data
 import android.content.Context
 import com.feragusper.smokeanalytics.libraries.architecture.common.coroutines.DispatcherProvider
 import com.feragusper.smokeanalytics.libraries.architecture.domain.utcMillis
+import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferencesRepository
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeCount
 import com.feragusper.smokeanalytics.libraries.smokes.domain.repository.SmokeRepository
 import com.feragusper.smokeanalytics.libraries.wear.domain.WearSyncManager
@@ -41,6 +42,7 @@ class WearSyncManagerImpl(
      */
     inner class Mobile(
         private val smokeRepository: SmokeRepository,
+        private val userPreferencesRepository: UserPreferencesRepository,
         private val coroutineScope: CoroutineScope,
     ) : WearSyncManager.Mobile, MessageClient.OnMessageReceivedListener {
 
@@ -55,7 +57,13 @@ class WearSyncManagerImpl(
          * Synchronizes the smoke count data with the connected Wear OS device.
          */
         override suspend fun syncWithWear() {
-            respondToWearWithSmokeCount(smokeRepository.fetchSmokeCount())
+            val preferences = userPreferencesRepository.fetch()
+            respondToWearWithSmokeCount(
+                smokeRepository.fetchSmokeCount(
+                    dayStartHour = preferences.dayStartHour,
+                    manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
+                )
+            )
         }
 
         /**
@@ -68,7 +76,10 @@ class WearSyncManagerImpl(
             coroutineScope.launch(dispatcherProvider.io()) {
                 when (messageEvent.path) {
                     WearPaths.REQUEST_SMOKES -> syncWithWear()
-                    WearPaths.ADD_SMOKE -> smokeRepository.addSmoke(Clock.System.now())
+                    WearPaths.ADD_SMOKE -> {
+                        smokeRepository.addSmoke(Clock.System.now())
+                        syncWithWear()
+                    }
                 }
             }
         }

--- a/libraries/wear/data/src/main/java/com/feragusper/smokeanalytics/libraries/wear/data/di/WearSyncModule.kt
+++ b/libraries/wear/data/src/main/java/com/feragusper/smokeanalytics/libraries/wear/data/di/WearSyncModule.kt
@@ -2,6 +2,7 @@ package com.feragusper.smokeanalytics.libraries.wear.data.di
 
 import android.content.Context
 import com.feragusper.smokeanalytics.libraries.architecture.common.coroutines.DispatcherProvider
+import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferencesRepository
 import com.feragusper.smokeanalytics.libraries.smokes.domain.repository.SmokeRepository
 import com.feragusper.smokeanalytics.libraries.wear.data.WearSyncManagerImpl
 import com.feragusper.smokeanalytics.libraries.wear.domain.WearSyncManager
@@ -37,11 +38,13 @@ object WearSyncModule {
     fun provideWearSyncManager(
         @ApplicationContext context: Context,
         smokeRepository: SmokeRepository,
+        userPreferencesRepository: UserPreferencesRepository,
         dispatcherProvider: DispatcherProvider
     ): WearSyncManager.Mobile {
         return WearSyncManagerImpl(context, dispatcherProvider).Mobile(
             coroutineScope = CoroutineScope(SupervisorJob() + dispatcherProvider.default()),
-            smokeRepository = smokeRepository
+            smokeRepository = smokeRepository,
+            userPreferencesRepository = userPreferencesRepository,
         )
     }
 }


### PR DESCRIPTION
## Summary
- add a mobile Map section on Android with day, week, and month grouping
- share the map range and clustering rules between mobile and web
- make Wear sync follow the configured day boundary and refresh immediately after quick logging

## Included
- mobile map screen, route, and bottom-nav entry
- shared map clustering helpers and tests
- web map alignment to the shared range logic
- Wear tile summary refresh and day-boundary-aware sync

## Testing
- ./gradlew :apps:web:jsBrowserDevelopmentWebpack
- ./gradlew :apps:mobile:compileStagingDebugKotlin
- ./gradlew :apps:wear:assembleProductionDebug
- ./gradlew :libraries:smokes:domain:jvmTest
- ./gradlew check