### PR TITLE
Polish current build and align the Wear tile with Pulse

### DIFF
--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/MainTileService.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/MainTileService.kt
@@ -52,9 +52,9 @@ class MainTileService : SuspendingTileService() {
         lifecycleScope.launch {
             viewModel.states()
                 .distinctUntilChanged { old, new ->
-                    old.smokesPerDay == new.smokesPerDay &&
-                        old.smokesPerWeek == new.smokesPerWeek &&
-                        old.smokesPerMonth == new.smokesPerMonth &&
+                    old.todayCount == new.todayCount &&
+                        old.targetGapMinutes == new.targetGapMinutes &&
+                        old.averageSmokesPerDayWeek == new.averageSmokesPerDayWeek &&
                         old.lastSmokeTimestamp == new.lastSmokeTimestamp
                 }
                 .collect {
@@ -120,19 +120,22 @@ class MainTileService : SuspendingTileService() {
 
         // Format last smoke time
         val lastSmokeText = formatLastSmokeTime(state.lastSmokeTimestamp)
-        val summaryText = getString(
-            R.string.stats_summary,
-            state.smokesPerWeek ?: 0,
-            state.smokesPerMonth ?: 0,
-        )
-
-        val statsText = Text.Builder(this, getString(R.string.stats_today_short, state.smokesPerDay ?: 0))
+        val statsText = Text.Builder(this, getString(R.string.stats_today_short, state.todayCount ?: 0))
             .setTypography(Typography.TYPOGRAPHY_TITLE3)
             .setColor(androidx.wear.protolayout.ColorBuilders.argb(0xFF00897B.toInt()))
             .setMaxLines(1)
             .build()
 
-        val content = Text.Builder(this, "$summaryText\n$lastSmokeText")
+        val content = Text.Builder(
+            this,
+            buildString {
+                append(lastSmokeText)
+                append('\n')
+                append(getString(R.string.target_gap_short, (state.targetGapMinutes ?: 0).toGapLabel()))
+                append('\n')
+                append(getString(R.string.average_week_short, (state.averageSmokesPerDayWeek ?: 0.0).formatOneDecimal()))
+            }
+        )
             .setTypography(Typography.TYPOGRAPHY_BODY2)
             .setColor(androidx.wear.protolayout.ColorBuilders.argb(0xFF00897B.toInt()))
             .setMaxLines(3)
@@ -193,3 +196,16 @@ class MainTileService : SuspendingTileService() {
     }
 
 }
+
+private fun Int.toGapLabel(): String {
+    if (this <= 0) return "--"
+    val hours = this / 60
+    val minutes = this % 60
+    return when {
+        hours > 0 && minutes > 0 -> "${hours}h ${minutes}m"
+        hours > 0 -> "${hours}h"
+        else -> "${minutes}m"
+    }
+}
+
+private fun Double.formatOneDecimal(): String = String.format("%.1f", this)

--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileProcessHolder.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileProcessHolder.kt
@@ -66,13 +66,13 @@ class TileProcessHolder @Inject constructor(
         wearSyncManager.sendRequestToMobile(WearPaths.REQUEST_SMOKES)
 
         // Listen for real-time updates
-        wearSyncManager.listenForDataUpdates { smokesToday, smokesPerWeek, smokesPerMonth, lastSmokeTimestamp ->
+        wearSyncManager.listenForDataUpdates { todayCount, targetGapMinutes, averageSmokesPerDayWeek, lastSmokeTimestamp ->
             trySend(
                 TileResult.FetchSmokesSuccess(
-                    smokesPerDay = smokesToday,
-                    smokesPerWeek = smokesPerWeek,
-                    smokesPerMonth = smokesPerMonth,
-                    lastSmokeTimestamp = lastSmokeTimestamp
+                    todayCount = todayCount,
+                    targetGapMinutes = targetGapMinutes,
+                    averageSmokesPerDayWeek = averageSmokesPerDayWeek,
+                    lastSmokeTimestamp = lastSmokeTimestamp,
                 )
             )
         }

--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileResult.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileResult.kt
@@ -4,10 +4,10 @@ import com.feragusper.smokeanalytics.libraries.architecture.presentation.mvi.MVI
 
 sealed class TileResult : MVIResult {
     data class FetchSmokesSuccess(
-        val smokesPerDay: Int,
-        val smokesPerWeek: Int,
-        val smokesPerMonth: Int,
-        val lastSmokeTimestamp: Long?
+        val todayCount: Int,
+        val targetGapMinutes: Int,
+        val averageSmokesPerDayWeek: Double,
+        val lastSmokeTimestamp: Long?,
     ) : TileResult()
 
     data object AddSmokeSuccess : TileResult()

--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileViewModel.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileViewModel.kt
@@ -51,10 +51,10 @@ object TileViewModel : MVIViewModel<TileIntent, TileViewState, TileResult, MVINa
         result: TileResult
     ): TileViewState = when (result) {
         is TileResult.FetchSmokesSuccess -> previous.copy(
-            smokesPerDay = result.smokesPerDay,
-            smokesPerWeek = result.smokesPerWeek,
-            smokesPerMonth = result.smokesPerMonth,
-            lastSmokeTimestamp = result.lastSmokeTimestamp
+            todayCount = result.todayCount,
+            targetGapMinutes = result.targetGapMinutes,
+            averageSmokesPerDayWeek = result.averageSmokesPerDayWeek,
+            lastSmokeTimestamp = result.lastSmokeTimestamp,
         )
 
         is TileResult.AddSmokeSuccess -> previous.copy()

--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileViewState.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileViewState.kt
@@ -4,9 +4,9 @@ import com.feragusper.smokeanalytics.libraries.architecture.presentation.mvi.MVI
 
 // Data class to represent the state of the Tile
 data class TileViewState(
-    val smokesPerDay: Int? = null, // The number of smokes for the current day
-    val smokesPerWeek: Int? = null, // The number of smokes for the current week
-    val smokesPerMonth: Int? = null, // The number of smokes for the current month
-    val lastSmokeTimestamp: Long? = null, // The timestamp for the last smoke
-    val error: TileResult? = null // Represents any error that might have occurred
+    val todayCount: Int? = null,
+    val targetGapMinutes: Int? = null,
+    val averageSmokesPerDayWeek: Double? = null,
+    val lastSmokeTimestamp: Long? = null,
+    val error: TileResult? = null,
 ) : MVIViewState<TileIntent>

--- a/apps/wear/src/main/res/values/strings.xml
+++ b/apps/wear/src/main/res/values/strings.xml
@@ -5,5 +5,6 @@
     <string name="last_smoke_hours_ago">Last smoke %1$d h ago</string>
     <string name="last_smoke_days_ago">Last smoke %1$d d ago</string>
     <string name="stats_today_short">Today %1$d</string>
-    <string name="stats_summary">Week %1$d · Month %2$d</string>
+    <string name="target_gap_short">Target gap %1$s</string>
+    <string name="average_week_short">7d avg %1$s</string>
 </resources>

--- a/features/goals/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/goals/domain/GoalProgress.kt
+++ b/features/goals/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/goals/domain/GoalProgress.kt
@@ -17,4 +17,10 @@ data class GoalProgress(
     val baselineLabel: String? = null,
     val supportingText: String,
     val status: GoalStatus,
+    val progressFraction: Float? = null,
+    val warningLabel: String? = null,
+    val celebrationLabel: String? = null,
+    val streakDays: Int = 0,
+    val streakLabel: String? = null,
+    val isBroken: Boolean = false,
 )

--- a/features/goals/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/goals/domain/GoalsEvaluator.kt
+++ b/features/goals/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/goals/domain/GoalsEvaluator.kt
@@ -1,6 +1,8 @@
 package com.feragusper.smokeanalytics.features.goals.domain
 
 import com.feragusper.smokeanalytics.libraries.architecture.domain.activeCurrentDayStartInstant
+import com.feragusper.smokeanalytics.libraries.architecture.domain.currentBucketDate
+import com.feragusper.smokeanalytics.libraries.architecture.domain.dayBucketDate
 import com.feragusper.smokeanalytics.libraries.architecture.domain.currentMonthStartInstant
 import com.feragusper.smokeanalytics.libraries.architecture.domain.currentWeekStartInstant
 import com.feragusper.smokeanalytics.libraries.architecture.domain.nextDayStartInstant
@@ -11,6 +13,7 @@ import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreference
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
 import kotlin.math.roundToInt
 import kotlinx.datetime.Clock
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
@@ -56,24 +59,61 @@ class EvaluateGoalProgressUseCase(
         )
         val todayCount = smokes.count { it.date >= currentDayStart && it.date < nextDayStart }
         val remaining = (goal.maxCigarettesPerDay - todayCount).coerceAtLeast(0)
+        val currentBucketDate = currentBucketDate(
+            now = now,
+            timeZone = timeZone,
+            dayStartHour = preferences.dayStartHour,
+            manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
+        )
+        val countsByBucketDate = smokes.groupingBy {
+            it.date.dayBucketDate(
+                timeZone = timeZone,
+                dayStartHour = preferences.dayStartHour,
+                manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
+            )
+        }.eachCount()
+        val yesterdayBucketDate = currentBucketDate.minus(1, DateTimeUnit.DAY)
+        val yesterdayCount = countsByBucketDate[yesterdayBucketDate] ?: 0
+        val hasHistoryBeforeToday = countsByBucketDate.keys.any { it < currentBucketDate }
+        val yesterdayCompleted = hasHistoryBeforeToday && yesterdayCount <= goal.maxCigarettesPerDay
+        val streakDays = countsByBucketDate.consecutiveCompletedDays(
+            endDateInclusive = yesterdayBucketDate,
+            maxPerDay = goal.maxCigarettesPerDay,
+        )
         val status = when {
             todayCount < goal.maxCigarettesPerDay -> GoalStatus.OnTrack
             todayCount == goal.maxCigarettesPerDay -> GoalStatus.Completed
             else -> GoalStatus.OffTrack
+        }
+        val warningLabel = when {
+            todayCount == goal.maxCigarettesPerDay - 1 -> "One more cigarette breaks today's cap."
+            todayCount > goal.maxCigarettesPerDay -> "Today's cap is broken."
+            else -> null
+        }
+        val celebrationLabel = when {
+            todayCount == goal.maxCigarettesPerDay -> "You reached today's cap without going over. Hold here to keep the win."
+            todayCount == 0 && yesterdayCompleted -> "Yesterday stayed under your cap. Strong work."
+            else -> null
         }
 
         return GoalProgress(
             goal = goal,
             title = "Daily cap",
             targetLabel = "Target: at most ${goal.maxCigarettesPerDay} today",
-            progressLabel = "$todayCount smoked today",
+            progressLabel = "$todayCount / ${goal.maxCigarettesPerDay} smoked today",
             supportingText = when (status) {
-                GoalStatus.OnTrack -> "$remaining left before reaching today's cap."
-                GoalStatus.Completed -> "You reached today's cap. Holding here keeps the goal intact."
+                GoalStatus.OnTrack -> warningLabel ?: "$remaining left before reaching today's cap."
+                GoalStatus.Completed -> celebrationLabel ?: "You reached today's cap. Holding here keeps the goal intact."
                 GoalStatus.OffTrack -> "Today's cap is exceeded. The next win is stopping the count from climbing further."
                 GoalStatus.NotEnoughData -> ""
             },
             status = status,
+            progressFraction = (todayCount.toFloat() / goal.maxCigarettesPerDay.toFloat()).coerceIn(0f, 1f),
+            warningLabel = warningLabel,
+            celebrationLabel = celebrationLabel,
+            streakDays = streakDays,
+            streakLabel = streakDays.takeIf { it > 0 }?.let(::formatStreakLabel),
+            isBroken = todayCount > goal.maxCigarettesPerDay,
         )
     }
 
@@ -156,6 +196,7 @@ class EvaluateGoalProgressUseCase(
                 baselineLabel = baselineLabel,
                 supportingText = "A previous comparison period is needed before this goal can be evaluated reliably.",
                 status = GoalStatus.NotEnoughData,
+                progressFraction = null,
             )
         }
 
@@ -180,6 +221,7 @@ class EvaluateGoalProgressUseCase(
                 GoalStatus.NotEnoughData -> ""
             },
             status = status,
+            progressFraction = ((currentReduction / reductionPercent).coerceAtLeast(0.0).coerceIn(0.0, 1.0)).toFloat(),
         )
     }
 
@@ -214,9 +256,29 @@ class EvaluateGoalProgressUseCase(
                 GoalStatus.NotEnoughData -> ""
             },
             status = status,
+            progressFraction = (elapsedMinutes.toFloat() / goal.targetMinutes.toFloat()).coerceIn(0f, 1f),
         )
     }
 }
