### PR TITLE
Tech debt: modernize the 0.12 stack baseline

### DIFF
--- a/apps/mobile/src/main/java/com/feragusper/smokeanalytics/MainShellDestinations.kt
+++ b/apps/mobile/src/main/java/com/feragusper/smokeanalytics/MainShellDestinations.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.compose.rememberNavController
 import com.feragusper.smokeanalytics.features.chatbot.presentation.ChatbotView
 import com.feragusper.smokeanalytics.features.chatbot.presentation.ChatbotViewModel

--- a/apps/mobile/src/main/java/com/feragusper/smokeanalytics/map/MapMobileScreen.kt
+++ b/apps/mobile/src/main/java/com/feragusper/smokeanalytics/map/MapMobileScreen.kt
@@ -38,7 +38,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner

--- a/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/apps/web/AboutWebScreen.kt
+++ b/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/apps/web/AboutWebScreen.kt
@@ -1,11 +1,11 @@
 package com.feragusper.smokeanalytics.apps.web
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import com.feragusper.smokeanalytics.libraries.design.PrimaryButton
 import com.feragusper.smokeanalytics.libraries.design.SmokeWebStyles
 import com.feragusper.smokeanalytics.libraries.design.SurfaceCard
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.promise
+import kotlinx.coroutines.launch
 import kotlinx.browser.window
 import org.jetbrains.compose.web.dom.A
 import org.jetbrains.compose.web.dom.Div
