### PR TITLE
Fix Home week/month averages to use elapsed days only

### DIFF
--- a/features/home/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/domain/HomeInsights.kt
+++ b/features/home/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/domain/HomeInsights.kt
@@ -1,8 +1,16 @@
 package com.feragusper.smokeanalytics.features.home.domain
 
 import com.feragusper.smokeanalytics.libraries.architecture.domain.WidgetSnapshot
+import com.feragusper.smokeanalytics.libraries.architecture.domain.currentBucketDate
+import com.feragusper.smokeanalytics.libraries.architecture.domain.currentMonthStartInstant
+import com.feragusper.smokeanalytics.libraries.architecture.domain.currentWeekStartInstant
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.daysUntil
+import kotlinx.datetime.toLocalDateTime
 import kotlin.math.max
 
 enum class ElapsedTone {
@@ -84,11 +92,33 @@ fun financialSummary(
 fun rateSummary(
     smokeCountListResult: SmokeCountListResult,
     preferences: UserPreferences,
+    now: Instant = Clock.System.now(),
+    timeZone: TimeZone = TimeZone.currentSystemDefault(),
 ): RateSummary {
     val targetGapMinutes = when (val count = smokeCountListResult.countByToday) {
         0 -> preferences.awakeMinutesPerDay
         else -> (preferences.awakeMinutesPerDay / count).coerceAtLeast(1)
     }
+    val currentDate = currentBucketDate(
+        now = now,
+        timeZone = timeZone,
+        dayStartHour = preferences.dayStartHour,
+        manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
+    )
+    val weekStartDate = currentWeekStartInstant(
+        now = now,
+        timeZone = timeZone,
+        dayStartHour = preferences.dayStartHour,
+        manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
+    ).toLocalDateTime(timeZone).date
+    val monthStartDate = currentMonthStartInstant(
+        now = now,
+        timeZone = timeZone,
+        dayStartHour = preferences.dayStartHour,
+        manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
+    ).toLocalDateTime(timeZone).date
+    val elapsedWeekDays = (weekStartDate.daysUntil(currentDate) + 1).coerceAtLeast(1)
+    val elapsedMonthDays = (monthStartDate.daysUntil(currentDate) + 1).coerceAtLeast(1)
 
     return RateSummary(
         latestIntervalMinutes = smokeCountListResult.lastSmoke
@@ -96,8 +126,8 @@ fun rateSummary(
             ?.totalMinutes()
             ?.takeIf { it > 0 },
         averageIntervalMinutesToday = targetGapMinutes,
-        averageSmokesPerDayWeek = smokeCountListResult.countByWeek / 7.0,
-        averageSmokesPerDayMonth = smokeCountListResult.countByMonth / 30.0,
+        averageSmokesPerDayWeek = smokeCountListResult.countByWeek / elapsedWeekDays.toDouble(),
+        averageSmokesPerDayMonth = smokeCountListResult.countByMonth / elapsedMonthDays.toDouble(),
     )
 }
 
@@ -138,10 +168,16 @@ fun gamificationSummary(smokes: List<Smoke>): GamificationSummary {
     )
 }
 
-fun SmokeCountListResult.toWidgetSnapshot(preferences: UserPreferences): WidgetSnapshot {
+fun SmokeCountListResult.toWidgetSnapshot(
+    preferences: UserPreferences,
+    now: Instant = Clock.System.now(),
+    timeZone: TimeZone = TimeZone.currentSystemDefault(),
+): WidgetSnapshot {
     val rate = rateSummary(
         smokeCountListResult = this,
         preferences = preferences,
+        now = now,
+        timeZone = timeZone,
     )
     val elapsed = timeSinceLastCigarette
     return WidgetSnapshot(

--- a/features/home/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/features/home/domain/HomeInsightsTest.kt
+++ b/features/home/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/features/home/domain/HomeInsightsTest.kt
@@ -2,16 +2,19 @@ package com.feragusper.smokeanalytics.features.home.domain
 
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
-import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class HomeInsightsTest {
 
+    private val utc = TimeZone.UTC
+
     @Test
     fun `rateSummary uses awake window to calculate the daily mindful gap target`() {
+        val now = Instant.parse("2026-03-25T12:00:00Z")
         val smokeCount = SmokeCountListResult(
             todaysSmokes = List(4) { index ->
                 Smoke(
@@ -35,16 +38,52 @@ class HomeInsightsTest {
                 dayStartHour = 6,
                 bedtimeHour = 22,
             ),
+            now = now,
+            timeZone = utc,
         )
 
         assertEquals(240, summary.averageIntervalMinutesToday)
-        assertEquals(16.0 / 7.0, summary.averageSmokesPerDayWeek, 0.0001)
-        assertEquals(1.6, summary.averageSmokesPerDayMonth, 0.0001)
+        assertEquals(16.0 / 3.0, summary.averageSmokesPerDayWeek, 0.0001)
+        assertEquals(48.0 / 25.0, summary.averageSmokesPerDayMonth, 0.0001)
+    }
+
+    @Test
+    fun `rateSummary uses elapsed days only at the start of week and month`() {
+        val now = Instant.parse("2026-06-01T09:00:00Z")
+        val smokeCount = SmokeCountListResult(
+            todaysSmokes = List(3) { index ->
+                Smoke(
+                    id = "$index",
+                    date = Instant.parse("2026-06-01T0${index + 6}:00:00Z"),
+                    timeElapsedSincePreviousSmoke = 1L to 0L,
+                )
+            },
+            countByWeek = 18,
+            countByMonth = 18,
+            lastSmoke = Smoke(
+                id = "last",
+                date = Instant.parse("2026-06-01T08:00:00Z"),
+                timeElapsedSincePreviousSmoke = 1L to 0L,
+            ),
+        )
+
+        val summary = rateSummary(
+            smokeCountListResult = smokeCount,
+            preferences = UserPreferences(
+                dayStartHour = 6,
+                bedtimeHour = 22,
+            ),
+            now = now,
+            timeZone = utc,
+        )
+
+        assertEquals(18.0, summary.averageSmokesPerDayWeek, 0.0001)
+        assertEquals(18.0, summary.averageSmokesPerDayMonth, 0.0001)
     }
 
     @Test
     fun `toWidgetSnapshot keeps pulse-oriented metrics for the widget`() {
-        val now = Clock.System.now()
+        val now = Instant.parse("2026-03-25T12:00:00Z")
         val smokeCount = SmokeCountListResult(
             todaysSmokes = List(4) { index ->
                 Smoke(
@@ -67,12 +106,14 @@ class HomeInsightsTest {
                 dayStartHour = 6,
                 bedtimeHour = 22,
             ),
+            now = now,
+            timeZone = utc,
         )
 
         assertEquals(4, snapshot.todayCount)
         assertTrue(snapshot.elapsedHours >= 0L)
         assertTrue(snapshot.elapsedMinutes >= 0L)
         assertEquals(240, snapshot.targetGapMinutes)
-        assertEquals(2.0, snapshot.averageSmokesPerDayWeek, 0.0001)
+        assertEquals(14.0 / 3.0, snapshot.averageSmokesPerDayWeek, 0.0001)
     }
 }


### PR DESCRIPTION
## Summary
- fix Home week/month averages so they divide by elapsed days in the current period instead of future calendar days
- keep the existing Home UI and copy intact
- add shared Home domain tests for partial-week and partial-month behavior

## Validation
- `./gradlew :features:home:domain:jvmTest`
- `./gradlew :features:home:presentation:mobile:compileDebugKotlin`
- `./gradlew :features:home:presentation:web:compileKotlinJs`
- `./gradlew :apps:mobile:assembleStagingDebug`

Closes #204