+
+private fun Map<LocalDate, Int>.consecutiveCompletedDays(
+    endDateInclusive: LocalDate,
+    maxPerDay: Int,
+): Int {
+    val firstTrackedDate = keys.minOrNull() ?: return 0
+    var streak = 0
+    var cursor = endDateInclusive
+    while (cursor >= firstTrackedDate) {
+        val count = this[cursor] ?: 0
+        if (count > maxPerDay) break
+        streak += 1
+        cursor = cursor.minus(1, DateTimeUnit.DAY)
+    }
+    return streak
+}
+
+private fun formatStreakLabel(days: Int): String =
+    if (days == 1) "1 day completed in a row" else "$days days completed in a row"
 
 fun goalDataFetchStart(
     preferences: UserPreferences,

--- a/features/goals/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/features/goals/domain/EvaluateGoalProgressUseCaseTest.kt
+++ b/features/goals/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/features/goals/domain/EvaluateGoalProgressUseCaseTest.kt
@@ -5,6 +5,8 @@ import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreference
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 
@@ -29,6 +31,62 @@ class EvaluateGoalProgressUseCaseTest {
         )
 
         assertEquals(GoalStatus.Completed, progress?.status)
+        assertTrue(progress?.celebrationLabel?.contains("reached today's cap") == true)
+    }
+
+    @Test
+    fun `daily cap warns when one smoke away from breaking`() {
+        val smokes = listOf(smokeAt("2026-03-29T08:00:00Z"))
+
+        val progress = useCase(
+            activeGoal = SmokingGoal.DailyCap(maxCigarettesPerDay = 2),
+            smokes = smokes,
+            preferences = preferences,
+            now = Instant.parse("2026-03-29T10:00:00Z"),
+        )
+
+        assertEquals(GoalStatus.OnTrack, progress?.status)
+        assertEquals("One more cigarette breaks today's cap.", progress?.warningLabel)
+    }
+
+    @Test
+    fun `daily cap acknowledges yesterday success and streak`() {
+        val smokes = listOf(
+            smokeAt("2026-03-27T08:00:00Z"),
+            smokeAt("2026-03-28T08:00:00Z"),
+            smokeAt("2026-03-28T09:00:00Z"),
+        )
+
+        val progress = useCase(
+            activeGoal = SmokingGoal.DailyCap(maxCigarettesPerDay = 2),
+            smokes = smokes,
+            preferences = preferences,
+            now = Instant.parse("2026-03-29T10:00:00Z"),
+        )
+
+        assertEquals(2, progress?.streakDays)
+        assertTrue(progress?.celebrationLabel?.contains("Yesterday stayed under your cap") == true)
+        assertTrue(progress?.streakLabel?.contains("2 days") == true)
+    }
+
+    @Test
+    fun `daily cap marks broken once count exceeds target`() {
+        val smokes = listOf(
+            smokeAt("2026-03-29T08:00:00Z"),
+            smokeAt("2026-03-29T09:00:00Z"),
+            smokeAt("2026-03-29T10:00:00Z"),
+        )
+
+        val progress = useCase(
+            activeGoal = SmokingGoal.DailyCap(maxCigarettesPerDay = 2),
+            smokes = smokes,
+            preferences = preferences,
+            now = Instant.parse("2026-03-29T10:30:00Z"),
+        )
+
+        assertEquals(GoalStatus.OffTrack, progress?.status)
+        assertTrue(progress?.isBroken == true)
+        assertFalse(progress?.warningLabel.isNullOrBlank())
     }
 
     @Test

