### PR TITLE
UI Revamp tranche 9: shared archive empty-state copy

### DIFF
--- a/libraries/smokes/presentation/src/main/java/com/feragusper/smokeanalytics/libraries/smokes/presentation/compose/EmptySmokes.kt
+++ b/libraries/smokes/presentation/src/main/java/com/feragusper/smokeanalytics/libraries/smokes/presentation/compose/EmptySmokes.kt
@@ -43,7 +43,7 @@ fun EmptySmokes() {
                 )
             }
             Text(
-                text = "No smoke entries yet",
+                text = "No archive entries for this day",
                 style = MaterialTheme.typography.titleLarge,
                 color = MaterialTheme.colorScheme.onSurface,
             )
@@ -53,7 +53,7 @@ fun EmptySmokes() {
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Text(
-                text = "Use Add for Date to fill the archive without leaving this view.",
+                text = "Use Add for Date to keep the archive complete without leaving this view.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )


### PR DESCRIPTION
## Summary
- refine the shared archive empty-state copy used in mobile history so it matches the quieter revamp language
- keep history behavior and add-for-date flow unchanged
- make the empty-state wording more aligned with The Archive destination naming

## Verification
- ./gradlew :apps:mobile:assembleStagingDebug

## Notes
- base branch is develop
- this tranche is a small shared presentation pass affecting archive empty-state copy