### PR TITLE
Clean up web shell parity leftovers

### DIFF
--- a/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/AppRoot.kt
+++ b/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/AppRoot.kt
@@ -47,10 +47,22 @@ fun AppRoot(graph: WebAppGraph) {
 
     DisposableEffect(Unit) {
         val handler: (Event) -> Unit = {
-            route = parseRouteFromHash(window.location.hash)
+            val parsedRoute = parseRouteFromHash(window.location.hash)
+            route = parsedRoute
+            val canonicalHash = parsedRoute.toHash()
+            if (window.location.hash != canonicalHash) {
+                window.location.hash = canonicalHash
+            }
         }
         window.addEventListener("hashchange", handler)
         onDispose { window.removeEventListener("hashchange", handler) }
+    }
+
+    LaunchedEffect(Unit) {
+        val canonicalHash = route.toHash()
+        if (window.location.hash != canonicalHash) {
+            window.location.hash = canonicalHash
+        }
     }
 
     val homeStore = remember(graph) { HomeWebStore(processHolder = graph.homeProcessHolder) }
@@ -102,7 +114,7 @@ fun AppRoot(graph: WebAppGraph) {
             WebRoute.Home -> "Smoke Analytics | Home"
             WebRoute.Analytics -> "Smoke Analytics | Analytics & Map"
             WebRoute.History -> "Smoke Analytics | History"
-            WebRoute.Coach -> "Smoke Analytics | AI Coach"
+            WebRoute.Coach -> "Smoke Analytics | The Guide"
             WebRoute.Settings -> "Smoke Analytics | You"
             WebRoute.Auth -> "Smoke Analytics | Sign in"
         }

--- a/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/WebScaffold.kt
+++ b/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/WebScaffold.kt
@@ -24,7 +24,7 @@ fun WebScaffold(
         Triple("⌂", "Home", WebRoute.Home),
         Triple("▤", "Analytics & Map", WebRoute.Analytics),
         Triple("◫", "History", WebRoute.History),
-        Triple("◌", "AI Coach", WebRoute.Coach),
+        Triple("◌", "The Guide", WebRoute.Coach),
         Triple("◉", "You", WebRoute.Settings),
     )
 

--- a/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/apps/web/CoachWebScreen.kt
+++ b/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/apps/web/CoachWebScreen.kt
@@ -79,7 +79,7 @@ fun CoachWebScreen(
     Div(attrs = { classes(SmokeWebStyles.panelStack) }) {
         PageSectionHeader(
             title = "The Guide",
-            eyebrow = "AI Coach",
+            eyebrow = "Guide",
             subtitle = "Pattern-aware prompts, quiet fallback support, and a calmer coaching surface built around recent smoking behavior.",
             badgeText = when {
                 loading -> "Refreshing"


### PR DESCRIPTION
## Summary
- canonicalize legacy web route aliases to their current hashes
- align shell and page copy from AI Coach to The Guide where the redesigned surface is already visible
- keep route contracts intact while removing visible web-only drift

## Validation
- `./gradlew :apps:web:jsBrowserDevelopmentWebpack`

Closes #168