### PR TITLE
Fix Play Store deployment failure

### DIFF
--- a/.github/workflows/deployment_playstore.yml
+++ b/.github/workflows/deployment_playstore.yml
@@ -100,8 +100,6 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Build & deploy Android release to Play Store
-        env:
-          PLAYSTORE_RELEASE_NOTES: ${{ steps.release_notes.outputs.playstore_notes }}
         run: bundler exec fastlane android deploy_playstore
 
       - name: Retrieve release metadata

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -3,7 +3,6 @@ default_platform(:android)
 platform :android do
   desc "Deploy the production release to Google Play Store beta channel"
   lane :deploy_playstore do |options|
-    release_notes = ENV["PLAYSTORE_RELEASE_NOTES"].to_s.strip
     upload_options = {
       release_status: "completed",                       # Marks the release as final.
       track: "beta",                                     # Deploys to the beta channel.
@@ -12,15 +11,6 @@ platform :android do
       package_name: "com.feragusper.smokeanalytics",     # The package name of the application.
       aab: "apps/mobile/build/outputs/bundle/productionRelease/mobile-production-release.aab" # Path to the AAB file.
     }
-
-    unless release_notes.empty?
-      upload_options[:release_notes] = [
-        {
-          language: "en-US",
-          text: release_notes
-        }
-      ]
-    end
 
     # Upload the Android App Bundle (AAB) to Google Play.
     # Ensure the service account JSON key is available at the specified path.


### PR DESCRIPTION
Summary
- remove the unsupported fastlane parameter from the Play Store deploy lane
- keep GitHub release notes intact
- unblock the Android production deploy for 0.11.0

Validation
- ruby syntax check passed for fastlane/Fastfile
- reviewed the deployment_playstore workflow diff

Context
The last Play Store deploy failed because the current fastlane version in this repo does not support that option.