### PR TITLE
Release hotfix for goals and history regressions

### DIFF
--- a/features/history/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/history/presentation/process/HistoryProcessHolder.kt
+++ b/features/history/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/history/presentation/process/HistoryProcessHolder.kt
@@ -24,13 +24,17 @@ import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.FetchSmokes
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.SyncWithWearUseCase
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.datetime.Clock
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.plus
 import kotlinx.datetime.toDeprecatedInstant
+import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
 import javax.inject.Inject
 
@@ -220,6 +224,7 @@ class HistoryProcessHolder @Inject constructor(
             is Session.LoggedIn -> {
                 emit(HistoryResult.Loading)
                 val preferences = runCatching { fetchUserPreferencesUseCase() }.getOrDefault(UserPreferences())
+                val timeZone = TimeZone.currentSystemDefault()
                 val location = if (preferences.locationTrackingEnabled) {
                     locationCaptureService.captureCurrentLocation()?.let {
                         GeoPoint(latitude = it.latitude, longitude = it.longitude)
@@ -227,7 +232,7 @@ class HistoryProcessHolder @Inject constructor(
                 } else {
                     null
                 }
-                addSmokeUseCase.invoke(intent.date, location)
+                addSmokeUseCase.invoke(intent.date.toVisibleAddTimestamp(timeZone), location)
                 refreshWidgetSnapshot()
                 emit(HistoryResult.AddSmokeSuccess)
                 syncWithWearUseCase.invoke()
@@ -245,4 +250,22 @@ class HistoryProcessHolder @Inject constructor(
         )
         widgetRefreshService.refreshHomeSnapshot(smokeCounts.toWidgetSnapshot(preferences))
     }
+}
+
+private fun Instant.toVisibleAddTimestamp(timeZone: TimeZone): Instant {
+    val selectedDate = toLocalDateTime(timeZone).date
+    val now = Clock.System.now()
+    val nowLocal = now.toLocalDateTime(timeZone)
+
+    if (selectedDate == nowLocal.date) return now
+
+    return LocalDateTime(
+        year = selectedDate.year,
+        monthNumber = selectedDate.monthNumber,
+        dayOfMonth = selectedDate.dayOfMonth,
+        hour = nowLocal.hour,
+        minute = nowLocal.minute,
+        second = nowLocal.second,
+        nanosecond = 0,
+    ).toInstant(timeZone).toDeprecatedInstant()
 }

--- a/features/history/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/history/presentation/process/HistoryProcessHolderTest.kt
+++ b/features/history/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/history/presentation/process/HistoryProcessHolderTest.kt
@@ -29,7 +29,11 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.datetime.Clock
+import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.minus
+import kotlinx.datetime.toLocalDateTime
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.AfterEach
@@ -98,7 +102,7 @@ class HistoryProcessHolderTest {
         @Test
         fun `WHEN adding smoke THEN returns Loading, Success and syncs with Wear`() = runTest {
             val date: Instant = Clock.System.now()
-            coEvery { addSmokeUseCase(date) } just Runs
+            coEvery { addSmokeUseCase(any()) } just Runs
 
             results = processHolder.processIntent(HistoryIntent.AddSmoke(date))
 
@@ -106,6 +110,25 @@ class HistoryProcessHolderTest {
                 awaitItem() shouldBe HistoryResult.Loading
                 awaitItem() shouldBe HistoryResult.AddSmokeSuccess
                 coVerify(exactly = 1) { syncWithWearUseCase.invoke() }
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
+        fun `WHEN adding smoke for historical date THEN keeps selected calendar day`() = runTest {
+            val timeZone = TimeZone.currentSystemDefault()
+            val selectedDate = Clock.System.now().minus(2, DateTimeUnit.DAY, timeZone)
+            var addedAt: Instant? = null
+            coEvery { addSmokeUseCase(any()) } answers {
+                addedAt = firstArg()
+            }
+
+            results = processHolder.processIntent(HistoryIntent.AddSmoke(selectedDate))
+
+            results.test {
+                awaitItem() shouldBe HistoryResult.Loading
+                awaitItem() shouldBe HistoryResult.AddSmokeSuccess
+                addedAt?.toLocalDateTime(timeZone)?.date shouldBeEqualTo selectedDate.toLocalDateTime(timeZone).date
                 cancelAndIgnoreRemainingEvents()
             }
         }

--- a/features/history/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/history/presentation/process/HistoryProcessHolder.kt
+++ b/features/history/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/history/presentation/process/HistoryProcessHolder.kt
@@ -19,13 +19,17 @@ import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.FetchSmokes
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
+import kotlinx.datetime.Clock
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.plus
 import kotlinx.datetime.toDeprecatedInstant
+import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
 
 class HistoryProcessHolder(
@@ -147,6 +151,7 @@ class HistoryProcessHolder(
             is Session.LoggedIn -> {
                 emit(HistoryResult.Loading)
                 val preferences = runCatching { fetchUserPreferencesUseCase() }.getOrDefault(UserPreferences())
+                val tz = TimeZone.currentSystemDefault()
                 val location = if (preferences.locationTrackingEnabled) {
                     locationCaptureService.captureCurrentLocation()?.let {
                         GeoPoint(latitude = it.latitude, longitude = it.longitude)
@@ -154,7 +159,7 @@ class HistoryProcessHolder(
                 } else {
                     null
                 }
-                addSmokeUseCase(intent.date, location)
+                addSmokeUseCase(intent.date.toVisibleAddTimestamp(tz), location)
                 emit(HistoryResult.AddSmokeSuccess)
             }
         }
@@ -171,4 +176,22 @@ class HistoryProcessHolder(
         deleteSmokeUseCase(intent.id)
         emit(HistoryResult.DeleteSmokeSuccess)
     }.catch { emit(HistoryResult.Error.Generic) }
+}
+
+private fun Instant.toVisibleAddTimestamp(timeZone: TimeZone): Instant {
+    val selectedDate = toLocalDateTime(timeZone).date
+    val now = Clock.System.now()
+    val nowLocal = now.toLocalDateTime(timeZone)
+
+    if (selectedDate == nowLocal.date) return now
+
+    return LocalDateTime(
+        year = selectedDate.year,
+        monthNumber = selectedDate.monthNumber,
+        dayOfMonth = selectedDate.dayOfMonth,
+        hour = nowLocal.hour,
+        minute = nowLocal.minute,
+        second = nowLocal.second,
+        nanosecond = 0,
+    ).toInstant(timeZone).toDeprecatedInstant()
 }

--- a/features/home/presentation/mobile/src/androidTest/java/com/feragusper/smokeanalytics/features/home/presentation/HomeViewTest.kt
+++ b/features/home/presentation/mobile/src/androidTest/java/com/feragusper/smokeanalytics/features/home/presentation/HomeViewTest.kt
@@ -3,6 +3,7 @@ package com.feragusper.smokeanalytics.features.home.presentation
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import com.feragusper.smokeanalytics.features.goals.domain.GoalProgress
 import com.feragusper.smokeanalytics.features.goals.domain.GoalStatus
@@ -59,6 +60,7 @@ class HomeViewTest {
         composeTestRule.onNodeWithText("Last cigarette").assertIsDisplayed()
         composeTestRule.onNodeWithText("Time since").assertIsDisplayed()
         composeTestRule.onNodeWithText("2h 35m").assertIsDisplayed()
+        composeTestRule.onNodeWithTag(HomeViewState.TestTags.BUTTON_ADD_SMOKE).assertIsDisplayed()
     }
 
     private fun prepareScreen(

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
@@ -247,6 +247,12 @@ private fun HomeContent(
             )
         }
         item {
+            TrackActionSection(
+                isLoading = isLoading,
+                onAddSmoke = { intent(HomeIntent.AddSmoke) },
+            )
+        }
+        item {
             LastCigaretteSection(
                 lastSmokeTimeLabel = lastSmokeTimeLabel,
                 timeSinceLastCigarette = timeSinceLastCigarette,
@@ -271,6 +277,34 @@ private fun HomeContent(
             }
         }
         item { Spacer(modifier = Modifier.height(24.dp)) }
+    }
+}
+
+@Composable
+private fun TrackActionSection(
+    isLoading: Boolean,
+    onAddSmoke: () -> Unit,
+) {
+    Button(
+        onClick = onAddSmoke,
+        enabled = !isLoading,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .testTag(HomeViewState.TestTags.BUTTON_ADD_SMOKE),
+        shape = RoundedCornerShape(20.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onPrimary,
+            disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+            disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        ),
+    ) {
+        Text(
+            text = "Track cigarette",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+        )
     }
 }
 

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
@@ -20,7 +20,6 @@ import com.feragusper.smokeanalytics.libraries.authentication.domain.FetchSessio
 import com.feragusper.smokeanalytics.libraries.authentication.domain.Session
 import com.feragusper.smokeanalytics.libraries.preferences.domain.FetchUserPreferencesUseCase
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UpdateUserPreferencesUseCase
-import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.AddSmokeUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.DeleteSmokeUseCase
@@ -89,7 +88,7 @@ class HomeProcessHolder @Inject constructor(
             is Session.Anonymous -> emit(HomeResult.NotLoggedIn)
             is Session.LoggedIn -> {
                 emit(if (isRefresh) HomeResult.RefreshLoading else HomeResult.Loading)
-                val preferences = runCatching { fetchUserPreferencesUseCase() }.getOrDefault(UserPreferences())
+                val preferences = fetchUserPreferencesUseCase()
                 val smokeCounts = fetchSmokeCountListUseCase.invoke(
                     dayStartHour = preferences.dayStartHour,
                     manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
@@ -201,7 +200,7 @@ class HomeProcessHolder @Inject constructor(
 
             is Session.LoggedIn -> {
                 emit(HomeResult.Loading)
-                val preferences = runCatching { fetchUserPreferencesUseCase() }.getOrDefault(UserPreferences())
+                val preferences = fetchUserPreferencesUseCase()
                 val location = if (preferences.locationTrackingEnabled) {
                     locationCaptureService.captureCurrentLocation()?.let {
                         GeoPoint(latitude = it.latitude, longitude = it.longitude)
@@ -221,7 +220,7 @@ class HomeProcessHolder @Inject constructor(
 
     private fun processStartNewDay(): Flow<HomeResult> = flow {
         emit(HomeResult.Loading)
-        val preferences = runCatching { fetchUserPreferencesUseCase() }.getOrDefault(UserPreferences())
+        val preferences = fetchUserPreferencesUseCase()
         updateUserPreferencesUseCase(
             preferences.copy(manualDayStartEpochMillis = kotlinx.datetime.Clock.System.now().toEpochMilliseconds())
         )
@@ -231,7 +230,7 @@ class HomeProcessHolder @Inject constructor(
     }
 
     private suspend fun refreshWidgetSnapshot() {
-        val preferences = runCatching { fetchUserPreferencesUseCase() }.getOrDefault(UserPreferences())
+        val preferences = fetchUserPreferencesUseCase()
         val smokeCounts = fetchSmokeCountListUseCase(
             dayStartHour = preferences.dayStartHour,
             manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeWebScreen.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeWebScreen.kt
@@ -341,7 +341,6 @@ private fun DetachedTrackAction(
             PrimaryButton(
                 text = "Track",
                 onClick = onAddSmoke,
-                extraClass = elapsedTone.buttonClass(),
             )
         }
     }
@@ -493,11 +492,4 @@ private fun ElapsedTone.pillForeground(): String = when (this) {
     ElapsedTone.Warning -> "var(--sa-color-on-tertiary-container)"
     ElapsedTone.Caution -> "var(--sa-color-on-secondary-container)"
     ElapsedTone.Calm -> "var(--sa-color-on-primary-container)"
-}
-
-private fun ElapsedTone.buttonClass(): String = when (this) {
-    ElapsedTone.Urgent -> SmokeWebStyles.elapsedCardUrgent
-    ElapsedTone.Warning -> SmokeWebStyles.elapsedCardWarning
-    ElapsedTone.Caution -> SmokeWebStyles.elapsedCardCaution
-    ElapsedTone.Calm -> SmokeWebStyles.elapsedCardCalm
 }

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/process/HomeProcessHolder.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/process/HomeProcessHolder.kt
@@ -16,7 +16,6 @@ import com.feragusper.smokeanalytics.libraries.authentication.domain.FetchSessio
 import com.feragusper.smokeanalytics.libraries.authentication.domain.Session
 import com.feragusper.smokeanalytics.libraries.preferences.domain.FetchUserPreferencesUseCase
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UpdateUserPreferencesUseCase
-import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
 import com.feragusper.smokeanalytics.libraries.logging.AppLogger
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.AddSmokeUseCase
@@ -92,7 +91,7 @@ class HomeProcessHolder(
 
                 is Session.LoggedIn -> {
                     emit(if (isRefresh) HomeResult.RefreshLoading else HomeResult.Loading)
-                    val preferences = runCatching { fetchUserPreferencesUseCase() }.getOrDefault(UserPreferences())
+                    val preferences = fetchUserPreferencesUseCase()
                     val smokeCounts = fetchSmokeCountListUseCase(
                         dayStartHour = preferences.dayStartHour,
                         manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
@@ -155,7 +154,7 @@ class HomeProcessHolder(
             is Session.LoggedIn -> {
                 AppLogger.i { "User logged in, adding smoke..." }
                 emit(HomeResult.Loading)
-                val preferences = runCatching { fetchUserPreferencesUseCase() }.getOrDefault(UserPreferences())
+                val preferences = fetchUserPreferencesUseCase()
                 val location = if (preferences.locationTrackingEnabled) {
                     locationCaptureService.captureCurrentLocation()?.let {
                         GeoPoint(latitude = it.latitude, longitude = it.longitude)
@@ -175,7 +174,7 @@ class HomeProcessHolder(
 
     private fun processStartNewDay(): Flow<HomeResult> = flow {
         emit(HomeResult.Loading)
-        val preferences = runCatching { fetchUserPreferencesUseCase() }.getOrDefault(UserPreferences())
+        val preferences = fetchUserPreferencesUseCase()
         updateUserPreferencesUseCase(
             preferences.copy(manualDayStartEpochMillis = kotlinx.datetime.Clock.System.now().toEpochMilliseconds())
         )

--- a/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/process/SettingsProcessHolder.kt
+++ b/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/process/SettingsProcessHolder.kt
@@ -12,6 +12,7 @@ import com.feragusper.smokeanalytics.libraries.preferences.domain.FetchUserPrefe
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UpdateUserPreferencesUseCase
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.FetchSmokesUseCase
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
@@ -59,7 +60,7 @@ class SettingsProcessHolder @Inject constructor(
         when (val session = fetchSessionUseCase()) {
             is Session.Anonymous -> emit(SettingsResult.UserLoggedOut)
             is Session.LoggedIn -> {
-                val preferences = runCatching { fetchUserPreferencesUseCase() }.getOrDefault(UserPreferences())
+                val preferences = fetchUserPreferencesUseCase()
                 val smokes = runCatching { fetchSmokesUseCase(start = goalDataFetchStart(preferences)) }.getOrDefault(emptyList())
                 emit(
                     SettingsResult.UserLoggedIn(
@@ -71,6 +72,8 @@ class SettingsProcessHolder @Inject constructor(
                 )
             }
         }
+    }.catch {
+        emit(SettingsResult.Error("Could not load your settings. Try again."))
     }
 
     /**
@@ -84,23 +87,28 @@ class SettingsProcessHolder @Inject constructor(
         emit(SettingsResult.Loading)
         signOutUseCase()
         emit(SettingsResult.UserLoggedOut)
+    }.catch {
+        emit(SettingsResult.Error("Could not sign out. Try again."))
     }
 
     private fun processUpdatePreferences(preferences: UserPreferences): Flow<SettingsResult> = flow {
         emit(SettingsResult.Loading)
         updateUserPreferencesUseCase(preferences)
-        val smokes = runCatching { fetchSmokesUseCase(start = goalDataFetchStart(preferences)) }.getOrDefault(emptyList())
+        val savedPreferences = fetchUserPreferencesUseCase()
+        val smokes = runCatching { fetchSmokesUseCase(start = goalDataFetchStart(savedPreferences)) }.getOrDefault(emptyList())
         when (val session = fetchSessionUseCase()) {
             is Session.Anonymous -> emit(SettingsResult.UserLoggedOut)
             is Session.LoggedIn -> emit(
                 SettingsResult.UserLoggedIn(
                     email = session.user.email,
                     displayName = session.user.displayName,
-                    preferences = preferences,
-                    goalProgress = evaluateGoalProgressUseCase(preferences.activeGoal, smokes, preferences),
+                    preferences = savedPreferences,
+                    goalProgress = evaluateGoalProgressUseCase(savedPreferences.activeGoal, smokes, savedPreferences),
                 )
             )
         }
         emit(SettingsResult.PreferencesSaved)
+    }.catch {
+        emit(SettingsResult.Error("Could not save your settings. Try again."))
     }
 }

--- a/features/settings/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/settings/presentation/process/SettingsProcessHolderTest.kt
+++ b/features/settings/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/settings/presentation/process/SettingsProcessHolderTest.kt
@@ -7,6 +7,7 @@ import com.feragusper.smokeanalytics.libraries.authentication.domain.FetchSessio
 import com.feragusper.smokeanalytics.libraries.authentication.domain.Session
 import com.feragusper.smokeanalytics.libraries.authentication.domain.SignOutUseCase
 import com.feragusper.smokeanalytics.libraries.preferences.domain.FetchUserPreferencesUseCase
+import com.feragusper.smokeanalytics.libraries.preferences.domain.SmokingGoal
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UpdateUserPreferencesUseCase
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.FetchSmokesUseCase
@@ -20,6 +21,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBe
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -106,5 +108,30 @@ class SettingsProcessHolderTest {
 
             // Verify that signOutUseCase() was actually called
             coVerify(exactly = 1) { signOutUseCase() }
+        }
+
+    @Test
+    fun `WHEN UpdatePreferences saves goal THEN emits persisted active goal`() =
+        runTest {
+            val email = "fernancho@gmail.com"
+            val displayName = "Fer"
+            val preferences = UserPreferences(activeGoal = SmokingGoal.DailyCap(15))
+            coEvery { updateUserPreferencesUseCase(preferences) } just Runs
+            coEvery { fetchUserPreferencesUseCase() } returns preferences
+            coEvery { fetchSessionUseCase() } returns Session.LoggedIn(
+                Session.User(id = "123", email = email, displayName = displayName)
+            )
+            coEvery { fetchSmokesUseCase(any(), any()) } returns emptyList()
+
+            processHolder.processIntent(SettingsIntent.UpdatePreferences(preferences)).test {
+                awaitItem() shouldBeEqualTo SettingsResult.Loading
+                val loggedIn = awaitItem() as SettingsResult.UserLoggedIn
+                loggedIn.email shouldBeEqualTo email
+                loggedIn.displayName shouldBeEqualTo displayName
+                loggedIn.preferences shouldBeEqualTo preferences
+                loggedIn.goalProgress shouldNotBe null
+                awaitItem() shouldBeEqualTo SettingsResult.PreferencesSaved
+                awaitComplete()
+            }
         }
 }

--- a/features/settings/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/settings/presentation/web/process/SettingsProcessHolder.kt
+++ b/features/settings/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/settings/presentation/web/process/SettingsProcessHolder.kt
@@ -9,7 +9,6 @@ import com.feragusper.smokeanalytics.libraries.authentication.domain.Session
 import com.feragusper.smokeanalytics.libraries.authentication.domain.SignOutUseCase
 import com.feragusper.smokeanalytics.libraries.preferences.domain.FetchUserPreferencesUseCase
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UpdateUserPreferencesUseCase
-import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.FetchSmokesUseCase
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -47,7 +46,7 @@ class SettingsProcessHolder(
         when (val session = fetchSessionUseCase()) {
             is Session.Anonymous -> emit(SettingsResult.UserLoggedOut)
             is Session.LoggedIn -> {
-                val preferences = runCatching { fetchUserPreferencesUseCase() }.getOrDefault(UserPreferences())
+                val preferences = fetchUserPreferencesUseCase()
                 val smokes = runCatching { fetchSmokesUseCase(start = goalDataFetchStart(preferences)) }.getOrDefault(emptyList())
                 emit(
                     SettingsResult.UserLoggedIn(
@@ -75,15 +74,16 @@ class SettingsProcessHolder(
         emit(SettingsResult.Loading)
         val preferences = intent.preferences
         updateUserPreferencesUseCase(preferences)
-        val smokes = runCatching { fetchSmokesUseCase(start = goalDataFetchStart(preferences)) }.getOrDefault(emptyList())
+        val savedPreferences = fetchUserPreferencesUseCase()
+        val smokes = runCatching { fetchSmokesUseCase(start = goalDataFetchStart(savedPreferences)) }.getOrDefault(emptyList())
         when (val session = fetchSessionUseCase()) {
             is Session.Anonymous -> emit(SettingsResult.UserLoggedOut)
             is Session.LoggedIn -> emit(
                 SettingsResult.UserLoggedIn(
                     email = session.user.email,
                     displayName = session.user.displayName,
-                    preferences = preferences,
-                    goalProgress = evaluateGoalProgressUseCase(preferences.activeGoal, smokes, preferences),
+                    preferences = savedPreferences,
+                    goalProgress = evaluateGoalProgressUseCase(savedPreferences.activeGoal, smokes, savedPreferences),
                 )
             )
         }

--- a/libraries/preferences/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesEntity.kt
+++ b/libraries/preferences/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesEntity.kt
@@ -1,7 +1,6 @@
 package com.feragusper.smokeanalytics.libraries.preferences.data
 
 import com.feragusper.smokeanalytics.libraries.preferences.domain.AccountTier
-import com.feragusper.smokeanalytics.libraries.preferences.domain.GoalType
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
 import com.feragusper.smokeanalytics.libraries.preferences.domain.smokingGoalOrNull
 
@@ -27,12 +26,22 @@ data class UserPreferencesEntity(
         currencySymbol = currencySymbol,
         accountTier = AccountTier.entries.firstOrNull { it.name == accountTier } ?: AccountTier.Free,
         activeGoal = smokingGoalOrNull(
-            type = GoalType.entries.firstOrNull { it.name == activeGoalType },
+            type = activeGoalType,
             metricValue = activeGoalMetricValue,
         ),
     )
 
     companion object {
         const val DOCUMENT = "preferences"
+        const val PACK_PRICE = "packPrice"
+        const val CIGARETTES_PER_PACK = "cigarettesPerPack"
+        const val DAY_START_HOUR = "dayStartHour"
+        const val BEDTIME_HOUR = "bedtimeHour"
+        const val MANUAL_DAY_START_EPOCH_MILLIS = "manualDayStartEpochMillis"
+        const val LOCATION_TRACKING_ENABLED = "locationTrackingEnabled"
+        const val CURRENCY_SYMBOL = "currencySymbol"
+        const val ACCOUNT_TIER = "accountTier"
+        const val ACTIVE_GOAL_TYPE = "activeGoalType"
+        const val ACTIVE_GOAL_METRIC_VALUE = "activeGoalMetricValue"
     }
 }

--- a/libraries/preferences/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImpl.kt
+++ b/libraries/preferences/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.feragusper.smokeanalytics.libraries.preferences.data
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferencesRepository
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
@@ -16,7 +17,7 @@ class UserPreferencesRepositoryImpl @Inject constructor(
 
     override suspend fun fetch(): UserPreferences {
         val snapshot = document().get().await()
-        return snapshot.toObject(UserPreferencesEntity::class.java)?.toDomain() ?: UserPreferences()
+        return snapshot.toUserPreferencesEntity()?.toDomain() ?: UserPreferences()
     }
 
     override suspend fun update(preferences: UserPreferences) {
@@ -41,3 +42,31 @@ class UserPreferencesRepositoryImpl @Inject constructor(
         .collection("profile")
         .document(UserPreferencesEntity.DOCUMENT)
 }
+
+private fun DocumentSnapshot.toUserPreferencesEntity(): UserPreferencesEntity? {
+    if (!exists()) return null
+
+    return UserPreferencesEntity(
+        packPrice = numberOrNull(UserPreferencesEntity.PACK_PRICE)?.toDouble() ?: 0.0,
+        cigarettesPerPack = numberOrNull(UserPreferencesEntity.CIGARETTES_PER_PACK)?.toLong() ?: 20,
+        dayStartHour = numberOrNull(UserPreferencesEntity.DAY_START_HOUR)?.toLong() ?: 6,
+        bedtimeHour = numberOrNull(UserPreferencesEntity.BEDTIME_HOUR)?.toLong() ?: 22,
+        manualDayStartEpochMillis = numberOrNull(UserPreferencesEntity.MANUAL_DAY_START_EPOCH_MILLIS)?.toLong(),
+        locationTrackingEnabled = booleanOrNull(UserPreferencesEntity.LOCATION_TRACKING_ENABLED) ?: false,
+        currencySymbol = stringOrNull(UserPreferencesEntity.CURRENCY_SYMBOL) ?: "€",
+        accountTier = stringOrNull(UserPreferencesEntity.ACCOUNT_TIER) ?: "Free",
+        activeGoalType = stringOrNull(UserPreferencesEntity.ACTIVE_GOAL_TYPE),
+        activeGoalMetricValue = numberOrNull(UserPreferencesEntity.ACTIVE_GOAL_METRIC_VALUE)?.toDouble(),
+    )
+}
+
+private fun DocumentSnapshot.numberOrNull(field: String): Number? =
+    runCatching { getDouble(field) }.getOrNull()
+        ?: runCatching { getLong(field) }.getOrNull()
+        ?: stringOrNull(field)?.toDoubleOrNull()
+
+private fun DocumentSnapshot.stringOrNull(field: String): String? =
+    runCatching { getString(field) }.getOrNull()
+
+private fun DocumentSnapshot.booleanOrNull(field: String): Boolean? =
+    runCatching { getBoolean(field) }.getOrNull()

--- a/libraries/preferences/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesEntity.kt
+++ b/libraries/preferences/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesEntity.kt
@@ -1,7 +1,6 @@
 package com.feragusper.smokeanalytics.libraries.preferences.data
 
 import com.feragusper.smokeanalytics.libraries.preferences.domain.AccountTier
-import com.feragusper.smokeanalytics.libraries.preferences.domain.GoalType
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
 import com.feragusper.smokeanalytics.libraries.preferences.domain.smokingGoalOrNull
 import kotlinx.serialization.Serializable
@@ -29,12 +28,22 @@ data class UserPreferencesEntity(
         currencySymbol = currencySymbol,
         accountTier = AccountTier.entries.firstOrNull { it.name == accountTier } ?: AccountTier.Free,
         activeGoal = smokingGoalOrNull(
-            type = GoalType.entries.firstOrNull { it.name == activeGoalType },
+            type = activeGoalType,
             metricValue = activeGoalMetricValue,
         ),
     )
 
     companion object {
         const val DOCUMENT = "preferences"
+        const val PACK_PRICE = "packPrice"
+        const val CIGARETTES_PER_PACK = "cigarettesPerPack"
+        const val DAY_START_HOUR = "dayStartHour"
+        const val BEDTIME_HOUR = "bedtimeHour"
+        const val MANUAL_DAY_START_EPOCH_MILLIS = "manualDayStartEpochMillis"
+        const val LOCATION_TRACKING_ENABLED = "locationTrackingEnabled"
+        const val CURRENCY_SYMBOL = "currencySymbol"
+        const val ACCOUNT_TIER = "accountTier"
+        const val ACTIVE_GOAL_TYPE = "activeGoalType"
+        const val ACTIVE_GOAL_METRIC_VALUE = "activeGoalMetricValue"
     }
 }

--- a/libraries/preferences/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImpl.kt
+++ b/libraries/preferences/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreference
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.auth.FirebaseAuth
 import dev.gitlive.firebase.auth.auth
+import dev.gitlive.firebase.firestore.DocumentSnapshot
 import dev.gitlive.firebase.firestore.FirebaseFirestore
 import dev.gitlive.firebase.firestore.firestore
 
@@ -15,7 +16,7 @@ class UserPreferencesRepositoryImpl(
 
     override suspend fun fetch(): UserPreferences {
         val snapshot = document().get()
-        return snapshot.data<UserPreferencesEntity>()?.toDomain() ?: UserPreferences()
+        return snapshot.toUserPreferencesEntity()?.toDomain() ?: UserPreferences()
     }
 
     override suspend fun update(preferences: UserPreferences) {
@@ -40,3 +41,33 @@ class UserPreferencesRepositoryImpl(
         .collection("profile")
         .document(UserPreferencesEntity.DOCUMENT)
 }
+
+private fun DocumentSnapshot.toUserPreferencesEntity(): UserPreferencesEntity? {
+    if (!exists) return null
+
+    return UserPreferencesEntity(
+        packPrice = numberOrNull(UserPreferencesEntity.PACK_PRICE)?.toDouble() ?: 0.0,
+        cigarettesPerPack = numberOrNull(UserPreferencesEntity.CIGARETTES_PER_PACK)?.toInt() ?: 20,
+        dayStartHour = numberOrNull(UserPreferencesEntity.DAY_START_HOUR)?.toInt() ?: 6,
+        bedtimeHour = numberOrNull(UserPreferencesEntity.BEDTIME_HOUR)?.toInt() ?: 22,
+        manualDayStartEpochMillis = numberOrNull(UserPreferencesEntity.MANUAL_DAY_START_EPOCH_MILLIS)?.toLong(),
+        locationTrackingEnabled = getOrNull<Boolean>(UserPreferencesEntity.LOCATION_TRACKING_ENABLED) ?: false,
+        currencySymbol = getOrNull<String>(UserPreferencesEntity.CURRENCY_SYMBOL) ?: "€",
+        accountTier = getOrNull<String>(UserPreferencesEntity.ACCOUNT_TIER) ?: "Free",
+        activeGoalType = getOrNull<String>(UserPreferencesEntity.ACTIVE_GOAL_TYPE),
+        activeGoalMetricValue = numberOrNull(UserPreferencesEntity.ACTIVE_GOAL_METRIC_VALUE)?.toDouble(),
+    )
+}
+
+private fun DocumentSnapshot.numberOrNull(field: String): Number? =
+    getOrNull<Double>(field)
+        ?: getOrNull<Long>(field)
+        ?: getOrNull<Int>(field)
+        ?: getOrNull<String>(field)?.toDoubleOrNull()
+
+private inline fun <reified T> DocumentSnapshot.getOrNull(field: String): T? =
+    try {
+        get(field)
+    } catch (_: Throwable) {
+        null
+    }

--- a/libraries/preferences/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/domain/SmokingGoal.kt
+++ b/libraries/preferences/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/domain/SmokingGoal.kt
@@ -51,3 +51,29 @@ fun smokingGoalOrNull(
     type == GoalType.MindfulGap -> SmokingGoal.MindfulGap(metricValue.toInt().coerceAtLeast(1))
     else -> null
 }
+
+fun goalTypeOrNull(rawType: String?): GoalType? {
+    val normalized = rawType
+        ?.trim()
+        ?.filter { it.isLetterOrDigit() }
+        ?.lowercase()
+        ?: return null
+
+    return when (normalized) {
+        "dailycap", "dailycapgoal", "cap", "daily" -> GoalType.DailyCap
+        "reductionvspreviousweek", "weeklyreduction", "weekreduction" -> GoalType.ReductionVsPreviousWeek
+        "reductionvspreviousmonth", "monthlyreduction", "monthreduction" -> GoalType.ReductionVsPreviousMonth
+        "mindfulgap", "gap", "steadygap" -> GoalType.MindfulGap
+        else -> GoalType.entries.firstOrNull {
+            it.name.filter { char -> char.isLetterOrDigit() }.lowercase() == normalized
+        }
+    }
+}
+
+fun smokingGoalOrNull(
+    type: String?,
+    metricValue: Double?,
+): SmokingGoal? = smokingGoalOrNull(
+    type = goalTypeOrNull(type),
+    metricValue = metricValue,
+)

--- a/libraries/preferences/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/preferences/domain/SmokingGoalTest.kt
+++ b/libraries/preferences/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/preferences/domain/SmokingGoalTest.kt
@@ -1,0 +1,35 @@
+package com.feragusper.smokeanalytics.libraries.preferences.domain
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+class SmokingGoalTest {
+
+    @Test
+    fun goalTypeParserAcceptsCanonicalAndLegacyDailyCapNames() {
+        assertEquals(GoalType.DailyCap, goalTypeOrNull("DailyCap"))
+        assertEquals(GoalType.DailyCap, goalTypeOrNull("daily_cap"))
+        assertEquals(GoalType.DailyCap, goalTypeOrNull("daily cap goal"))
+    }
+
+    @Test
+    fun goalTypeParserAcceptsGapAliases() {
+        assertEquals(GoalType.MindfulGap, goalTypeOrNull("MindfulGap"))
+        assertEquals(GoalType.MindfulGap, goalTypeOrNull("steady_gap"))
+    }
+
+    @Test
+    fun smokingGoalParserBuildsGoalFromRawType() {
+        val goal = smokingGoalOrNull(type = "daily_cap", metricValue = 15.0)
+
+        assertIs<SmokingGoal.DailyCap>(goal)
+        assertEquals(15, goal.maxCigarettesPerDay)
+    }
+
+    @Test
+    fun smokingGoalParserReturnsNullForUnknownType() {
+        assertNull(smokingGoalOrNull(type = "something_else", metricValue = 15.0))
+    }
+}

--- a/openspec/changes/fix-release-goals-home-history/design.md
+++ b/openspec/changes/fix-release-goals-home-history/design.md
@@ -1,0 +1,12 @@
+# Design
+
+## Preferences and Goals
+Use the existing Firestore document shape and make decoding tolerant at the platform repository boundary. Shared domain keeps the canonical goal mapping so mobile and web do not diverge on accepted goal identifiers.
+
+Home and Settings should fail loudly enough for UI state to show an error. Smoke list fetches used only for secondary progress can still fall back to an empty list.
+
+## Home CTA
+Mobile gets a content-level Track action in the goal-first layout. Web keeps the sticky Track action but switches to button tone classes instead of elapsed card classes.
+
+## History Add for Date
+The existing `HistoryIntent.AddSmoke(date)` remains the contract. The process holder normalizes the selected day to a timestamp using the current local clock time for historical dates, and now for current-day dates. This avoids adding at the bucket boundary, which looks like a no-op to users.

--- a/openspec/changes/fix-release-goals-home-history/proposal.md
+++ b/openspec/changes/fix-release-goals-home-history/proposal.md
@@ -1,0 +1,17 @@
+# Fix release regressions in goals, home track CTA, and history add-for-date
+
+## Why
+The latest release regressed core daily use: active goals can disappear from Home, goal save failures are not visible, mobile Home lacks an obvious track action, the web track button can lose contrast in light theme, and History's add-for-date action does not produce an understandable result.
+
+## What
+- Preserve and surface persisted active goals on mobile and web.
+- Stop treating preferences fetch failures as "no goal".
+- Restore a visible mobile Home track CTA and fix web track button contrast.
+- Make History add-for-date create a smoke in the selected day at an expected visible time.
+
+## Success Criteria
+- A saved goal remains visible after returning to Home on mobile and web.
+- Preference load/save failures show an error instead of silently falling back to empty preferences.
+- Mobile Home has a visible Track button wired to the existing add-smoke intent.
+- Web Home primary Track button has high contrast in light and dark themes.
+- History Add for Date adds an entry to the selected day and refreshes the list.

--- a/openspec/changes/fix-release-goals-home-history/specs/goals/spec.md
+++ b/openspec/changes/fix-release-goals-home-history/specs/goals/spec.md
@@ -1,0 +1,23 @@
+# goals Specification Delta
+
+## MODIFIED Requirements
+
+### Requirement: Active goal persistence
+The system SHALL preserve an authenticated user's active smoking goal across Settings, Home, mobile, and web.
+
+#### Scenario: Saved daily cap appears on Home
+- GIVEN a logged-in user saves a daily cap goal
+- WHEN Home refreshes preferences
+- THEN Home shows an active goal state
+- AND goal progress is evaluated from the saved goal.
+
+#### Scenario: Preferences cannot be fetched
+- GIVEN preferences fetch fails
+- WHEN Home or Settings loads
+- THEN the UI shows an error state
+- AND the UI MUST NOT present the fallback as "no active goal".
+
+#### Scenario: Legacy goal identifiers
+- GIVEN a stored goal type uses a legacy or case-varied identifier
+- WHEN preferences are decoded
+- THEN the app maps it to the canonical goal type when unambiguous.

--- a/openspec/changes/fix-release-goals-home-history/specs/history/spec.md
+++ b/openspec/changes/fix-release-goals-home-history/specs/history/spec.md
@@ -1,0 +1,18 @@
+# history Specification Delta
+
+## MODIFIED Requirements
+
+### Requirement: Add smoke for selected date
+History SHALL add a smoke to the selected day when Add for Date is pressed.
+
+#### Scenario: Add smoke to selected historical date
+- GIVEN the user is viewing a historical day
+- WHEN the user presses Add for Date
+- THEN a smoke is created on that day
+- AND the History list refreshes showing the new entry.
+
+#### Scenario: Add smoke to current day
+- GIVEN the user is viewing the current day
+- WHEN the user presses Add for Date
+- THEN a smoke is created near the current time
+- AND the Home/widget snapshot can refresh from the new entry.

--- a/openspec/changes/fix-release-goals-home-history/specs/home/spec.md
+++ b/openspec/changes/fix-release-goals-home-history/specs/home/spec.md
@@ -1,0 +1,16 @@
+# home Specification Delta
+
+## MODIFIED Requirements
+
+### Requirement: Track action visibility
+Home SHALL provide a visible primary Track action in the goal-first layout on mobile and web.
+
+#### Scenario: Mobile user opens Home
+- GIVEN Home has loaded
+- WHEN the user scans the first screen
+- THEN a Track action is visible without relying only on a shell FAB.
+
+#### Scenario: Web light theme
+- GIVEN the web app is in light theme
+- WHEN the Track button is rendered
+- THEN the button text and background meet high-contrast primary button styling.

--- a/openspec/changes/fix-release-goals-home-history/tasks.md
+++ b/openspec/changes/fix-release-goals-home-history/tasks.md
@@ -1,0 +1,10 @@
+# Tasks
+
+- [x] Add tolerant shared goal type parsing.
+- [x] Harden mobile and web preferences repositories against legacy goal values.
+- [x] Stop Home/Settings from silently converting preferences errors into empty preferences.
+- [x] Restore mobile Home content-level Track CTA.
+- [x] Fix web Home Track button contrast.
+- [x] Make History Add for Date add at a visible selected-day timestamp.
+- [x] Add/update tests for goal parsing, settings persistence state, home CTA, and history add timestamp.
+- [x] Run web build, nearest feature tests, and one mobile app build.


### PR DESCRIPTION
## Summary
- ship release regression hotfix for goals persistence/home visibility
- restore Home track CTA behavior and web contrast
- fix History Add for Date timestamp behavior

## Included PRs
- #243

## Verification
- Feature PR #243 Integration passed
- Local verification listed in #243