### PR TITLE
UI Revamp tranche 5: stats and coach feedback polish

### DIFF
--- a/features/chatbot/presentation/src/main/java/com/feragusper/smokeanalytics/features/chatbot/presentation/mvi/compose/ChatbotViewState.kt
+++ b/features/chatbot/presentation/src/main/java/com/feragusper/smokeanalytics/features/chatbot/presentation/mvi/compose/ChatbotViewState.kt
@@ -266,15 +266,37 @@ private fun PrimaryInsightCard(
 
             when {
                 isLoading -> {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(28.dp),
-                        strokeWidth = 3.dp,
-                    )
-                    Text(
-                        text = "Preparing your guide...",
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(14.dp),
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(24.dp),
+                                strokeWidth = 3.dp,
+                            )
+                            Text(
+                                text = "Preparing your guide",
+                                style = MaterialTheme.typography.titleMedium,
+                                color = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                        Text(
+                            text = "Reviewing your recent rhythm, recovery gap, and prompts before the next insight lands.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        FlowRow(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            LoadingTag(label = "Recent rhythm")
+                            LoadingTag(label = "Recovery gap")
+                            LoadingTag(label = "Coach context")
+                        }
+                    }
                 }
 
                 insight != null -> {
@@ -328,6 +350,27 @@ private fun PrimaryInsightCard(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun LoadingTag(
+    label: String,
+) {
+    Box(
+        modifier = Modifier
+            .background(
+                color = MaterialTheme.colorScheme.secondaryContainer,
+                shape = RoundedCornerShape(999.dp),
+            )
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+        )
     }
 }
 

--- a/features/stats/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/stats/presentation/web/StatsWebScreen.kt
+++ b/features/stats/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/stats/presentation/web/StatsWebScreen.kt
@@ -11,7 +11,8 @@ import androidx.compose.runtime.setValue
 import com.feragusper.smokeanalytics.features.stats.presentation.web.mvi.StatsIntent
 import com.feragusper.smokeanalytics.features.stats.presentation.web.mvi.StatsWebStore
 import com.feragusper.smokeanalytics.libraries.design.GhostButton
-import com.feragusper.smokeanalytics.libraries.design.InlineErrorCard
+import com.feragusper.smokeanalytics.libraries.design.EmptyStateCard
+import com.feragusper.smokeanalytics.libraries.design.LoadingSkeletonCard
 import com.feragusper.smokeanalytics.libraries.design.PageSectionHeader
 import com.feragusper.smokeanalytics.libraries.design.PrimaryButton
 import com.feragusper.smokeanalytics.libraries.design.SmokeWebStyles
@@ -164,19 +165,17 @@ private fun StatsWebContent(
         }
 
         when {
-            state.error != null -> InlineErrorCard(
-                title = "Stats are unavailable",
-                message = "The chart could not be loaded for the selected period. Try changing the filters or refresh the browser.",
+            state.error != null -> EmptyStateCard(
+                title = "Pattern view unavailable",
+                message = "The selected range could not be assembled right now. Keep the period and date, then refresh to try this view again.",
                 actionLabel = "Try again",
                 onAction = onReload,
             )
 
-            state.displayLoading || state.stats == null -> SurfaceCard {
-                Div(attrs = { classes(SmokeWebStyles.chartHeader) }) {
-                    Text(currentPeriod.chartTitle())
-                }
-                Div(attrs = { classes(SmokeWebStyles.chartSkeleton) })
-            }
+            state.displayLoading || state.stats == null -> LoadingSkeletonCard(
+                heightPx = 240,
+                lineWidths = listOf("24%", "64%", "42%")
+            )
 
             else -> {
                 val stats = state.stats


### PR DESCRIPTION
## Summary
- replace legacy stats web loading and error treatments with revamp-aligned skeleton and quiet-state feedback
- refine the primary loading state in mobile coach so the guide feels contextual instead of showing a raw spinner-only block
- keep domain logic, prompts, and routing unchanged while tightening feedback consistency across the shell

## Verification
- ./gradlew :apps:web:jsBrowserDevelopmentWebpack
- ./gradlew :apps:mobile:assembleStagingDebug

## Notes
- base branch is `develop`
- this tranche is a small consistency pass across Stats web and Coach mobile
