### PR TITLE
IA: unify Analytics & Map into one destination

### DIFF
--- a/apps/mobile/src/main/java/com/feragusper/smokeanalytics/MainShellDestinations.kt
+++ b/apps/mobile/src/main/java/com/feragusper/smokeanalytics/MainShellDestinations.kt
@@ -135,6 +135,7 @@ fun AnalyticsMobileDestination(
             AnalyticsTab.Map -> MapMobileRoute(
                 modifier = Modifier.fillMaxSize(),
                 refreshNonce = refreshNonce,
+                embedded = true,
             )
         }
     }
@@ -166,6 +167,7 @@ private fun StatsMobileDestination(
         StatsView(
             viewModel = viewModel,
             refreshNonce = refreshNonce,
+            embedded = true,
         )
     }
 }

--- a/apps/mobile/src/main/java/com/feragusper/smokeanalytics/map/MapMobileScreen.kt
+++ b/apps/mobile/src/main/java/com/feragusper/smokeanalytics/map/MapMobileScreen.kt
@@ -62,6 +62,7 @@ import kotlinx.coroutines.withContext
 fun MapMobileRoute(
     modifier: Modifier = Modifier,
     refreshNonce: Int = 0,
+    embedded: Boolean = false,
     viewModel: MapMobileViewModel = hiltViewModel(),
 ) {
     LaunchedEffect(refreshNonce) {
@@ -71,6 +72,7 @@ fun MapMobileRoute(
     MapMobileScreen(
         modifier = modifier,
         state = state,
+        embedded = embedded,
         onPeriodChange = viewModel::onPeriodChange,
         onSelectCluster = viewModel::onSelectCluster,
         onRetry = viewModel::refresh,
@@ -81,6 +83,7 @@ fun MapMobileRoute(
 private fun MapMobileScreen(
     modifier: Modifier = Modifier,
     state: MapMobileState,
+    embedded: Boolean,
     onPeriodChange: (SmokeMapPeriod) -> Unit,
     onSelectCluster: (SmokeMapCluster) -> Unit,
     onRetry: () -> Unit,
@@ -93,6 +96,7 @@ private fun MapMobileScreen(
         else -> LoadedState(
             modifier = modifier,
             state = state,
+            embedded = embedded,
             onPeriodChange = onPeriodChange,
             onSelectCluster = onSelectCluster,
         )
@@ -139,6 +143,7 @@ private fun LoadingState(modifier: Modifier) {
 private fun LoadedState(
     modifier: Modifier,
     state: MapMobileState,
+    embedded: Boolean,
     onPeriodChange: (SmokeMapPeriod) -> Unit,
     onSelectCluster: (SmokeMapCluster) -> Unit,
 ) {
@@ -161,19 +166,31 @@ private fun LoadedState(
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    if (!embedded) {
+                        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                            Text(
+                                text = "Locations",
+                                style = MaterialTheme.typography.labelLarge,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Text(
+                                text = "Geographic clusters",
+                                style = MaterialTheme.typography.headlineSmall,
+                            )
+                            Text(
+                                text = "See where repeated smoking clusters show up across the selected period.",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    } else {
                         Text(
-                            text = "Locations",
-                            style = MaterialTheme.typography.labelLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                        Text(
-                            text = "Geographic clusters",
-                            style = MaterialTheme.typography.headlineSmall,
-                        )
-                        Text(
-                            text = "See where repeated smoking clusters show up across the selected period.",
-                            style = MaterialTheme.typography.bodyMedium,
+                            text = if (state.isRefreshing) {
+                                "Refreshing clusters in background"
+                            } else {
+                                "${state.clusters.sumOf { it.count }} mapped smokes in the selected period"
+                            },
+                            style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
@@ -193,7 +210,7 @@ private fun LoadedState(
                             )
                         }
                     }
-                    if (state.isRefreshing) {
+                    if (state.isRefreshing && !embedded) {
                         Text(
                             text = "Refreshing clusters in background",
                             style = MaterialTheme.typography.bodySmall,

--- a/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/AppRoot.kt
+++ b/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/AppRoot.kt
@@ -39,7 +39,7 @@ import org.w3c.dom.events.Event
 @Composable
 fun AppRoot(graph: WebAppGraph) {
     var route by remember { mutableStateOf(parseRouteFromHash(window.location.hash)) }
-    var analyticsTab by remember { mutableStateOf(AnalyticsTab.Trends) }
+    var analyticsTab by remember { mutableStateOf(parseAnalyticsTabFromHash(window.location.hash)) }
     var statsPeriod by remember { mutableStateOf(StatsPeriod.WEEK) }
     var statsSelectedDate by remember {
         mutableStateOf(Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date)
@@ -47,8 +47,10 @@ fun AppRoot(graph: WebAppGraph) {
 
     DisposableEffect(Unit) {
         val handler: (Event) -> Unit = {
-            val parsedRoute = parseRouteFromHash(window.location.hash)
+            val currentHash = window.location.hash
+            val parsedRoute = parseRouteFromHash(currentHash)
             route = parsedRoute
+            analyticsTab = parseAnalyticsTabFromHash(currentHash)
             val canonicalHash = parsedRoute.toHash()
             if (window.location.hash != canonicalHash) {
                 window.location.hash = canonicalHash
@@ -168,12 +170,16 @@ fun AppRoot(graph: WebAppGraph) {
                         store = statsStore,
                         currentPeriod = statsPeriod,
                         selectedDate = statsSelectedDate,
+                        embedded = true,
                         onPeriodChange = { statsPeriod = it },
                         onDateChange = { statsSelectedDate = it },
                     )
                 },
                 mapContent = {
-                    MapWebScreen(stateHolder = mapStateHolder)
+                    MapWebScreen(
+                        stateHolder = mapStateHolder,
+                        embedded = true,
+                    )
                 },
             )
 

--- a/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/WebRoute.kt
+++ b/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/WebRoute.kt
@@ -27,3 +27,8 @@ internal fun parseRouteFromHash(hash: String): WebRoute = when (hash.removePrefi
     "/home", "/", "" -> WebRoute.Home
     else -> WebRoute.Home
 }
+
+internal fun parseAnalyticsTabFromHash(hash: String) = when (hash.removePrefix("#")) {
+    "/map" -> com.feragusper.smokeanalytics.apps.web.AnalyticsTab.Map
+    else -> com.feragusper.smokeanalytics.apps.web.AnalyticsTab.Trends
+}

--- a/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/apps/web/MapWebScreen.kt
+++ b/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/apps/web/MapWebScreen.kt
@@ -16,25 +16,51 @@ import org.jetbrains.compose.web.dom.Text
 @Composable
 fun MapWebScreen(
     stateHolder: MapWebStateHolder,
+    embedded: Boolean = false,
 ) {
     val state = stateHolder.state
 
     Div(attrs = { classes(SmokeWebStyles.panelStack) }) {
-        PageSectionHeader(
-            title = "Geographic Clusters",
-            eyebrow = "Locations",
-            badgeText = if (state.isRefreshing) "Refreshing" else "${state.clusters.sumOf { it.count }} smokes",
-            subtitle = "Inspect repeated smoking areas and the places that dominate the current map period.",
-            actions = {
-                SmokeMapPeriod.entries.forEach { candidate ->
-                    PrimaryButton(
-                        text = candidate.name,
-                        onClick = { stateHolder.onPeriodChange(candidate) },
-                        enabled = !state.isLoading && candidate != state.period,
-                    )
+        if (!embedded) {
+            PageSectionHeader(
+                title = "Geographic Clusters",
+                eyebrow = "Locations",
+                badgeText = if (state.isRefreshing) "Refreshing" else "${state.clusters.sumOf { it.count }} smokes",
+                subtitle = "Inspect repeated smoking areas and the places that dominate the current map period.",
+                actions = {
+                    SmokeMapPeriod.entries.forEach { candidate ->
+                        PrimaryButton(
+                            text = candidate.name,
+                            onClick = { stateHolder.onPeriodChange(candidate) },
+                            enabled = !state.isLoading && candidate != state.period,
+                        )
+                    }
+                }
+            )
+        } else {
+            SurfaceCard {
+                Div(attrs = { classes(SmokeWebStyles.panelStack) }) {
+                    Div(attrs = { classes(SmokeWebStyles.helperText) }) {
+                        Text(
+                            if (state.isRefreshing) {
+                                "Refreshing clusters in background."
+                            } else {
+                                "${state.clusters.sumOf { it.count }} mapped smokes in the selected period."
+                            }
+                        )
+                    }
+                    Div(attrs = { classes(SmokeWebStyles.sectionActions) }) {
+                        SmokeMapPeriod.entries.forEach { candidate ->
+                            PrimaryButton(
+                                text = candidate.name,
+                                onClick = { stateHolder.onPeriodChange(candidate) },
+                                enabled = !state.isLoading && candidate != state.period,
+                            )
+                        }
+                    }
                 }
             }
-        )
+        }
 
         when {
             state.isLoading -> LoadingSkeletonCard(heightPx = 320, lineWidths = listOf("50%", "30%"))

--- a/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/apps/web/RevampWebScreens.kt
+++ b/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/apps/web/RevampWebScreens.kt
@@ -22,7 +22,7 @@ fun AnalyticsWebScreen(
         PageSectionHeader(
             title = "Analytics & Map",
             eyebrow = "Patterns",
-            subtitle = "Review smoking frequency and geographic clusters from one destination.",
+            subtitle = "Review smoking frequency and repeated smoking areas from one destination.",
             badgeText = selectedTab.label,
         )
 

--- a/features/stats/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/stats/presentation/StatsView.kt
+++ b/features/stats/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/stats/presentation/StatsView.kt
@@ -15,12 +15,16 @@ import androidx.compose.runtime.remember
 fun StatsView(
     viewModel: StatsViewModel,
     refreshNonce: Int = 0,
+    embedded: Boolean = false,
 ) {
     // Observe the ViewModel's state using collectAsState and remember to optimize recomposition.
     val viewState by remember(viewModel) { viewModel.states() }.collectAsState()
 
     // Render the UI based on the current state and send user intents to the ViewModel.
-    viewState.Compose(refreshNonce = refreshNonce) { intent ->
+    viewState.Compose(
+        refreshNonce = refreshNonce,
+        embedded = embedded,
+    ) { intent ->
         viewModel.intents().trySend(intent)
     }
 }

--- a/features/stats/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/stats/presentation/mvi/compose/StatsViewState.kt
+++ b/features/stats/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/stats/presentation/mvi/compose/StatsViewState.kt
@@ -77,6 +77,7 @@ data class StatsViewState(
     @Composable
     fun Compose(
         refreshNonce: Int = 0,
+        embedded: Boolean = false,
         intent: (StatsIntent) -> Unit,
     ) {
         var currentPeriod by remember { mutableStateOf(StatsPeriod.WEEK) }
@@ -106,51 +107,68 @@ data class StatsViewState(
                     modifier = Modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(28.dp),
                     colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.58f)
+                        containerColor = if (embedded) {
+                            MaterialTheme.colorScheme.surfaceContainerLow
+                        } else {
+                            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.58f)
+                        }
                     ),
                 ) {
                     Column(modifier = Modifier.padding(12.dp)) {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 8.dp, vertical = 4.dp),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                                Text(
-                                    text = "Trends",
-                                    style = MaterialTheme.typography.labelLarge,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-                                Text(
-                                    text = "Patterns in motion",
-                                    style = MaterialTheme.typography.titleLarge,
-                                    fontWeight = FontWeight.Bold,
-                                )
-                                Text(
-                                    text = when {
-                                        displayRefreshLoading -> "Refreshing in background"
-                                        error != null && stats != null -> "Latest refresh failed"
-                                        else -> selectedDate.summaryMeta(currentPeriod)
-                                    },
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-                            }
-                            Card(
-                                shape = RoundedCornerShape(999.dp),
-                                colors = CardDefaults.cardColors(
-                                    containerColor = MaterialTheme.colorScheme.secondaryContainer
-                                ),
+                        if (!embedded) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically,
                             ) {
-                                Text(
-                                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
-                                    text = if (displayRefreshLoading) "Refreshing" else selectedDate.summaryMeta(currentPeriod),
-                                    style = MaterialTheme.typography.labelMedium,
-                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                                )
+                                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                                    Text(
+                                        text = "Trends",
+                                        style = MaterialTheme.typography.labelLarge,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                    Text(
+                                        text = "Patterns in motion",
+                                        style = MaterialTheme.typography.titleLarge,
+                                        fontWeight = FontWeight.Bold,
+                                    )
+                                    Text(
+                                        text = when {
+                                            displayRefreshLoading -> "Refreshing in background"
+                                            error != null && stats != null -> "Latest refresh failed"
+                                            else -> selectedDate.summaryMeta(currentPeriod)
+                                        },
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                                Card(
+                                    shape = RoundedCornerShape(999.dp),
+                                    colors = CardDefaults.cardColors(
+                                        containerColor = MaterialTheme.colorScheme.secondaryContainer
+                                    ),
+                                ) {
+                                    Text(
+                                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                                        text = if (displayRefreshLoading) "Refreshing" else selectedDate.summaryMeta(currentPeriod),
+                                        style = MaterialTheme.typography.labelMedium,
+                                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    )
+                                }
                             }
+                        } else {
+                            Text(
+                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                                text = when {
+                                    displayRefreshLoading -> "Refreshing trends in background"
+                                    error != null && stats != null -> "Latest frequency refresh failed. Showing the last snapshot."
+                                    else -> selectedDate.summaryMeta(currentPeriod)
+                                },
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
                         }
 
                         TabRow(

--- a/features/stats/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/stats/presentation/web/StatsWebScreen.kt
+++ b/features/stats/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/stats/presentation/web/StatsWebScreen.kt
@@ -33,6 +33,7 @@ fun StatsWebScreen(
     store: StatsWebStore,
     currentPeriod: StatsPeriod,
     selectedDate: LocalDate,
+    embedded: Boolean = false,
     onPeriodChange: (StatsPeriod) -> Unit,
     onDateChange: (LocalDate) -> Unit,
 ) {
@@ -44,6 +45,7 @@ fun StatsWebScreen(
         state = state,
         currentPeriod = currentPeriod,
         selectedDate = selectedDate,
+        embedded = embedded,
         onPeriodChange = onPeriodChange,
         onDateChange = onDateChange,
         onReload = {
@@ -73,28 +75,42 @@ private fun StatsWebContent(
     state: StatsViewState,
     currentPeriod: StatsPeriod,
     selectedDate: LocalDate,
+    embedded: Boolean,
     onPeriodChange: (StatsPeriod) -> Unit,
     onDateChange: (LocalDate) -> Unit,
     onReload: () -> Unit,
 ) {
     Div(attrs = { classes(SmokeWebStyles.panelStack) }) {
-        PageSectionHeader(
-            title = "Patterns in motion",
-            eyebrow = "Trends",
-            badgeText = when {
-                state.displayRefreshLoading -> "Refreshing"
-                state.displayLoading -> "Loading"
-                state.error != null -> "Error"
-                else -> currentPeriod.label()
-            },
-            badgeTone = when {
-                state.displayLoading || state.displayRefreshLoading -> StatusTone.Busy
-                state.error != null -> StatusTone.Error
-                else -> StatusTone.Default
-            }
-        )
+        if (!embedded) {
+            PageSectionHeader(
+                title = "Patterns in motion",
+                eyebrow = "Trends",
+                badgeText = when {
+                    state.displayRefreshLoading -> "Refreshing"
+                    state.displayLoading -> "Loading"
+                    state.error != null -> "Error"
+                    else -> currentPeriod.label()
+                },
+                badgeTone = when {
+                    state.displayLoading || state.displayRefreshLoading -> StatusTone.Busy
+                    state.error != null -> StatusTone.Error
+                    else -> StatusTone.Default
+                }
+            )
+        }
 
         SurfaceCard {
+            if (embedded) {
+                Div(attrs = { classes(SmokeWebStyles.helperText) }) {
+                    Text(
+                        when {
+                            state.displayRefreshLoading -> "Refreshing frequency in background."
+                            state.error != null && state.stats != null -> "Latest frequency refresh failed. Showing the last snapshot."
+                            else -> selectedDate.summaryLabel(currentPeriod)
+                        }
+                    )
+                }
+            }
             Div(attrs = { classes(SmokeWebStyles.statsToolbar) }) {
                 Div(attrs = { classes(SmokeWebStyles.periodPills) }) {
                     StatsPeriod.entries.forEach { p ->


### PR DESCRIPTION
## Summary
- make Analytics & Map feel like one destination instead of two nested screens
- embed the stats and map subviews under the shared destination shell on mobile and web
- route legacy web hashes like  into the unified destination while opening the correct tab

## Testing
- ./gradlew :features:stats:presentation:mobile:compileDebugKotlin
- ./gradlew :features:stats:presentation:web:compileKotlinJs
- ./gradlew :apps:mobile:assembleStagingDebug
- ./gradlew :apps:web:jsBrowserDevelopmentWebpack

Refs #165