@@ -24,6 +24,7 @@ fun AboutWebScreen(
 fun AboutWebSections(
     onShare: (suspend () -> Unit)? = null,
 ) {
+    val scope = rememberCoroutineScope()
     Div(attrs = { classes(SmokeWebStyles.panelStack) }) {
         SurfaceCard {
             Div(attrs = { attr("style", "display:flex;flex-direction:column;gap:14px;") }) {
@@ -38,7 +39,7 @@ fun AboutWebSections(
                     Div(attrs = { classes(SmokeWebStyles.sectionActions) }) {
                         PrimaryButton(
                             text = "Share app",
-                            onClick = { GlobalScope.promise { share() } },
+                            onClick = { scope.launch { share() } },
                         )
                     }
                 }

--- a/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/apps/web/CoachWebScreen.kt
+++ b/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/apps/web/CoachWebScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import com.feragusper.smokeanalytics.features.chatbot.domain.ChatbotUseCase
 import com.feragusper.smokeanalytics.features.chatbot.domain.CoachReplySource
@@ -16,8 +17,7 @@ import com.feragusper.smokeanalytics.libraries.design.PrimaryButton
 import com.feragusper.smokeanalytics.libraries.design.SmokeWebStyles
 import com.feragusper.smokeanalytics.libraries.design.StatusTone
 import com.feragusper.smokeanalytics.libraries.design.SurfaceCard
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.promise
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.web.dom.Button
 import org.jetbrains.compose.web.dom.Div
 import org.jetbrains.compose.web.dom.Text
@@ -26,6 +26,7 @@ import org.jetbrains.compose.web.dom.Text
 fun CoachWebScreen(
     chatbotUseCase: ChatbotUseCase,
 ) {
+    val scope = rememberCoroutineScope()
     var messages by remember { mutableStateOf(emptyList<CoachMessage>()) }
     var loading by remember { mutableStateOf(false) }
     var error by remember { mutableStateOf<String?>(null) }
@@ -95,7 +96,7 @@ fun CoachWebScreen(
             actions = {
                 GhostButton(
                     text = "Refresh",
-                    onClick = { GlobalScope.promise { loadInitialInsight() } },
+                    onClick = { scope.launch { loadInitialInsight() } },
                     enabled = !loading,
                 )
             },
@@ -135,7 +136,7 @@ fun CoachWebScreen(
                 title = "No guide insight yet",
                 message = "Refresh the coach to rebuild a new insight from your recent smoking pattern and current session context.",
                 actionLabel = "Refresh",
-                onAction = { GlobalScope.promise { loadInitialInsight() } },
+                onAction = { scope.launch { loadInitialInsight() } },
             )
 
             else -> {
@@ -143,10 +144,10 @@ fun CoachWebScreen(
                     message = primaryInsight,
                     hasFallback = hasFallback,
                     onPrimaryAction = {
-                        GlobalScope.promise { sendPrompt(primaryCoachActions.first()) }
+                        scope.launch { sendPrompt(primaryCoachActions.first()) }
                     },
                     onSecondaryAction = {
-                        GlobalScope.promise { sendPrompt(primaryCoachActions.last()) }
+                        scope.launch { sendPrompt(primaryCoachActions.last()) }
                     },
                 )
 
@@ -173,7 +174,7 @@ fun CoachWebScreen(
                         ActionGroupCard(
                             group = group,
                             loading = loading,
-                            onPromptClick = { prompt -> GlobalScope.promise { sendPrompt(prompt) } },
+                            onPromptClick = { prompt -> scope.launch { sendPrompt(prompt) } },
                         )
                     }
                 }
@@ -215,7 +216,7 @@ fun CoachWebScreen(
                 title = "Guide temporarily unavailable",
                 message = message,
                 actionLabel = "Refresh guide",
-                onAction = { GlobalScope.promise { loadInitialInsight() } },
+                onAction = { scope.launch { loadInitialInsight() } },
             )
         }
     }

--- a/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/apps/web/RevampWebScreens.kt
+++ b/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/apps/web/RevampWebScreens.kt
@@ -1,14 +1,14 @@
 package com.feragusper.smokeanalytics.apps.web
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import com.feragusper.smokeanalytics.features.settings.presentation.web.SettingsWebDependencies
 import com.feragusper.smokeanalytics.features.settings.presentation.web.SettingsWebScreen
 import com.feragusper.smokeanalytics.libraries.design.GhostButton
 import com.feragusper.smokeanalytics.libraries.design.PageSectionHeader
 import com.feragusper.smokeanalytics.libraries.design.PrimaryButton
 import com.feragusper.smokeanalytics.libraries.design.SmokeWebStyles
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.promise
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.web.dom.Div
 
 @Composable
@@ -51,6 +51,7 @@ fun SettingsAboutWebScreen(
     settingsDeps: SettingsWebDependencies,
     onShare: suspend () -> Unit,
 ) {
+    val scope = rememberCoroutineScope()
     Div(attrs = { classes(SmokeWebStyles.panelStack) }) {
         PageSectionHeader(
             title = "You",
@@ -59,7 +60,7 @@ fun SettingsAboutWebScreen(
             actions = {
                 PrimaryButton(
                     text = "Share",
-                    onClick = { GlobalScope.promise { onShare() } },
+                    onClick = { scope.launch { onShare() } },
                 )
             },
         )

--- a/docs/technical-baseline-0.12.0.md
+++ b/docs/technical-baseline-0.12.0.md
@@ -1,0 +1,42 @@
+# Technical Baseline `0.12.0`
+
+## Scope
+- close the remaining modernization pass in `#196` without widening product scope
+- keep `mobile`, `web`, and shared modules building cleanly on the same baseline
+- remove stale build flags and obvious deprecation paths that were already surfacing in local and CI builds
+
+## Reviewed Baseline
+- Kotlin: `2.2.20`
+- Compose Multiplatform plugin: `1.9.3`
+- Android Gradle Plugin: `8.13.2`
+- Firebase Android BoM: `34.7.0`
+- Hilt Android: `2.57.2`
+- AndroidX Navigation Compose: `2.9.6`
+- Material 3: `1.4.0`
+
+These versions were reviewed against the current repository state and retained as the stable release baseline for `0.12.0`. The repo was already close to current on the main catalog entries, so this pass focused on modernization work that reduced maintenance noise without destabilizing the release train.
+
+## Modernization Applied
+- removed the stale Gradle property `android.lint.useK2Uast=false`
+  - this flag was producing an experimental warning on every Android build and is no longer part of the intended baseline
+- migrated Compose Hilt view-model lookups from `androidx.hilt.navigation.compose.hiltViewModel` to `androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel`
+  - the version catalog now points at `androidx.hilt:hilt-lifecycle-viewmodel-compose`
+  - this removes the deprecation path already reported during mobile builds
+- replaced `GlobalScope.promise` usage in the active web surfaces with `rememberCoroutineScope().launch`
+  - covered `The Guide`, `You`, and the remaining share actions in the revamp shell
+  - this keeps async UI actions scoped to composition instead of using app-wide global coroutines
+
+## Validation
+- `./gradlew :apps:web:jsBrowserDevelopmentWebpack`
+- `./gradlew :apps:mobile:assembleStagingDebug`
+
+## Deferred On Purpose
+- no broad version-catalog bump was forced for `0.12.0`
+  - the main stack entries are already near-current and stable in this repo
+  - a larger catalog churn this late in the release train would increase regression risk more than product value
+- Compose Web still emits some non-blocking warnings outside the files modernized in this pass
+  - those are acceptable for `0.12.0`
+  - any broader cleanup should be handled as a follow-up only if it starts affecting CI signal or release velocity
+
+## Outcome
+`0.12.0` ships on a cleaner build baseline: fewer stale flags, no active mobile deprecation on `hiltViewModel`, and less fragile web async UI plumbing, while preserving product behavior.

--- a/features/authentication/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/authentication/presentation/navigation/AuthenticationNavigationGraph.kt
+++ b/features/authentication/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/authentication/presentation/navigation/AuthenticationNavigationGraph.kt
@@ -1,6 +1,6 @@
 package com.feragusper.smokeanalytics.features.authentication.presentation.navigation
 
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation

--- a/features/chatbot/presentation/src/main/java/com/feragusper/smokeanalytics/features/chatbot/presentation/navigation/ChatbotNavigationGraph.kt
+++ b/features/chatbot/presentation/src/main/java/com/feragusper/smokeanalytics/features/chatbot/presentation/navigation/ChatbotNavigationGraph.kt
@@ -1,6 +1,6 @@
 package com.feragusper.smokeanalytics.features.chatbot.presentation.navigation
 
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation

--- a/features/devtools/presentation/src/main/java/com/feragusper/smokeanalytics/features/devtools/presentation/navigation/DevToolsNavigationGraph.kt
+++ b/features/devtools/presentation/src/main/java/com/feragusper/smokeanalytics/features/devtools/presentation/navigation/DevToolsNavigationGraph.kt
@@ -1,6 +1,6 @@
 package com.feragusper.smokeanalytics.features.devtools.presentation.navigation
 
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation

--- a/features/history/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/history/presentation/navigation/HistoryNavigationGraph.kt
+++ b/features/history/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/history/presentation/navigation/HistoryNavigationGraph.kt
@@ -1,6 +1,6 @@
 package com.feragusper.smokeanalytics.features.history.presentation.navigation
 
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/navigation/HomeNavigationGraph.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/navigation/HomeNavigationGraph.kt
@@ -1,6 +1,6 @@
 package com.feragusper.smokeanalytics.features.home.presentation.navigation
 
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation

--- a/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/navigation/SettingsNavigationGraph.kt
+++ b/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/navigation/SettingsNavigationGraph.kt
@@ -1,6 +1,6 @@
 package com.feragusper.smokeanalytics.features.settings.presentation.navigation
 
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation

--- a/features/settings/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/settings/presentation/web/SettingsWebScreen.kt
+++ b/features/settings/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/settings/presentation/web/SettingsWebScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import com.feragusper.smokeanalytics.features.goals.domain.GoalProgress
 import com.feragusper.smokeanalytics.features.settings.presentation.web.mvi.SettingsIntent
@@ -18,8 +19,7 @@ import com.feragusper.smokeanalytics.libraries.design.PrimaryButton
 import com.feragusper.smokeanalytics.libraries.design.SmokeWebStyles
 import com.feragusper.smokeanalytics.libraries.design.SurfaceCard
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.promise
+import kotlinx.coroutines.launch
 import kotlin.math.abs
 import kotlin.math.roundToInt
 import org.jetbrains.compose.web.attributes.InputType
@@ -324,6 +324,7 @@ private fun AppInfoCard(
     accountTier: String,
     onShare: suspend () -> Unit,
 ) {
+    val scope = rememberCoroutineScope()
     SurfaceCard {
         Div(attrs = { attr("style", "display:flex;flex-direction:column;gap:16px;") }) {
             Div(attrs = {
@@ -349,7 +350,7 @@ private fun AppInfoCard(
                 Div(attrs = { classes(SmokeWebStyles.sectionActions) }) {
                     PrimaryButton(
                         text = "Share app",
-                        onClick = { GlobalScope.promise { onShare() } },
+                        onClick = { scope.launch { onShare() } },
                     )
                     A("https://github.com/feragusper/SmokeAnalytics/issues/new/choose", attrs = { attr("target", "_blank") }) {
                         Text("Report bug")

--- a/features/stats/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/stats/presentation/navigation/StatsNavigationGraph.kt
+++ b/features/stats/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/stats/presentation/navigation/StatsNavigationGraph.kt
@@ -1,6 +1,6 @@
 package com.feragusper.smokeanalytics.features.stats.presentation.navigation
 
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation

--- a/gradle.properties
+++ b/gradle.properties
@@ -43,4 +43,3 @@ android.lifecycleProcessor.incremental=true
 org.gradle.configureondemand=true
 
 org.jetbrains.compose.experimental.jscanvas.enabled=true
-android.lint.useK2Uast=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ googleid = "1.1.1"
 glance = "1.1.1"
 gradle = "8.13.2"
 hilt = "2.57.2"
-hiltNavigationCompose = "1.3.0"
+hiltLifecycleViewmodelCompose = "1.3.0"
 horologistComposables = "0.7.15"
 horologistComposeToolsVersion = "0.7.15"
 horologistTiles = "0.7.15"
@@ -97,7 +97,7 @@ gitlive-firebase-firestore = { module = "dev.gitlive:firebase-firestore", versio
 hilt = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-android-gradle-plugin = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+hilt-lifecycle-viewmodel-compose = { module = "androidx.hilt:hilt-lifecycle-viewmodel-compose", version.ref = "hiltLifecycleViewmodelCompose" }
 horologist-composables = { module = "com.google.android.horologist:horologist-composables", version.ref = "horologistComposables" }
 horologist-compose-tools = { module = "com.google.android.horologist:horologist-compose-tools", version.ref = "horologistComposeToolsVersion" }
 horologist-tiles = { module = "com.google.android.horologist:horologist-tiles", version.ref = "horologistTiles" }
@@ -145,7 +145,7 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 [bundles]
 android-test = ["androidx-espresso-core", "androidx-junit"]
 androidx-base = ["androidx-appcompat", "androidx-core-ktx"]
-androidx-navigation = ["androidx-navigation-compose", "androidx-navigation-fragment-ktx", "androidx-navigation-testing", "androidx-navigation-ui-ktx", "hilt-navigation-compose"]
+androidx-navigation = ["androidx-navigation-compose", "androidx-navigation-fragment-ktx", "androidx-navigation-testing", "androidx-navigation-ui-ktx", "hilt-lifecycle-viewmodel-compose"]
 compose = ["androidx-compose-ui", "androidx-compose-ui-tooling", "androidx-compose-activity", "androidx-compose-material3"]
 compose-debug = ["androidx-compose-ui-tooling", "androidx-compose-ui-test-manifest"]
 compose-test = ["mockkAndroid", "androidx-compose-ui-test-junit4"]


### PR DESCRIPTION
## Summary
- modernize the active 0.12 baseline without widening product scope
- migrate mobile Hilt view-model lookups to the new androidx lifecycle compose package and dependency
- remove the stale lint K2 UAST flag and replace web GlobalScope usage with composition-scoped coroutines
- document the reviewed technical baseline and deferred follow-ups

## Validation
- ./gradlew :apps:web:jsBrowserDevelopmentWebpack
- ./gradlew :apps:mobile:assembleStagingDebug

Closes #196