### PR TITLE
fix(release): disable debuggable production bundle

### DIFF
--- a/apps/mobile/build.gradle.kts
+++ b/apps/mobile/build.gradle.kts
@@ -66,7 +66,6 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            isDebuggable = true
             // Use the release signing configuration.
             signingConfig = signingConfigs.getByName("release")
         }


### PR DESCRIPTION
## Summary
- remove the accidental debuggable flag from the Android release build type
- restore Play Store eligibility for the production release bundle
- keep the release fix isolated to the mobile app build config

## Verification
- ./gradlew :apps:mobile:bundleProductionRelease
