### PR TITLE
fix(release): upload only the Android app bundle

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,7 +9,8 @@ platform :android do
       timeout: 600,                                      # Timeout for the upload process (in seconds).
       json_key: "playstore.credentials.json",            # Path to the service account JSON key.
       package_name: "com.feragusper.smokeanalytics",     # The package name of the application.
-      aab: "apps/mobile/build/outputs/bundle/productionRelease/mobile-production-release.aab" # Path to the AAB file.
+      aab: "apps/mobile/build/outputs/bundle/productionRelease/mobile-production-release.aab", # Path to the AAB file.
+      skip_upload_apk: true
     }
 
     # Upload the Android App Bundle (AAB) to Google Play.


### PR DESCRIPTION
## Summary
- force the Play Store lane to upload only the production AAB
- avoid any implicit APK upload path during release
- unblock the Android beta release after the web release already shipped

## Verification
- generated a universal APK from the production AAB with bundletool
- verified the generated APK does not report application-debuggable
