### PR TITLE
UI Revamp tranche 7: unify web shell quiet error states

### DIFF
--- a/features/authentication/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/authentication/presentation/AuthenticationWebScreen.kt
+++ b/features/authentication/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/authentication/presentation/AuthenticationWebScreen.kt
@@ -8,8 +8,8 @@ import androidx.compose.runtime.remember
 import com.feragusper.smokeanalytics.features.authentication.presentation.mvi.AuthenticationIntent
 import com.feragusper.smokeanalytics.features.authentication.presentation.mvi.AuthenticationWebStore
 import com.feragusper.smokeanalytics.libraries.authentication.presentation.compose.GoogleSignInComponentWeb
+import com.feragusper.smokeanalytics.libraries.design.EmptyStateCard
 import com.feragusper.smokeanalytics.libraries.design.GhostButton
-import com.feragusper.smokeanalytics.libraries.design.InlineErrorCard
 import com.feragusper.smokeanalytics.libraries.design.LoadingSkeletonCard
 import com.feragusper.smokeanalytics.libraries.design.PageSectionHeader
 import com.feragusper.smokeanalytics.libraries.design.PrimaryButton
@@ -57,7 +57,7 @@ fun AuthenticationViewState.Render(
         )
 
         error?.let {
-            InlineErrorCard(
+            EmptyStateCard(
                 title = "Authentication failed",
                 message = "The session could not be restored. Try signing in again.",
                 actionLabel = "Retry session check",

--- a/features/history/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/history/presentation/HistoryWebScreen.kt
+++ b/features/history/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/history/presentation/HistoryWebScreen.kt
@@ -13,7 +13,6 @@ import com.feragusper.smokeanalytics.features.history.presentation.mvi.HistoryRe
 import com.feragusper.smokeanalytics.features.history.presentation.mvi.HistoryWebStore
 import com.feragusper.smokeanalytics.libraries.design.EmptyStateCard
 import com.feragusper.smokeanalytics.libraries.design.GhostButton
-import com.feragusper.smokeanalytics.libraries.design.InlineErrorCard
 import com.feragusper.smokeanalytics.libraries.design.LoadingSkeletonCard
 import com.feragusper.smokeanalytics.libraries.design.PageSectionHeader
 import com.feragusper.smokeanalytics.libraries.design.PrimaryButton
@@ -78,7 +77,7 @@ fun HistoryWebScreen(
         )
 
         if (state.error != null) {
-            InlineErrorCard(
+            EmptyStateCard(
                 title = if (state.error == HistoryResult.Error.NotLoggedIn) "Sign in required" else "History could not be loaded",
                 message = when (state.error) {
                     HistoryResult.Error.NotLoggedIn -> "Archive access needs an active session so edits, dates, and older smoke entries stay tied to the same account."

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeWebScreen.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeWebScreen.kt
@@ -11,8 +11,8 @@ import com.feragusper.smokeanalytics.features.home.domain.GamificationSummary
 import com.feragusper.smokeanalytics.features.home.domain.RateSummary
 import com.feragusper.smokeanalytics.features.home.presentation.web.mvi.HomeIntent
 import com.feragusper.smokeanalytics.features.home.presentation.web.mvi.HomeWebStore
+import com.feragusper.smokeanalytics.libraries.design.EmptyStateCard
 import com.feragusper.smokeanalytics.libraries.design.GhostButton
-import com.feragusper.smokeanalytics.libraries.design.InlineErrorCard
 import com.feragusper.smokeanalytics.libraries.design.LoadingSkeletonCard
 import com.feragusper.smokeanalytics.libraries.design.PageSectionHeader
 import com.feragusper.smokeanalytics.libraries.design.PrimaryButton
@@ -92,7 +92,7 @@ fun HomeViewState.Render(
         }
 
         if (error != null) {
-            InlineErrorCard(
+            EmptyStateCard(
                 title = if (error == HomeViewState.HomeError.NotLoggedIn) "Session required" else "Could not refresh home",
                 message = when (error) {
                     HomeViewState.HomeError.NotLoggedIn -> "The Pulse needs an active session to sync the latest smoke entries and keep the dashboard aligned with your real archive."

--- a/features/settings/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/settings/presentation/web/SettingsWebScreen.kt
+++ b/features/settings/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/settings/presentation/web/SettingsWebScreen.kt
@@ -10,8 +10,8 @@ import androidx.compose.runtime.setValue
 import com.feragusper.smokeanalytics.features.settings.presentation.web.mvi.SettingsIntent
 import com.feragusper.smokeanalytics.features.settings.presentation.web.mvi.SettingsWebStore
 import com.feragusper.smokeanalytics.libraries.authentication.presentation.compose.GoogleSignInComponentWeb
+import com.feragusper.smokeanalytics.libraries.design.EmptyStateCard
 import com.feragusper.smokeanalytics.libraries.design.GhostButton
-import com.feragusper.smokeanalytics.libraries.design.InlineErrorCard
 import com.feragusper.smokeanalytics.libraries.design.LoadingSkeletonCard
 import com.feragusper.smokeanalytics.libraries.design.PrimaryButton
 import com.feragusper.smokeanalytics.libraries.design.SmokeWebStyles
@@ -58,7 +58,8 @@ private fun SettingsViewState.Render(
         )
 
         errorMessage?.let { msg ->
-            InlineErrorCard(
+            EmptyStateCard(
+                title = "Settings unavailable",
                 message = msg,
                 actionLabel = "Try again",
                 onAction = { onIntent(SettingsIntent.FetchUser) },


### PR DESCRIPTION
## Summary
- replace remaining legacy web shell InlineErrorCard usage in Home, History, Settings, and Authentication with the shared quiet-state treatment
- keep existing retry and sign-in actions intact while making edge states visually consistent with the revamp
- avoid any routing or domain changes and focus only on shell-level feedback alignment

## Verification
- ./gradlew :apps:web:jsBrowserDevelopmentWebpack

## Notes
- base branch is develop
- this tranche is a web-only consistency pass across top-level shell surfaces
