### PR TITLE
Show mobile Google sign-in failures

### DIFF
--- a/.github/workflows/deployment_artifact.yml
+++ b/.github/workflows/deployment_artifact.yml
@@ -32,7 +32,7 @@ jobs:
           GOOGLE_SERVICES_JSON_STAGING: ${{ secrets.GOOGLE_SERVICES_JSON_STAGING }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
-          echo google.auth.server.client.id=$GOOGLE_AUTH_SERVER_CLIENT_ID_STAGING > ./local.properties
+          echo google.auth.server.client.id.staging=$GOOGLE_AUTH_SERVER_CLIENT_ID_STAGING > ./local.properties
           echo google.ai.client.generativeai.api.key=$GOOGLE_AI_CLIENT_GENERATIVEAI_API_KEY_STAGING >> ./local.properties
           echo google.maps.android.api.key.staging=$GOOGLE_MAPS_ANDROID_API_KEY_STAGING >> ./local.properties
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Configure API keys and google-services.json
         shell: bash
         env:
+          GOOGLE_AUTH_SERVER_CLIENT_ID: ${{ secrets.GOOGLE_AUTH_SERVER_CLIENT_ID }}
           GOOGLE_AUTH_SERVER_CLIENT_ID_STAGING: ${{ secrets.GOOGLE_AUTH_SERVER_CLIENT_ID_STAGING }}
           GOOGLE_AI_CLIENT_GENERATIVEAI_API_KEY_STAGING: ${{ secrets.GOOGLE_AI_CLIENT_GENERATIVEAI_API_KEY_STAGING }}
           GOOGLE_MAPS_ANDROID_API_KEY_STAGING: ${{ secrets.GOOGLE_MAPS_ANDROID_API_KEY_STAGING }}
@@ -53,7 +54,8 @@ jobs:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
-          echo google.auth.server.client.id=$GOOGLE_AUTH_SERVER_CLIENT_ID_STAGING > ./local.properties
+          echo google.auth.server.client.id=$GOOGLE_AUTH_SERVER_CLIENT_ID > ./local.properties
+          echo google.auth.server.client.id.staging=$GOOGLE_AUTH_SERVER_CLIENT_ID_STAGING >> ./local.properties
           echo google.ai.client.generativeai.api.key=$GOOGLE_AI_CLIENT_GENERATIVEAI_API_KEY_STAGING >> ./local.properties
           echo google.maps.android.api.key.staging=$GOOGLE_MAPS_ANDROID_API_KEY_STAGING >> ./local.properties
           echo google.maps.android.api.key.production=$GOOGLE_MAPS_ANDROID_API_KEY_PRODUCTION >> ./local.properties

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ Each feature or library follows the same general split when needed:
 
 Local Android and product-specific keys live in `local.properties`. Typical entries include:
 
-- `google.auth.server.client.id`
+- `google.auth.server.client.id` for production
+- `google.auth.server.client.id.staging` for staging
 - `google.maps.android.api.key.staging`
 - `google.maps.android.api.key.production`
 - `google.ai.client.generativeai.api.key.staging`

--- a/features/authentication/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/authentication/presentation/mvi/compose/AuthenticationViewState.kt
+++ b/features/authentication/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/authentication/presentation/mvi/compose/AuthenticationViewState.kt
@@ -46,10 +46,6 @@ data class AuthenticationViewState(
     fun Compose(intent: (AuthenticationIntent) -> Unit) {
         val snackbarHostState = remember { SnackbarHostState() }
         val scope = rememberCoroutineScope()
-        val genericErrorMessage = stringResource(
-            com.feragusper.smokeanalytics.libraries.design.mobile.R.string.error_general
-        )
-
         Scaffold(
             snackbarHost = { SnackbarHost(snackbarHostState) },
         ) { contentPadding ->
@@ -66,8 +62,8 @@ data class AuthenticationViewState(
                     item {
                         AuthEntryCard(
                             onRefresh = { intent(AuthenticationIntent.FetchUser) },
-                            onSignInError = {
-                                scope.launch { snackbarHostState.showSnackbar(genericErrorMessage) }
+                            onSignInError = { message ->
+                                scope.launch { snackbarHostState.showSnackbar(message) }
                             },
                         )
                     }
@@ -156,7 +152,7 @@ private fun AuthHeroCard() {
 @Composable
 private fun AuthEntryCard(
     onRefresh: () -> Unit,
-    onSignInError: () -> Unit,
+    onSignInError: (String) -> Unit,
 ) {
     Card(
         shape = RoundedCornerShape(24.dp),

--- a/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/GoalsEditorScreen.kt
+++ b/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/GoalsEditorScreen.kt
@@ -40,10 +40,12 @@ fun GoalsEditorScreen(
     goalProgress: GoalProgress?,
     displayLoading: Boolean,
     errorMessage: String? = null,
+    signInErrorMessage: String? = null,
     onBack: () -> Unit,
     onSaveGoal: (SmokingGoal) -> Unit,
     onClearGoal: () -> Unit,
     onSignInSuccess: () -> Unit,
+    onSignInError: (String) -> Unit,
 ) {
     var selectedType by remember(preferences.activeGoal) {
         mutableStateOf(preferences.activeGoal?.type ?: GoalType.DailyCap)
@@ -120,10 +122,33 @@ fun GoalsEditorScreen(
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
+                    signInErrorMessage?.let { message ->
+                        Card(
+                            shape = androidx.compose.foundation.shape.RoundedCornerShape(24.dp),
+                            colors = CardDefaults.cardColors(
+                                containerColor = MaterialTheme.colorScheme.errorContainer,
+                                contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                            ),
+                        ) {
+                            Column(
+                                modifier = Modifier.padding(18.dp),
+                                verticalArrangement = Arrangement.spacedBy(10.dp),
+                            ) {
+                                Text(
+                                    text = "Sign-in failed",
+                                    style = MaterialTheme.typography.titleMedium,
+                                )
+                                Text(
+                                    text = message,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                )
+                            }
+                        }
+                    }
                     GoogleSignInComponent(
                         modifier = Modifier.fillMaxWidth(),
                         onSignInSuccess = onSignInSuccess,
-                        onSignInError = {},
+                        onSignInError = onSignInError,
                     )
                 }
             }

--- a/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/mvi/compose/SettingsViewState.kt
+++ b/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/mvi/compose/SettingsViewState.kt
@@ -86,9 +86,13 @@ data class SettingsViewState(
     ) {
         var draftPreferences by remember(currentEmail, preferences) { mutableStateOf(preferences) }
         var showingGoals by remember(currentEmail, preferences.activeGoal) { mutableStateOf(false) }
+        var signInErrorMessage by remember { mutableStateOf<String?>(null) }
 
         LaunchedEffect(preferences, currentEmail) {
             draftPreferences = preferences
+            if (currentEmail != null) {
+                signInErrorMessage = null
+            }
         }
 
         if (showingGoals) {
@@ -108,6 +112,8 @@ data class SettingsViewState(
                     intent(SettingsIntent.UpdatePreferences(draftPreferences.copy(activeGoal = null)))
                 },
                 onSignInSuccess = { intent(SettingsIntent.FetchUser) },
+                onSignInError = { signInErrorMessage = it },
+                signInErrorMessage = signInErrorMessage,
             )
             return
         }
@@ -151,8 +157,10 @@ data class SettingsViewState(
                 currentEmail = currentEmail,
                 currentDisplayName = currentDisplayName,
                 displayLoading = displayLoading,
+                signInErrorMessage = signInErrorMessage,
                 onSignOut = { intent(SettingsIntent.SignOut) },
                 onSignInSuccess = { intent(SettingsIntent.FetchUser) },
+                onSignInError = { signInErrorMessage = it },
             )
 
             HighlightsRow(tier = preferences.accountTier)
@@ -207,7 +215,8 @@ data class SettingsViewState(
 @Composable
 private fun SettingsErrorCard(
     message: String,
-    onRetry: () -> Unit,
+    onRetry: (() -> Unit)? = null,
+    title: String = "Your space is unavailable",
 ) {
     Card(
         shape = RoundedCornerShape(24.dp),
@@ -221,7 +230,7 @@ private fun SettingsErrorCard(
             verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
             Text(
-                text = "Your space is unavailable",
+                text = title,
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
             )
@@ -229,8 +238,10 @@ private fun SettingsErrorCard(
                 text = message,
                 style = MaterialTheme.typography.bodyMedium,
             )
-            Button(onClick = onRetry) {
-                Text("Retry")
+            if (onRetry != null) {
+                Button(onClick = onRetry) {
+                    Text("Retry")
+                }
             }
         }
     }
@@ -449,8 +460,10 @@ private fun SessionCard(
     currentEmail: String?,
     currentDisplayName: String?,
     displayLoading: Boolean,
+    signInErrorMessage: String?,
     onSignOut: () -> Unit,
     onSignInSuccess: () -> Unit,
+    onSignInError: (String) -> Unit,
 ) {
     SettingsCard(
         title = "Session",
@@ -534,12 +547,19 @@ private fun SessionCard(
                     body = "Give the guide enough recent behavior to stay grounded instead of generic.",
                 )
 
+                signInErrorMessage?.let { message ->
+                    SettingsErrorCard(
+                        title = "Sign-in failed",
+                        message = message,
+                    )
+                }
+
                 GoogleSignInComponent(
                     modifier = Modifier
                         .fillMaxWidth()
                         .testTag(SettingsViewState.TestTags.BUTTON_SIGN_IN),
                     onSignInSuccess = onSignInSuccess,
-                    onSignInError = {},
+                    onSignInError = onSignInError,
                 )
             }
         }

--- a/libraries/authentication/presentation/mobile/build.gradle.kts
+++ b/libraries/authentication/presentation/mobile/build.gradle.kts
@@ -1,5 +1,14 @@
 import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 
+val localProperties = gradleLocalProperties(rootDir, providers)
+val requestedTasks = gradle.startParameter.taskNames.joinToString(" ").lowercase()
+val googleAuthServerClientId = when {
+    "staging" in requestedTasks -> localProperties.getProperty("google.auth.server.client.id.staging")
+        ?: localProperties.getProperty("google.auth.server.client.id")
+
+    else -> localProperties.getProperty("google.auth.server.client.id")
+}.orEmpty()
+
 plugins {
     // Use the predefined android-lib plugin for Android library modules.
     `android-lib`
@@ -20,9 +29,7 @@ android {
         buildConfigField(
             "String",
             "GOOGLE_AUTH_SERVER_CLIENT_ID",
-            gradleLocalProperties(rootDir, providers)
-                .getProperty("google.auth.server.client.id")
-                .asBuildConfigString(),
+            googleAuthServerClientId.asBuildConfigString(),
         )
     }
 

--- a/libraries/authentication/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/authentication/presentation/compose/GoogleSignInComponent.kt
+++ b/libraries/authentication/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/authentication/presentation/compose/GoogleSignInComponent.kt
@@ -55,7 +55,7 @@ import java.util.UUID
 fun GoogleSignInComponent(
     modifier: Modifier = Modifier,
     onSignInSuccess: () -> Unit,
-    onSignInError: () -> Unit,
+    onSignInError: (String) -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
@@ -109,8 +109,13 @@ private fun doGoogleSignIn(
     context: Context,
     startAddAccountIntentLauncher: ManagedActivityResultLauncher<Intent, ActivityResult>?,
     onSignInSuccess: () -> Unit,
-    onSignInError: () -> Unit
+    onSignInError: (String) -> Unit,
 ) {
+    if (BuildConfig.GOOGLE_AUTH_SERVER_CLIENT_ID.isBlank()) {
+        onSignInError("Google sign-in is not configured for this app build: missing server client id.")
+        return
+    }
+
     val credentialManager = CredentialManager.create(context)
 
     // Create Google ID Option for sign-in
@@ -136,10 +141,14 @@ private fun doGoogleSignIn(
         } catch (e: NoCredentialException) {
             Timber.e(e, "No credentials found")
             // Prompt user to add Google account if no credentials are available
-            startAddAccountIntentLauncher?.launch(getAddGoogleAccountIntent())
+            if (startAddAccountIntentLauncher != null) {
+                startAddAccountIntentLauncher.launch(getAddGoogleAccountIntent())
+            } else {
+                onSignInError("No Google account is available on this device. Add an account and try again.")
+            }
         } catch (e: Exception) {
             Timber.e(e, "Unexpected error during sign-in")
-            onSignInError()
+            onSignInError(e.toUserVisibleSignInMessage())
         }
     }
 }
@@ -154,7 +163,7 @@ private fun doGoogleSignIn(
 private suspend fun handleSignIn(
     result: GetCredentialResponse,
     onSignInSuccess: () -> Unit,
-    onSignInError: () -> Unit
+    onSignInError: (String) -> Unit,
 ) {
     val credential = result.credential
 
@@ -172,21 +181,35 @@ private suspend fun handleSignIn(
                     onSignInSuccess()
                 } catch (e: GoogleIdTokenParsingException) {
                     Timber.e(e, "Invalid Google ID Token")
-                    onSignInError()
+                    onSignInError("Google returned an invalid sign-in token. Try again.")
                 } catch (e: Exception) {
                     Timber.e(e, "Unexpected error during sign-in")
-                    onSignInError()
+                    onSignInError(e.toUserVisibleSignInMessage())
                 }
             } else {
                 Timber.e("Unexpected credential type")
-                onSignInError()
+                onSignInError("Google returned an unsupported credential type. Try again.")
             }
         }
 
         else -> {
             Timber.e("Credential is not of the expected type")
-            onSignInError()
+            onSignInError("Google returned an unsupported credential. Try again.")
         }
+    }
+}
+
+private fun Throwable.toUserVisibleSignInMessage(): String {
+    val detail = message.orEmpty()
+    return when {
+        detail.contains("28444") || detail.contains("Developer console is not set up correctly", ignoreCase = true) ->
+            "Google sign-in is not configured for this app build ([28444]). Check the OAuth client, package name, and signing certificate in Google Cloud/Firebase."
+
+        detail.isNotBlank() ->
+            "Google sign-in failed: $detail"
+
+        else ->
+            "Google sign-in failed (${javaClass.simpleName}). Try again."
     }
 }
 


### PR DESCRIPTION
## Summary
- Surface Google sign-in failures with user-visible messages instead of empty callbacks.
- Show sign-in errors on auth, settings, and goals entry points.
- Select the staging Google server client id for staging builds when available, and fail visibly at runtime if the client id is missing.

## Validation
- ./gradlew :libraries:authentication:presentation:mobile:compileDebugKotlin
- ./gradlew :features:authentication:presentation:mobile:compileDebugKotlin
- ./gradlew :features:settings:presentation:mobile:compileDebugKotlin
- ./gradlew :apps:mobile:compileProductionDebugKotlin
- ./gradlew :apps:mobile:compileProductionReleaseKotlin
- ./gradlew :apps:mobile:compileStagingDebugKotlin
- git diff --check

## Notes
The production emulator log shows Google Credential Manager error [28444] Developer console is not set up correctly. This PR makes that failure visible in the app; the production OAuth client/package/signing certificate still needs to be corrected in Google Cloud/Firebase if the config is wrong.