### PR TITLE
Document release version bump policy

### DIFF
--- a/.agents/skills/release-hygiene/SKILL.md
+++ b/.agents/skills/release-hygiene/SKILL.md
@@ -14,18 +14,31 @@ description: Use for versioning, GitHub Actions, tags, releases, deploy workflow
 2. Inspect the affected workflow files before editing release behavior.
 3. Keep tags, release names, and CI metadata platform-specific when Android and web ship on different cadences.
 4. Use the branch flow `master <- develop <- feature branch`. Release PRs must go from `develop` into `master`.
-5. Do not merge the release PR until its checks are green.
-6. Before merging the release PR, make sure the release summary that should ship is present in GitHub release metadata or in the release PR context. Do not keep a growing archive of release-note markdown files in the repo unless a task explicitly asks for it.
-7. After the release PR lands on `master`, trigger the Android Play Store and web production deploy workflows from `master`.
-8. Confirm the resulting tags and GitHub releases match the shipped version and expose usable release notes in GitHub itself.
-9. If a recent release is missing GitHub release notes, backfill it directly in GitHub when the summary can be reconstructed confidently.
-10. After the release is out, bump `version.properties` on `develop` to the next product version before continuing feature work.
-11. Update GitHub issues or project state if the task materially changes backlog or release status.
+5. Before opening the release PR, classify the release content since the last released `master` and adjust `version.properties` on `develop` when the current value does not match the policy below.
+6. Do not merge the release PR until its checks are green.
+7. Before merging the release PR, make sure the release summary that should ship is present in GitHub release metadata or in the release PR context. Do not keep a growing archive of release-note markdown files in the repo unless a task explicitly asks for it.
+8. After the release PR lands on `master`, trigger the Android Play Store and web production deploy workflows from `master`.
+9. Confirm the resulting tags and GitHub releases match the shipped version and expose usable release notes in GitHub itself.
+10. If a recent release is missing GitHub release notes, backfill it directly in GitHub when the summary can be reconstructed confidently.
+11. After the release is out, bump `version.properties` on `develop` to the next product version before continuing feature work.
+12. Update GitHub issues or project state if the task materially changes backlog or release status.
+
+## Version Bump Policy
+- `version.properties` is the product version source of truth. Platform version names and tags are derived from it plus build metadata.
+- Use semantic versioning: `MAJOR.MINOR.PATCH`.
+- `MAJOR` is only for breaking compatibility, destructive migration, or intentionally disruptive product/API shifts.
+- A release that includes at least one new feature and no breaking change must bump `MINOR` and reset `PATCH` to `0`.
+- A release that only includes bugfixes, polish, docs, CI/deploy fixes, release fixes, or other operational fixes must bump `PATCH`.
+- When a release contains both features and bugfixes, classify it as a feature release and bump `MINOR`.
+- Default post-release bump on `develop`: bump `PATCH` by one from the shipped product version so new work starts from the next unreleased patch version.
+- If the next planned tranche is already known to be a feature release, it is acceptable to set `develop` to the next `MINOR.0` immediately after release instead of the default patch bump.
+- Before creating the release PR, validate the derived release metadata with Gradle after any `version.properties` adjustment.
 
 ## Verification
 - Run the nearest relevant Gradle task.
 - Re-check the affected workflow definitions after editing.
 - When preparing a release, validate the derived Android and web release metadata from Gradle before opening the release PR.
+- When preparing a release, verify that `version.properties` matches the Version Bump Policy and that the release PR title/body use the same product version.
 - When preparing a release, verify where the GitHub release notes will come from and avoid depending on stale repo-side markdown unless the release task explicitly uses it.
 - After bumping post-release version metadata, confirm the single source of truth was updated in the repo.
 - Summarize what was verified locally and what still depends on remote CI or deploy credentials.

--- a/.codex/agents/release-guardian.toml
+++ b/.codex/agents/release-guardian.toml
@@ -6,6 +6,6 @@ sandbox_mode = "read-only"
 developer_instructions = """
 Review release-related work like an owner.
 Look for version drift, workflow trigger regressions, tagging collisions, broken deploy assumptions, and mismatches between GitHub project state and shipped code.
+Enforce the repo version policy: semantic `MAJOR.MINOR.PATCH`, major only for breaking/disruptive changes, minor for releases containing at least one feature, patch for bugfix-only or operational-only releases, and a post-release bump on develop to the next default patch version unless the next tranche is intentionally minor/major.
 Lead with concrete operational risks and verification gaps.
 """
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,12 @@
 - Open feature/tranche PRs into `develop`.
 - Merge `develop` into `master` only when preparing a release.
 - Release flow is: open PR `develop -> master`, wait for green checks, merge, deploy Android and web from `master`, then bump `version.properties` on `develop` to the next version before resuming feature work.
+- Before opening a release PR, inspect the changes since the last released `master` and adjust `version.properties` on `develop` if needed:
+  - Use semantic versioning for `product.version`.
+  - `MAJOR` changes are reserved for breaking compatibility or intentionally disruptive product/API shifts.
+  - If the release includes at least one new feature and no breaking change, bump `MINOR` and reset `PATCH` to `0`.
+  - If the release only contains bugfixes, polish, docs, or operational fixes, bump `PATCH`.
+  - After a successful release, bump `develop` to the next default patch development version unless the next tranche is already known to require a minor or major bump.
 - Tags and deploys happen from the release state on `master`, not from feature branches.
 - If work is merged to `master` by mistake, bring `develop` forward before starting the next branch.
 - Never use PR auto-delete or `gh pr merge --delete-branch` when the PR head branch is `develop` or `master`.


### PR DESCRIPTION
## Summary
- Add release version bump rules to the repo agent guide.
- Extend the release-hygiene skill with SemVer classification before release PRs and default post-release bumps.
- Teach the release guardian agent to flag version-policy drift.

## Policy
- MAJOR: breaking or intentionally disruptive product/API shifts.
- MINOR: releases containing at least one feature, with PATCH reset to 0.
- PATCH: bugfix-only, polish, docs, CI/deploy, or operational releases.
- Default post-release develop bump: next patch version unless the next tranche is known to be minor/major.

## Validation
- git diff --check