--- a/features/history/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/history/presentation/HistoryPendingAction.kt
+++ b/features/history/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/history/presentation/HistoryPendingAction.kt
@@ -1,0 +1,6 @@
+package com.feragusper.smokeanalytics.features.history.presentation
+
+enum class HistoryPendingAction {
+    Editing,
+    Deleting,
+}

--- a/features/history/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/history/presentation/HistoryViewModel.kt
+++ b/features/history/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/history/presentation/HistoryViewModel.kt
@@ -4,7 +4,9 @@ import com.feragusper.smokeanalytics.features.history.presentation.mvi.HistoryIn
 import com.feragusper.smokeanalytics.features.history.presentation.mvi.HistoryResult
 import com.feragusper.smokeanalytics.features.history.presentation.mvi.HistoryResult.AddSmokeSuccess
 import com.feragusper.smokeanalytics.features.history.presentation.mvi.HistoryResult.DeleteSmokeSuccess
+import com.feragusper.smokeanalytics.features.history.presentation.mvi.HistoryResult.DeleteSmokeInFlight
 import com.feragusper.smokeanalytics.features.history.presentation.mvi.HistoryResult.EditSmokeSuccess
+import com.feragusper.smokeanalytics.features.history.presentation.mvi.HistoryResult.EditSmokeInFlight
 import com.feragusper.smokeanalytics.features.history.presentation.mvi.HistoryResult.Error
 import com.feragusper.smokeanalytics.features.history.presentation.mvi.HistoryResult.FetchSmokesError
 import com.feragusper.smokeanalytics.features.history.presentation.mvi.HistoryResult.FetchSmokesSuccess
