### PR TITLE
Fix mobile tracking side effects

### DIFF
--- a/features/history/presentation/mobile/build.gradle.kts
+++ b/features/history/presentation/mobile/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
 
     // Core AndroidX libraries and Compose dependencies
     implementation(libs.bundles.androidx.base)
+    implementation(libs.timber)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.compose)
     implementation(libs.material3)

--- a/features/history/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/history/presentation/process/HistoryProcessHolder.kt
+++ b/features/history/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/history/presentation/process/HistoryProcessHolder.kt
@@ -35,6 +35,7 @@ import kotlinx.datetime.plus
 import kotlinx.datetime.toDeprecatedInstant
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
+import timber.log.Timber
 import javax.inject.Inject
 
 /**
@@ -85,9 +86,9 @@ class HistoryProcessHolder @Inject constructor(
     private fun processDeleteSmoke(intent: HistoryIntent.DeleteSmoke) = flow {
         emit(HistoryResult.DeleteSmokeInFlight(intent.id))
         deleteSmokeUseCase.invoke(intent.id)
-        refreshWidgetSnapshot()
         emit(HistoryResult.DeleteSmokeSuccess)
-        syncWithWearUseCase.invoke()
+        refreshWidgetSnapshotBestEffort()
+        syncWithWearBestEffort()
     }.catchAndLog {
         emit(HistoryResult.Error.Generic)
     }
@@ -101,9 +102,9 @@ class HistoryProcessHolder @Inject constructor(
     private fun processEditSmoke(intent: HistoryIntent.EditSmoke) = flow {
         emit(HistoryResult.EditSmokeInFlight(intent.id))
         editSmokeUseCase.invoke(intent.id, intent.date)
-        refreshWidgetSnapshot()
         emit(HistoryResult.EditSmokeSuccess)
-        syncWithWearUseCase.invoke()
+        refreshWidgetSnapshotBestEffort()
+        syncWithWearBestEffort()
     }.catchAndLog {
         emit(HistoryResult.Error.Generic)
     }
@@ -232,9 +233,9 @@ class HistoryProcessHolder @Inject constructor(
                     null
                 }
                 addSmokeUseCase.invoke(intent.date.toVisibleAddTimestamp(timeZone), location)
-                refreshWidgetSnapshot()
                 emit(HistoryResult.AddSmokeSuccess)
-                syncWithWearUseCase.invoke()
+                refreshWidgetSnapshotBestEffort()
+                syncWithWearBestEffort()
             }
         }
     }.catchAndLog {
@@ -248,6 +249,16 @@ class HistoryProcessHolder @Inject constructor(
             manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
         )
         widgetRefreshService.refreshHomeSnapshot(smokeCounts.toWidgetSnapshot(preferences))
+    }
+
+    private suspend fun refreshWidgetSnapshotBestEffort() {
+        runCatching { refreshWidgetSnapshot() }
+            .onFailure { Timber.w(it, "History mutation succeeded but widget refresh failed") }
+    }
+
+    private suspend fun syncWithWearBestEffort() {
+        runCatching { syncWithWearUseCase.invoke() }
+            .onFailure { Timber.w(it, "History mutation succeeded but Wear sync failed") }
     }
 }
 

--- a/features/history/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/history/presentation/process/HistoryProcessHolderTest.kt
+++ b/features/history/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/history/presentation/process/HistoryProcessHolderTest.kt
@@ -150,6 +150,22 @@ class HistoryProcessHolderTest {
         }
 
         @Test
+        fun `WHEN widget refresh fails after add for date THEN tracking still succeeds`() = runTest {
+            val date: Instant = Clock.System.now()
+            coEvery { addSmokeUseCase(any()) } just Runs
+            coEvery { fetchSmokeCountListUseCase.invoke(any()) } throws IllegalStateException("Quota exceeded")
+
+            results = processHolder.processIntent(HistoryIntent.AddSmoke(date))
+
+            results.test {
+                awaitItem() shouldBe HistoryResult.Loading
+                awaitItem() shouldBe HistoryResult.AddSmokeSuccess
+                coVerify(exactly = 1) { syncWithWearUseCase.invoke() }
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
         fun `WHEN preferences cannot be fetched for history THEN returns fetch error instead of empty archive`() =
             runTest {
                 coEvery { fetchUserPreferencesUseCase() } throws IllegalStateException("Quota exceeded")

--- a/features/home/presentation/mobile/build.gradle.kts
+++ b/features/home/presentation/mobile/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
 
     // Core AndroidX libraries and Compose dependencies
     implementation(libs.bundles.androidx.base)
+    implementation(libs.timber)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.compose)
     implementation(libs.androidx.compose.material.icons.core)

--- a/features/home/presentation/mobile/src/androidTest/java/com/feragusper/smokeanalytics/features/home/presentation/HomeViewTest.kt
+++ b/features/home/presentation/mobile/src/androidTest/java/com/feragusper/smokeanalytics/features/home/presentation/HomeViewTest.kt
@@ -3,7 +3,6 @@ package com.feragusper.smokeanalytics.features.home.presentation
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import com.feragusper.smokeanalytics.features.goals.domain.GoalProgress
 import com.feragusper.smokeanalytics.features.goals.domain.GoalStatus
@@ -60,7 +59,6 @@ class HomeViewTest {
         composeTestRule.onNodeWithText("Last cigarette").assertIsDisplayed()
         composeTestRule.onNodeWithText("Time since").assertIsDisplayed()
         composeTestRule.onNodeWithText("2h 35m").assertIsDisplayed()
-        composeTestRule.onNodeWithTag(HomeViewState.TestTags.BUTTON_ADD_SMOKE).assertIsDisplayed()
     }
 
     private fun prepareScreen(

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -123,7 +122,9 @@ data class HomeViewState(
         }
 
         LaunchedEffect(displayLoading, elapsedTone) {
-            onFabConfigChanged(false, elapsedTone, null)
+            onFabConfigChanged(!displayLoading, elapsedTone) {
+                intent(HomeIntent.AddSmoke)
+            }
         }
 
         val nestedScrollConnection = remember {
@@ -263,12 +264,6 @@ private fun HomeContent(
             )
         }
         item {
-            TrackActionSection(
-                isLoading = isLoading,
-                onAddSmoke = { intent(HomeIntent.AddSmoke) },
-            )
-        }
-        item {
             LastCigaretteSection(
                 lastSmokeTimeLabel = lastSmokeTimeLabel,
                 timeSinceLastCigarette = timeSinceLastCigarette,
@@ -336,34 +331,6 @@ private fun HomeErrorSection(
                 Text("Retry")
             }
         }
-    }
-}
-
-@Composable
-private fun TrackActionSection(
-    isLoading: Boolean,
-    onAddSmoke: () -> Unit,
-) {
-    Button(
-        onClick = onAddSmoke,
-        enabled = !isLoading,
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(56.dp)
-            .testTag(HomeViewState.TestTags.BUTTON_ADD_SMOKE),
-        shape = RoundedCornerShape(20.dp),
-        colors = ButtonDefaults.buttonColors(
-            containerColor = MaterialTheme.colorScheme.primary,
-            contentColor = MaterialTheme.colorScheme.onPrimary,
-            disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
-            disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-        ),
-    ) {
-        Text(
-            text = "Track cigarette",
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Bold,
-        )
     }
 }
 

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
@@ -29,6 +29,7 @@ import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.SyncWithWea
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.datetime.toLocalDateTime
+import timber.log.Timber
 import javax.inject.Inject
 
 /**
@@ -144,9 +145,9 @@ class HomeProcessHolder @Inject constructor(
     private fun processDeleteSmoke(intent: HomeIntent.DeleteSmoke) = flow {
         emit(HomeResult.Loading)
         deleteSmokeUseCase.invoke(intent.id)
-        refreshWidgetSnapshot()
         emit(HomeResult.DeleteSmokeSuccess)
-        syncWithWearUseCase.invoke()
+        refreshWidgetSnapshotBestEffort()
+        syncWithWearBestEffort()
     }.catchAndLog {
         emit(HomeResult.Error.Generic)
     }
@@ -160,9 +161,9 @@ class HomeProcessHolder @Inject constructor(
     private fun processEditSmoke(intent: HomeIntent.EditSmoke) = flow {
         emit(HomeResult.Loading)
         editSmokeUseCase.invoke(intent.id, intent.date)
-        refreshWidgetSnapshot()
         emit(HomeResult.EditSmokeSuccess)
-        syncWithWearUseCase.invoke()
+        refreshWidgetSnapshotBestEffort()
+        syncWithWearBestEffort()
     }.catchAndLog {
         emit(HomeResult.Error.Generic)
     }
@@ -207,9 +208,9 @@ class HomeProcessHolder @Inject constructor(
                     null
                 }
                 addSmokeUseCase.invoke(location = location)
-                refreshWidgetSnapshot()
                 emit(HomeResult.AddSmokeSuccess)
-                syncWithWearUseCase.invoke()
+                refreshWidgetSnapshotBestEffort()
+                syncWithWearBestEffort()
             }
         }
     }.catchAndLog {
@@ -234,6 +235,16 @@ class HomeProcessHolder @Inject constructor(
             manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
         )
         widgetRefreshService.refreshHomeSnapshot(smokeCounts.toWidgetSnapshot(preferences))
+    }
+
+    private suspend fun refreshWidgetSnapshotBestEffort() {
+        runCatching { refreshWidgetSnapshot() }
+            .onFailure { Timber.w(it, "Home mutation succeeded but widget refresh failed") }
+    }
+
+    private suspend fun syncWithWearBestEffort() {
+        runCatching { syncWithWearUseCase.invoke() }
+            .onFailure { Timber.w(it, "Home mutation succeeded but Wear sync failed") }
     }
 }
 

--- a/features/home/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolderTest.kt
+++ b/features/home/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolderTest.kt
@@ -149,6 +149,19 @@ class HomeProcessHolderTest {
         }
 
         @Test
+        fun `WHEN widget refresh fails after adding smoke THEN tracking still succeeds`() = runTest {
+            coEvery { addSmokeUseCase.invoke(any()) } just Runs
+            coEvery { fetchSmokeCountListUseCase.invoke(any()) } throws IllegalStateException("Quota exceeded")
+
+            processHolder.processIntent(HomeIntent.AddSmoke).test {
+                awaitItem() shouldBeEqualTo HomeResult.Loading
+                awaitItem() shouldBeEqualTo HomeResult.AddSmokeSuccess
+                coVerify(exactly = 1) { syncWithWearUseCase.invoke() }
+                awaitComplete()
+            }
+        }
+
+        @Test
         fun `WHEN goal smoke fetch fails THEN fetch returns error instead of empty progress`() = runTest {
             coEvery { fetchSmokesUseCase.invoke(any(), any()) } throws IllegalStateException("Quota exceeded")
 


### PR DESCRIPTION
## Summary
- Re-enable the Home mobile shell FAB so it actually dispatches AddSmoke while the screen is ready.
- Remove the duplicate inline track button from Home so mobile has a single tracking action.
- Emit add/edit/delete success immediately after the primary smoke mutation, then run widget refresh and Wear sync as best-effort side effects.
- Add regression coverage for quota-like widget refresh failures after Home tracking and History add-for-date tracking.

## Validation
- ./gradlew :features:home:presentation:mobile:testDebugUnitTest --tests '*HomeProcessHolderTest'
- ./gradlew :features:history:presentation:mobile:testDebugUnitTest --tests '*HistoryProcessHolderTest'
- ./gradlew :apps:mobile:compileStagingDebugKotlin
- ./gradlew :features:home:presentation:mobile:compileDebugAndroidTestKotlin
- git diff --check