### PR TITLE
release: ship 0.8.1 hotfix from develop

### DIFF
--- a/.github/workflows/deployment_artifact.yml
+++ b/.github/workflows/deployment_artifact.yml
@@ -28,11 +28,13 @@ jobs:
         env:
           GOOGLE_AUTH_SERVER_CLIENT_ID_STAGING: ${{ secrets.GOOGLE_AUTH_SERVER_CLIENT_ID_STAGING }}
           GOOGLE_AI_CLIENT_GENERATIVEAI_API_KEY_STAGING: ${{ secrets.GOOGLE_AI_CLIENT_GENERATIVEAI_API_KEY_STAGING }}
+          GOOGLE_MAPS_ANDROID_API_KEY_STAGING: ${{ secrets.GOOGLE_MAPS_ANDROID_API_KEY_STAGING }}
           GOOGLE_SERVICES_JSON_STAGING: ${{ secrets.GOOGLE_SERVICES_JSON_STAGING }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
           echo google.auth.server.client.id=$GOOGLE_AUTH_SERVER_CLIENT_ID_STAGING > ./local.properties
           echo google.ai.client.generativeai.api.key=$GOOGLE_AI_CLIENT_GENERATIVEAI_API_KEY_STAGING >> ./local.properties
+          echo google.maps.android.api.key.staging=$GOOGLE_MAPS_ANDROID_API_KEY_STAGING >> ./local.properties
 
           echo "✅ local.properties configured for staging."
 

--- a/.github/workflows/deployment_playstore.yml
+++ b/.github/workflows/deployment_playstore.yml
@@ -28,11 +28,13 @@ jobs:
         env:
           GOOGLE_AUTH_SERVER_CLIENT_ID: ${{ secrets.GOOGLE_AUTH_SERVER_CLIENT_ID }}
           GOOGLE_AI_CLIENT_GENERATIVEAI_API_KEY: ${{ secrets.GOOGLE_AI_CLIENT_GENERATIVEAI_API_KEY }}
+          GOOGLE_MAPS_ANDROID_API_KEY_PRODUCTION: ${{ secrets.GOOGLE_MAPS_ANDROID_API_KEY_PRODUCTION }}
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
           echo google.auth.server.client.id=$GOOGLE_AUTH_SERVER_CLIENT_ID > ./local.properties
           echo google.ai.client.generativeai.api.key=$GOOGLE_AI_CLIENT_GENERATIVEAI_API_KEY >> ./local.properties
+          echo google.maps.android.api.key.production=$GOOGLE_MAPS_ANDROID_API_KEY_PRODUCTION >> ./local.properties
 
           echo "✅ local.properties configured for production."
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,12 +38,16 @@ jobs:
         env:
           GOOGLE_AUTH_SERVER_CLIENT_ID_STAGING: ${{ secrets.GOOGLE_AUTH_SERVER_CLIENT_ID_STAGING }}
           GOOGLE_AI_CLIENT_GENERATIVEAI_API_KEY_STAGING: ${{ secrets.GOOGLE_AI_CLIENT_GENERATIVEAI_API_KEY_STAGING }}
+          GOOGLE_MAPS_ANDROID_API_KEY_STAGING: ${{ secrets.GOOGLE_MAPS_ANDROID_API_KEY_STAGING }}
+          GOOGLE_MAPS_ANDROID_API_KEY_PRODUCTION: ${{ secrets.GOOGLE_MAPS_ANDROID_API_KEY_PRODUCTION }}
           GOOGLE_SERVICES_JSON_STAGING: ${{ secrets.GOOGLE_SERVICES_JSON_STAGING }}
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
           echo google.auth.server.client.id=$GOOGLE_AUTH_SERVER_CLIENT_ID_STAGING > ./local.properties
           echo google.ai.client.generativeai.api.key=$GOOGLE_AI_CLIENT_GENERATIVEAI_API_KEY_STAGING >> ./local.properties
+          echo google.maps.android.api.key.staging=$GOOGLE_MAPS_ANDROID_API_KEY_STAGING >> ./local.properties
+          echo google.maps.android.api.key.production=$GOOGLE_MAPS_ANDROID_API_KEY_PRODUCTION >> ./local.properties
 
           echo "✅ local.properties configured for staging."
 

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-product.version=0.8.0
+product.version=0.8.1


### PR DESCRIPTION
## Summary
- release the `0.8.1` hotfix from `develop` to `master`
- fix missing Google Maps Android API key injection in CI, artifact, and Play Store workflows
- ensure future staging and production mobile builds receive the correct Maps property wiring

## Included work
- inject `GOOGLE_MAPS_ANDROID_API_KEY_STAGING` into staging workflow-generated `local.properties`
- inject `GOOGLE_MAPS_ANDROID_API_KEY_PRODUCTION` into production workflow-generated `local.properties`
- bump product version from `0.8.0` to `0.8.1`

## Verification
- `Integration` passed on the hotfix PR into `develop`
- release PR is the final merge from `develop` to `master`

Closes #161