@@ -45,6 +47,18 @@ class HistoryViewModel @Inject constructor(
                 error = null,
             )
 
+            is EditSmokeInFlight -> previous.copy(
+                pendingSmokeId = result.id,
+                pendingAction = HistoryPendingAction.Editing,
+                error = null,
+            )
+
+            is DeleteSmokeInFlight -> previous.copy(
+                pendingSmokeId = result.id,
+                pendingAction = HistoryPendingAction.Deleting,
+                error = null,
+            )
+
             is NotLoggedIn -> previous.copy(
                 displayLoading = false,
                 error = null,
@@ -57,21 +71,32 @@ class HistoryViewModel @Inject constructor(
                 smokes = result.smokes,
                 selectedDate = result.selectedDate,
                 monthCounts = result.monthCounts,
+                pendingSmokeId = null,
+                pendingAction = null,
+                rowInteractionEpoch = previous.rowInteractionEpoch + 1,
             )
 
             DeleteSmokeSuccess, EditSmokeSuccess, AddSmokeSuccess -> {
                 intents().trySend(HistoryIntent.FetchSmokes(previous.selectedDate))
-                previous
+                previous.copy(
+                    pendingSmokeId = null,
+                    pendingAction = null,
+                    rowInteractionEpoch = previous.rowInteractionEpoch + 1,
+                )
             }
 
             is Error -> previous.copy(
                 displayLoading = false,
                 error = result,
+                pendingSmokeId = null,
+                pendingAction = null,
             )
 
             FetchSmokesError -> previous.copy(
                 displayLoading = false,
                 error = Error.Generic,
+                pendingSmokeId = null,
+                pendingAction = null,
             )
 
             NavigateUp -> {

--- a/features/history/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/history/presentation/mvi/HistoryResult.kt
+++ b/features/history/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/history/presentation/mvi/HistoryResult.kt
@@ -17,6 +17,14 @@ sealed interface HistoryResult : MVIResult {
      */
     data object Loading : HistoryResult
 
+    data class EditSmokeInFlight(
+        val id: String,
+    ) : HistoryResult
+
+    data class DeleteSmokeInFlight(
+        val id: String,
+    ) : HistoryResult
+
     /**
      * Indicates that the user is not logged in and the selected date is preserved.
      *

--- a/features/history/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/history/presentation/mvi/compose/HistoryViewState.kt
+++ b/features/history/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/history/presentation/mvi/compose/HistoryViewState.kt
@@ -74,6 +74,9 @@ data class HistoryViewState(
     internal val monthCounts: Map<Int, Int> = emptyMap(),
     internal val error: HistoryResult.Error? = null,
     internal val selectedDate: Instant = Clock.System.now(),
+    internal val pendingSmokeId: String? = null,
+    internal val pendingAction: com.feragusper.smokeanalytics.features.history.presentation.HistoryPendingAction? = null,
+    internal val rowInteractionEpoch: Int = 0,
 ) : MVIViewState<HistoryIntent> {
 
     @Composable
@@ -275,7 +278,10 @@ data class HistoryViewState(
                             }
                         }
 
-                        items(smokes) { smoke ->
+                        items(
+                            items = smokes,
+                            key = { smoke -> "${smoke.id}-${rowInteractionEpoch}" }
+                        ) { smoke ->
                             Card(
                                 shape = RoundedCornerShape(22.dp),
                                 colors = CardDefaults.cardColors(
@@ -283,11 +289,18 @@ data class HistoryViewState(
                                 ),
                             ) {
                                 SwipeToDismissRow(
+                                    itemKey = smoke.id,
                                     date = smoke.date,
                                     timeElapsedSincePreviousSmoke = smoke.timeElapsedSincePreviousSmoke,
                                     onDelete = { intent(HistoryIntent.DeleteSmoke(smoke.id)) },
                                     fullDateTimeEdit = true,
                                     onEdit = { editedInstant -> intent(HistoryIntent.EditSmoke(smoke.id, editedInstant)) },
+                                    isPending = pendingSmokeId == smoke.id,
+                                    pendingLabel = when (pendingAction) {
+                                        com.feragusper.smokeanalytics.features.history.presentation.HistoryPendingAction.Editing -> "Saving edit…"
+                                        com.feragusper.smokeanalytics.features.history.presentation.HistoryPendingAction.Deleting -> "Deleting…"
+                                        null -> null
+                                    },
                                 )
                             }
                         }

--- a/features/history/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/history/presentation/process/HistoryProcessHolder.kt
+++ b/features/history/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/history/presentation/process/HistoryProcessHolder.kt
@@ -79,7 +79,7 @@ class HistoryProcessHolder @Inject constructor(
      * @return A [Flow] emitting the result of the delete operation.
      */
     private fun processDeleteSmoke(intent: HistoryIntent.DeleteSmoke) = flow {
-        emit(HistoryResult.Loading)
+        emit(HistoryResult.DeleteSmokeInFlight(intent.id))
         deleteSmokeUseCase.invoke(intent.id)
         refreshWidgetSnapshot()
         emit(HistoryResult.DeleteSmokeSuccess)
@@ -95,7 +95,7 @@ class HistoryProcessHolder @Inject constructor(
      * @return A [Flow] emitting the result of the edit operation.
      */
     private fun processEditSmoke(intent: HistoryIntent.EditSmoke) = flow {
-        emit(HistoryResult.Loading)
+        emit(HistoryResult.EditSmokeInFlight(intent.id))
         editSmokeUseCase.invoke(intent.id, intent.date)
         refreshWidgetSnapshot()
         emit(HistoryResult.EditSmokeSuccess)

--- a/features/history/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/history/presentation/process/HistoryProcessHolderTest.kt
+++ b/features/history/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/history/presentation/process/HistoryProcessHolderTest.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.test.setMain
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -118,8 +119,8 @@ class HistoryProcessHolderTest {
             results = processHolder.processIntent(HistoryIntent.EditSmoke(id, date))
 
             results.test {
-                awaitItem() shouldBe HistoryResult.Loading
-                awaitItem() shouldBe HistoryResult.EditSmokeSuccess
+                awaitItem() shouldBeEqualTo HistoryResult.EditSmokeInFlight(id)
+                awaitItem() shouldBeEqualTo HistoryResult.EditSmokeSuccess
                 coVerify(exactly = 1) { syncWithWearUseCase.invoke() }
                 cancelAndIgnoreRemainingEvents()
             }
@@ -133,8 +134,8 @@ class HistoryProcessHolderTest {
             results = processHolder.processIntent(HistoryIntent.DeleteSmoke(id))
 
             results.test {
-                awaitItem() shouldBe HistoryResult.Loading
-                awaitItem() shouldBe HistoryResult.DeleteSmokeSuccess
+                awaitItem() shouldBeEqualTo HistoryResult.DeleteSmokeInFlight(id)
+                awaitItem() shouldBeEqualTo HistoryResult.DeleteSmokeSuccess
                 coVerify(exactly = 1) { syncWithWearUseCase.invoke() }
                 cancelAndIgnoreRemainingEvents()
             }

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
@@ -433,10 +433,56 @@ private fun GoalFocusSection(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
+            goalProgress?.progressFraction?.let { progressFraction ->
+                LinearProgressIndicator(
+                    progress = { progressFraction },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            goalProgress?.warningLabel?.let {
+                GoalAssistPill(
+                    text = it,
+                    containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                )
+            }
+            goalProgress?.celebrationLabel?.let {
+                GoalAssistPill(
+                    text = it,
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+            }
+            goalProgress?.streakLabel?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
             Button(onClick = onOpenGoals) {
                 Text(if (hasActiveGoal) "Review in You" else "Set in You")
             }
         }
+    }
+}
+
+@Composable
+private fun GoalAssistPill(
+    text: String,
+    containerColor: Color,
+    contentColor: Color,
+) {
+    Surface(
+        color = containerColor,
+        contentColor = contentColor,
+        shape = RoundedCornerShape(999.dp),
+    ) {
+        Text(
+            text = text,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            style = MaterialTheme.typography.labelMedium,
+        )
     }
 }
 

--- a/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/GoalsEditorScreen.kt
+++ b/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/GoalsEditorScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
@@ -157,6 +158,12 @@ fun GoalsEditorScreen(
                 }
 
                 goalProgress?.let { progress ->
+                    progress.progressFraction?.let { fraction ->
+                        LinearProgressIndicator(
+                            progress = { fraction },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
                     Text(
                         text = progress.progressLabel,
                         style = MaterialTheme.typography.bodyMedium,
@@ -165,6 +172,27 @@ fun GoalsEditorScreen(
                     progress.baselineLabel?.let { baseline ->
                         Text(
                             text = baseline,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    progress.warningLabel?.let { warning ->
+                        Text(
+                            text = warning,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onTertiaryContainer,
+                        )
+                    }
+                    progress.celebrationLabel?.let { celebration ->
+                        Text(
+                            text = celebration,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                    progress.streakLabel?.let { streak ->
+                        Text(
+                            text = streak,
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )

--- a/libraries/smokes/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImpl.kt
+++ b/libraries/smokes/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImpl.kt
@@ -78,14 +78,23 @@ class SmokeRepositoryImpl @Inject constructor(
         val startMillis = (startDate ?: firstInstantThisMonth()).toEpochMilliseconds().toDouble()
         val endMillis = (endDate ?: nextDayStartInstant()).toEpochMilliseconds().toDouble()
 
-        var query: Query = smokesQuery()
+        val query: Query = smokesQuery()
             .orderBy(SmokeEntity.Fields.TIMESTAMP_MILLIS, Direction.DESCENDING)
             .whereGreaterThanOrEqualTo(SmokeEntity.Fields.TIMESTAMP_MILLIS, startMillis)
             .whereLessThan(SmokeEntity.Fields.TIMESTAMP_MILLIS, endMillis)
 
         val result = query.get().await()
+        val previousDocument = smokesQuery()
+            .orderBy(SmokeEntity.Fields.TIMESTAMP_MILLIS, Direction.DESCENDING)
+            .whereLessThan(SmokeEntity.Fields.TIMESTAMP_MILLIS, startMillis)
+            .limit(1)
+            .get()
+            .await()
+            .documents
+            .firstOrNull()
 
-        val instants = result.documents.mapNotNull { it.getInstant() }
+        val documents = previousDocument?.let { result.documents + it } ?: result.documents
+        val instants = documents.mapNotNull { it.getInstant() }
 
         return result.documents.mapIndexedNotNull { index, document ->
             val currentInstant = instants.getOrNull(index) ?: return@mapIndexedNotNull null

--- a/libraries/smokes/data/mobile/src/test/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImplTest.kt
+++ b/libraries/smokes/data/mobile/src/test/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImplTest.kt
@@ -105,6 +105,28 @@ class SmokeRepositoryImplTest {
             }
 
         @Test
+        fun `GIVEN fetch starts after an older smoke WHEN fetch smokes is called THEN first row keeps the real previous gap`() =
+            runTest {
+                mockFetchSmokes(
+                    resultDocuments = listOf(mockDocumentSnapshot(id1, instant1)),
+                    previousDocument = mockDocumentSnapshot(id2, instant2),
+                )
+
+                val result = smokeRepository.fetchSmokes(instant1, Instant.fromEpochMilliseconds(1_672_580_000_000))
+
+                assertEquals(
+                    listOf(
+                        Smoke(
+                            id = id1,
+                            date = instant1,
+                            timeElapsedSincePreviousSmoke = timeAfter2
+                        )
+                    ),
+                    result
+                )
+            }
+
+        @Test
         fun `GIVEN user is logged in WHEN add smoke is called THEN it should finish`() = runTest {
             val date = Instant.fromEpochMilliseconds(1_672_574_400_000)
             val smokeEntitySlot = slot<SmokeEntity>()
@@ -179,9 +201,17 @@ class SmokeRepositoryImplTest {
                 smokeRepository.deleteSmoke(id)
             }
 
-        private fun mockFetchSmokes() {
+        private fun mockFetchSmokes(
+            resultDocuments: List<DocumentSnapshot> = listOf(
+                mockDocumentSnapshot(id1, instant1),
+                mockDocumentSnapshot(id2, instant2),
+            ),
+            previousDocument: DocumentSnapshot? = null,
+        ) {
             val query = mockk<Query>(relaxed = true)
             val finalQuery = mockk<Query>(relaxed = true)
+            val previousQuery = mockk<Query>(relaxed = true)
+            val previousLimitedQuery = mockk<Query>(relaxed = true)
 
             every {
                 collectionReference.orderBy(
@@ -197,6 +227,12 @@ class SmokeRepositoryImplTest {
             every {
                 finalQuery.whereLessThan(any<String>(), any())
             } returns finalQuery
+            every {
+                query.whereLessThan(any<String>(), any())
+            } returns previousQuery
+            every {
+                previousQuery.limit(1)
+            } returns previousLimitedQuery
 
             every { finalQuery.get() } answers {
                 mockk<Task<QuerySnapshot>>().apply {
@@ -205,10 +241,20 @@ class SmokeRepositoryImplTest {
                     every { isCanceled } returns false
                     every { result } answers {
                         mockk<QuerySnapshot>().apply {
-                            every { documents } returns listOf(
-                                mockDocumentSnapshot(id1, instant1),
-                                mockDocumentSnapshot(id2, instant2)
-                            )
+                            every { documents } returns resultDocuments
+                        }
+                    }
+                    every { exception } returns null
+                }
+            }
+            every { previousLimitedQuery.get() } answers {
+                mockk<Task<QuerySnapshot>>().apply {
+                    every { isComplete } returns true
+                    every { isSuccessful } returns true
+                    every { isCanceled } returns false
+                    every { result } answers {
+                        mockk<QuerySnapshot>().apply {
+                            every { documents } returns listOfNotNull(previousDocument)
                         }
                     }
                     every { exception } returns null

--- a/libraries/smokes/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImpl.kt
+++ b/libraries/smokes/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImpl.kt
@@ -102,7 +102,17 @@ class SmokeRepositoryImpl(
             }
             .get()
 
-        val instants = result.documents.mapNotNull { it.getInstant() }
+        val previousDocument = smokesCollection()
+            .orderBy(SmokeEntity.Fields.TIMESTAMP_MILLIS, Direction.DESCENDING)
+            .where {
+                SmokeEntity.Fields.TIMESTAMP_MILLIS lessThan startMillis
+            }
+            .limit(1)
+            .get()
+            .documents
+            .firstOrNull()
+        val documents = previousDocument?.let { result.documents + it } ?: result.documents
+        val instants = documents.mapNotNull { it.getInstant() }
 
         return result.documents.mapIndexedNotNull { index, document ->
             val currentInstant = instants.getOrNull(index) ?: return@mapIndexedNotNull null

--- a/libraries/smokes/presentation/src/main/java/com/feragusper/smokeanalytics/libraries/smokes/presentation/compose/SwipeToDismissRow.kt
+++ b/libraries/smokes/presentation/src/main/java/com/feragusper/smokeanalytics/libraries/smokes/presentation/compose/SwipeToDismissRow.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -62,16 +63,19 @@ import kotlinx.datetime.toLocalDateTime
  */
 @Composable
 fun SwipeToDismissRow(
+    itemKey: String,
     date: Instant,
     timeElapsedSincePreviousSmoke: Pair<Long, Long>,
     onDelete: () -> Unit,
     fullDateTimeEdit: Boolean,
     onEdit: (Instant) -> Unit,
+    isPending: Boolean = false,
+    pendingLabel: String? = null,
 ) {
     val timeZone = TimeZone.currentSystemDefault()
     val shape = MaterialTheme.shapes.medium
 
-    val state = rememberRevealState(
+    val revealState = rememberRevealState(
         directions = setOf(RevealDirection.StartToEnd, RevealDirection.EndToStart),
     )
 
@@ -79,22 +83,24 @@ fun SwipeToDismissRow(
 
     RevealSwipe(
         modifier = Modifier.padding(vertical = 5.dp),
-        state = state,
+        state = revealState,
         shape = shape,
         backgroundCardStartColor = MaterialTheme.colorScheme.primaryContainer,
         backgroundCardEndColor = MaterialTheme.colorScheme.errorContainer,
         backgroundStartActionLabel = "Edit smoke",
         backgroundEndActionLabel = "Delete smoke",
         onBackgroundStartClick = {
+            if (isPending) return@RevealSwipe false
             showDatePicker = true
             true
         },
         onBackgroundEndClick = {
+            if (isPending) return@RevealSwipe false
             onDelete()
             true
         },
         hiddenContentStart = {
-            IconButton(onClick = { showDatePicker = true }) {
+            IconButton(onClick = { showDatePicker = true }, enabled = !isPending) {
                 Icon(
                     imageVector = ImageVector.vectorResource(R.drawable.ic_pencil),
                     contentDescription = null,
@@ -103,7 +109,7 @@ fun SwipeToDismissRow(
             }
         },
         hiddenContentEnd = {
-            IconButton(onClick = onDelete) {
+            IconButton(onClick = onDelete, enabled = !isPending) {
                 Icon(
                     imageVector = Icons.Filled.Delete,
                     contentDescription = null,
@@ -116,25 +122,44 @@ fun SwipeToDismissRow(
                 modifier = Modifier.matchParentSize(),
                 colors = CardDefaults.cardColors(
                     contentColor = MaterialTheme.colorScheme.onSecondary,
-                    containerColor = Color.Transparent
+                    containerColor = MaterialTheme.colorScheme.surface
                 ),
                 shape = cardShape,
                 content = content
             )
         }
     ) {
-        SmokeItem(
-            date = date,
-            timeZone = timeZone,
-            timeAfterPrevious = timeElapsedSincePreviousSmoke,
-            tone = elapsedToneFrom(
-                timeElapsedSincePreviousSmoke.first,
-                timeElapsedSincePreviousSmoke.second,
-            ),
-        )
+        Column {
+            SmokeItem(
+                date = date,
+                timeZone = timeZone,
+                timeAfterPrevious = timeElapsedSincePreviousSmoke,
+                tone = elapsedToneFrom(
+                    timeElapsedSincePreviousSmoke.first,
+                    timeElapsedSincePreviousSmoke.second,
+                ),
+            )
+            if (isPending) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                        .padding(horizontal = 12.dp, vertical = 10.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.width(18.dp).height(18.dp), strokeWidth = 2.dp)
+                    Text(
+                        text = pendingLabel ?: "Updating…",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
     }
 
-    if (showDatePicker) {
+    if (showDatePicker && !isPending) {
         var selectedDateTime: LocalDateTime = date.toLocalDateTime(timeZone)
 
         if (fullDateTimeEdit) {
@@ -192,6 +217,7 @@ private fun SmokeItem(
 
     Row(
         modifier = Modifier
+            .fillMaxWidth()
             .background(color = tone.rowContainerColor(), shape = MaterialTheme.shapes.medium)
             .padding(horizontal = 12.dp)
             .height(72.dp),

--- a/libraries/wear/data/src/main/java/com/feragusper/smokeanalytics/libraries/wear/data/WearPaths.kt
+++ b/libraries/wear/data/src/main/java/com/feragusper/smokeanalytics/libraries/wear/data/WearPaths.kt
@@ -11,11 +11,8 @@ object WearPaths {
     // Path to add a smoke record
     const val ADD_SMOKE = "/add-smoke"
 
-    // Constants representing the different smoke count metrics
-    const val SMOKE_COUNT_TODAY = "smoke_count_today" // Count of smokes for today
-    const val SMOKE_COUNT_WEEK = "smoke_count_week" // Count of smokes for the current week
-    const val SMOKE_COUNT_MONTH = "smoke_count_month" // Count of smokes for the current month
-
-    // Path to get the timestamp of the last smoke
+    const val SMOKE_COUNT_TODAY = "smoke_count_today"
+    const val AVERAGE_SMOKES_PER_DAY_WEEK = "average_smokes_per_day_week"
+    const val TARGET_GAP_MINUTES = "target_gap_minutes"
     const val LAST_SMOKE_TIMESTAMP = "last_smoke_timestamp"
 }

--- a/libraries/wear/data/src/main/java/com/feragusper/smokeanalytics/libraries/wear/data/WearSyncManagerImpl.kt
+++ b/libraries/wear/data/src/main/java/com/feragusper/smokeanalytics/libraries/wear/data/WearSyncManagerImpl.kt
@@ -58,11 +58,14 @@ class WearSyncManagerImpl(
          */
         override suspend fun syncWithWear() {
             val preferences = userPreferencesRepository.fetch()
+            val smokeCount = smokeRepository.fetchSmokeCount(
+                dayStartHour = preferences.dayStartHour,
+                manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
+            )
             respondToWearWithSmokeCount(
-                smokeRepository.fetchSmokeCount(
-                    dayStartHour = preferences.dayStartHour,
-                    manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
-                )
+                smokeCount = smokeCount,
+                targetGapMinutes = smokeCount.targetGapMinutes(preferences.awakeMinutesPerDay),
+                averageSmokesPerDayWeek = smokeCount.averageSmokesPerDayWeek(),
             )
         }
 
@@ -89,11 +92,15 @@ class WearSyncManagerImpl(
          *
          * @param smokeCount The [SmokeCount] object containing today's, week's, and month's smoke data.
          */
-        private fun respondToWearWithSmokeCount(smokeCount: SmokeCount) {
+        private fun respondToWearWithSmokeCount(
+            smokeCount: SmokeCount,
+            targetGapMinutes: Int,
+            averageSmokesPerDayWeek: Double,
+        ) {
             val putDataMapRequest = PutDataMapRequest.create(WearPaths.SMOKE_DATA).apply {
                 dataMap.putInt(WearPaths.SMOKE_COUNT_TODAY, smokeCount.today.size)
-                dataMap.putInt(WearPaths.SMOKE_COUNT_WEEK, smokeCount.week)
-                dataMap.putInt(WearPaths.SMOKE_COUNT_MONTH, smokeCount.month)
+                dataMap.putInt(WearPaths.TARGET_GAP_MINUTES, targetGapMinutes)
+                dataMap.putDouble(WearPaths.AVERAGE_SMOKES_PER_DAY_WEEK, averageSmokesPerDayWeek)
                 smokeCount.lastSmoke?.date?.utcMillis()?.let {
                     dataMap.putLong(WearPaths.LAST_SMOKE_TIMESTAMP, it)
                 }
@@ -128,7 +135,12 @@ class WearSyncManagerImpl(
          * @param onDataReceived Callback function to handle the received data.
          */
         override fun listenForDataUpdates(
-            onDataReceived: (smokesToday: Int, smokesPerWeek: Int, smokesPerMonth: Int, lastSmokeTimestamp: Long?) -> Unit
+            onDataReceived: (
+                todayCount: Int,
+                targetGapMinutes: Int,
+                averageSmokesPerDayWeek: Double,
+                lastSmokeTimestamp: Long?,
+            ) -> Unit
         ) {
             Timber.d("listenForDataUpdates")
 
@@ -141,9 +153,9 @@ class WearSyncManagerImpl(
 
                             onDataReceived(
                                 dataMap.getInt(WearPaths.SMOKE_COUNT_TODAY),
-                                dataMap.getInt(WearPaths.SMOKE_COUNT_WEEK),
-                                dataMap.getInt(WearPaths.SMOKE_COUNT_MONTH),
-                                dataMap.getLong(WearPaths.LAST_SMOKE_TIMESTAMP)
+                                dataMap.getInt(WearPaths.TARGET_GAP_MINUTES),
+                                dataMap.getDouble(WearPaths.AVERAGE_SMOKES_PER_DAY_WEEK),
+                                dataMap.getLong(WearPaths.LAST_SMOKE_TIMESTAMP),
                             )
                         }
                     }
@@ -194,3 +206,10 @@ class WearSyncManagerImpl(
     private val dataClient: DataClient by lazy { Wearable.getDataClient(context) }
     private val messageClient: MessageClient by lazy { Wearable.getMessageClient(context) }
 }
+
+private fun SmokeCount.targetGapMinutes(awakeMinutesPerDay: Int): Int = when (val count = today.size) {
+    0 -> awakeMinutesPerDay
+    else -> (awakeMinutesPerDay / count).coerceAtLeast(1)
+}
+
+private fun SmokeCount.averageSmokesPerDayWeek(): Double = week / 7.0

--- a/libraries/wear/domain/src/main/java/com/feragusper/smokeanalytics/libraries/wear/domain/WearSyncManager.kt
+++ b/libraries/wear/domain/src/main/java/com/feragusper/smokeanalytics/libraries/wear/domain/WearSyncManager.kt
@@ -31,18 +31,14 @@ sealed interface WearSyncManager {
         /**
          * Listens for data updates from the mobile app and processes them.
          *
-         * @param onDataReceived Callback function that receives the smoke count data.
-         *                       - `smokesToday`: Number of smokes recorded today.
-         *                       - `smokesPerWeek`: Number of smokes recorded this week.
-         *                       - `smokesPerMonth`: Number of smokes recorded this month.
-         *                       - `lastSmokeTimestamp`: Timestamp of the last recorded smoke.
+         * @param onDataReceived Callback function that receives the pulse snapshot data.
          */
         fun listenForDataUpdates(
             onDataReceived: (
-                smokesToday: Int,
-                smokesPerWeek: Int,
-                smokesPerMonth: Int,
-                lastSmokeTimestamp: Long?
+                todayCount: Int,
+                targetGapMinutes: Int,
+                averageSmokesPerDayWeek: Double,
+                lastSmokeTimestamp: Long?,
             ) -> Unit
         )
     }


### PR DESCRIPTION
## Summary
- fix current-build polish issues in History, Home, and Goals
- keep the first-smoke gap tied to the real previous smoke across day boundaries
- align the Wear tile with the Pulse snapshot model instead of the old week/month summary

## Included
- row-level pending feedback and swipe reset fixes in History edit/delete
- active goal progress, warning, broken, celebration, and streak states in mobile
- Wear tile now shows today, last smoke, target gap, and 7d avg with quick add preserved

## Validation
- ./gradlew :libraries:smokes:data:mobile:testDebugUnitTest :features:history:presentation:mobile:testDebugUnitTest :features:goals:domain:jvmTest :features:home:presentation:mobile:compileDebugKotlin :features:settings:presentation:mobile:compileDebugKotlin
- ./gradlew :apps:mobile:assembleStagingDebug
- ./gradlew :apps:wear:assembleDebug :apps:mobile:assembleStagingDebug

Closes #201
Closes #184