### PR TITLE
Release 0.14.2

### DIFF
--- a/.agents/skills/release-hygiene/SKILL.md
+++ b/.agents/skills/release-hygiene/SKILL.md
@@ -14,18 +14,31 @@ description: Use for versioning, GitHub Actions, tags, releases, deploy workflow
 2. Inspect the affected workflow files before editing release behavior.
 3. Keep tags, release names, and CI metadata platform-specific when Android and web ship on different cadences.
 4. Use the branch flow `master <- develop <- feature branch`. Release PRs must go from `develop` into `master`.
-5. Do not merge the release PR until its checks are green.
-6. Before merging the release PR, make sure the release summary that should ship is present in GitHub release metadata or in the release PR context. Do not keep a growing archive of release-note markdown files in the repo unless a task explicitly asks for it.
-7. After the release PR lands on `master`, trigger the Android Play Store and web production deploy workflows from `master`.
-8. Confirm the resulting tags and GitHub releases match the shipped version and expose usable release notes in GitHub itself.
-9. If a recent release is missing GitHub release notes, backfill it directly in GitHub when the summary can be reconstructed confidently.
-10. After the release is out, bump `version.properties` on `develop` to the next product version before continuing feature work.
-11. Update GitHub issues or project state if the task materially changes backlog or release status.
+5. Before opening the release PR, classify the release content since the last released `master` and adjust `version.properties` on `develop` when the current value does not match the policy below.
+6. Do not merge the release PR until its checks are green.
+7. Before merging the release PR, make sure the release summary that should ship is present in GitHub release metadata or in the release PR context. Do not keep a growing archive of release-note markdown files in the repo unless a task explicitly asks for it.
+8. After the release PR lands on `master`, trigger the Android Play Store and web production deploy workflows from `master`.
+9. Confirm the resulting tags and GitHub releases match the shipped version and expose usable release notes in GitHub itself.
+10. If a recent release is missing GitHub release notes, backfill it directly in GitHub when the summary can be reconstructed confidently.
+11. After the release is out, bump `version.properties` on `develop` to the next product version before continuing feature work.
+12. Update GitHub issues or project state if the task materially changes backlog or release status.
+
+## Version Bump Policy
+- `version.properties` is the product version source of truth. Platform version names and tags are derived from it plus build metadata.
+- Use semantic versioning: `MAJOR.MINOR.PATCH`.
+- `MAJOR` is only for breaking compatibility, destructive migration, or intentionally disruptive product/API shifts.
+- A release that includes at least one new feature and no breaking change must bump `MINOR` and reset `PATCH` to `0`.
+- A release that only includes bugfixes, polish, docs, CI/deploy fixes, release fixes, or other operational fixes must bump `PATCH`.
+- When a release contains both features and bugfixes, classify it as a feature release and bump `MINOR`.
+- Default post-release bump on `develop`: bump `PATCH` by one from the shipped product version so new work starts from the next unreleased patch version.
+- If the next planned tranche is already known to be a feature release, it is acceptable to set `develop` to the next `MINOR.0` immediately after release instead of the default patch bump.
+- Before creating the release PR, validate the derived release metadata with Gradle after any `version.properties` adjustment.
 
 ## Verification
 - Run the nearest relevant Gradle task.
 - Re-check the affected workflow definitions after editing.
 - When preparing a release, validate the derived Android and web release metadata from Gradle before opening the release PR.
+- When preparing a release, verify that `version.properties` matches the Version Bump Policy and that the release PR title/body use the same product version.
 - When preparing a release, verify where the GitHub release notes will come from and avoid depending on stale repo-side markdown unless the release task explicitly uses it.
 - After bumping post-release version metadata, confirm the single source of truth was updated in the repo.
 - Summarize what was verified locally and what still depends on remote CI or deploy credentials.

--- a/.codex/agents/release-guardian.toml
+++ b/.codex/agents/release-guardian.toml
@@ -6,6 +6,6 @@ sandbox_mode = "read-only"
 developer_instructions = """
 Review release-related work like an owner.
 Look for version drift, workflow trigger regressions, tagging collisions, broken deploy assumptions, and mismatches between GitHub project state and shipped code.
+Enforce the repo version policy: semantic `MAJOR.MINOR.PATCH`, major only for breaking/disruptive changes, minor for releases containing at least one feature, patch for bugfix-only or operational-only releases, and a post-release bump on develop to the next default patch version unless the next tranche is intentionally minor/major.
 Lead with concrete operational risks and verification gaps.
 """
-

--- a/.github/workflows/deployment_artifact.yml
+++ b/.github/workflows/deployment_artifact.yml
@@ -32,7 +32,7 @@ jobs:
           GOOGLE_SERVICES_JSON_STAGING: ${{ secrets.GOOGLE_SERVICES_JSON_STAGING }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
-          echo google.auth.server.client.id=$GOOGLE_AUTH_SERVER_CLIENT_ID_STAGING > ./local.properties
+          echo google.auth.server.client.id.staging=$GOOGLE_AUTH_SERVER_CLIENT_ID_STAGING > ./local.properties
           echo google.ai.client.generativeai.api.key=$GOOGLE_AI_CLIENT_GENERATIVEAI_API_KEY_STAGING >> ./local.properties
           echo google.maps.android.api.key.staging=$GOOGLE_MAPS_ANDROID_API_KEY_STAGING >> ./local.properties
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Configure API keys and google-services.json
         shell: bash
         env:
+          GOOGLE_AUTH_SERVER_CLIENT_ID: ${{ secrets.GOOGLE_AUTH_SERVER_CLIENT_ID }}
           GOOGLE_AUTH_SERVER_CLIENT_ID_STAGING: ${{ secrets.GOOGLE_AUTH_SERVER_CLIENT_ID_STAGING }}
           GOOGLE_AI_CLIENT_GENERATIVEAI_API_KEY_STAGING: ${{ secrets.GOOGLE_AI_CLIENT_GENERATIVEAI_API_KEY_STAGING }}
           GOOGLE_MAPS_ANDROID_API_KEY_STAGING: ${{ secrets.GOOGLE_MAPS_ANDROID_API_KEY_STAGING }}
@@ -53,7 +54,8 @@ jobs:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
-          echo google.auth.server.client.id=$GOOGLE_AUTH_SERVER_CLIENT_ID_STAGING > ./local.properties
+          echo google.auth.server.client.id=$GOOGLE_AUTH_SERVER_CLIENT_ID > ./local.properties
+          echo google.auth.server.client.id.staging=$GOOGLE_AUTH_SERVER_CLIENT_ID_STAGING >> ./local.properties
           echo google.ai.client.generativeai.api.key=$GOOGLE_AI_CLIENT_GENERATIVEAI_API_KEY_STAGING >> ./local.properties
           echo google.maps.android.api.key.staging=$GOOGLE_MAPS_ANDROID_API_KEY_STAGING >> ./local.properties
           echo google.maps.android.api.key.production=$GOOGLE_MAPS_ANDROID_API_KEY_PRODUCTION >> ./local.properties

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,12 @@
 - Open feature/tranche PRs into `develop`.
 - Merge `develop` into `master` only when preparing a release.
 - Release flow is: open PR `develop -> master`, wait for green checks, merge, deploy Android and web from `master`, then bump `version.properties` on `develop` to the next version before resuming feature work.
+- Before opening a release PR, inspect the changes since the last released `master` and adjust `version.properties` on `develop` if needed:
+  - Use semantic versioning for `product.version`.
+  - `MAJOR` changes are reserved for breaking compatibility or intentionally disruptive product/API shifts.
+  - If the release includes at least one new feature and no breaking change, bump `MINOR` and reset `PATCH` to `0`.
+  - If the release only contains bugfixes, polish, docs, or operational fixes, bump `PATCH`.
+  - After a successful release, bump `develop` to the next default patch development version unless the next tranche is already known to require a minor or major bump.
 - Tags and deploys happen from the release state on `master`, not from feature branches.
 - If work is merged to `master` by mistake, bring `develop` forward before starting the next branch.
 - Never use PR auto-delete or `gh pr merge --delete-branch` when the PR head branch is `develop` or `master`.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ Each feature or library follows the same general split when needed:
 
 Local Android and product-specific keys live in `local.properties`. Typical entries include:
 
-- `google.auth.server.client.id`
+- `google.auth.server.client.id` for production
+- `google.auth.server.client.id.staging` for staging
 - `google.maps.android.api.key.staging`
 - `google.maps.android.api.key.production`
 - `google.ai.client.generativeai.api.key.staging`

--- a/features/authentication/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/authentication/presentation/mvi/compose/AuthenticationViewState.kt
+++ b/features/authentication/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/authentication/presentation/mvi/compose/AuthenticationViewState.kt
@@ -46,10 +46,6 @@ data class AuthenticationViewState(
     fun Compose(intent: (AuthenticationIntent) -> Unit) {
         val snackbarHostState = remember { SnackbarHostState() }
         val scope = rememberCoroutineScope()
-        val genericErrorMessage = stringResource(
-            com.feragusper.smokeanalytics.libraries.design.mobile.R.string.error_general
-        )
-
         Scaffold(
             snackbarHost = { SnackbarHost(snackbarHostState) },
         ) { contentPadding ->
@@ -66,8 +62,8 @@ data class AuthenticationViewState(
                     item {
                         AuthEntryCard(
                             onRefresh = { intent(AuthenticationIntent.FetchUser) },
-                            onSignInError = {
-                                scope.launch { snackbarHostState.showSnackbar(genericErrorMessage) }
+                            onSignInError = { message ->
+                                scope.launch { snackbarHostState.showSnackbar(message) }
                             },
                         )
                     }
@@ -156,7 +152,7 @@ private fun AuthHeroCard() {
 @Composable
 private fun AuthEntryCard(
     onRefresh: () -> Unit,
-    onSignInError: () -> Unit,
+    onSignInError: (String) -> Unit,
 ) {
     Card(
         shape = RoundedCornerShape(24.dp),

--- a/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/GoalsEditorScreen.kt
+++ b/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/GoalsEditorScreen.kt
@@ -40,10 +40,12 @@ fun GoalsEditorScreen(
     goalProgress: GoalProgress?,
     displayLoading: Boolean,
     errorMessage: String? = null,
+    signInErrorMessage: String? = null,
     onBack: () -> Unit,
     onSaveGoal: (SmokingGoal) -> Unit,
     onClearGoal: () -> Unit,
     onSignInSuccess: () -> Unit,
+    onSignInError: (String) -> Unit,
 ) {
     var selectedType by remember(preferences.activeGoal) {
         mutableStateOf(preferences.activeGoal?.type ?: GoalType.DailyCap)
@@ -120,10 +122,33 @@ fun GoalsEditorScreen(
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
+                    signInErrorMessage?.let { message ->
+                        Card(
+                            shape = androidx.compose.foundation.shape.RoundedCornerShape(24.dp),
+                            colors = CardDefaults.cardColors(
+                                containerColor = MaterialTheme.colorScheme.errorContainer,
+                                contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                            ),
+                        ) {
+                            Column(
+                                modifier = Modifier.padding(18.dp),
+                                verticalArrangement = Arrangement.spacedBy(10.dp),
+                            ) {
+                                Text(
+                                    text = "Sign-in failed",
+                                    style = MaterialTheme.typography.titleMedium,
+                                )
+                                Text(
+                                    text = message,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                )
+                            }
+                        }
+                    }
                     GoogleSignInComponent(
                         modifier = Modifier.fillMaxWidth(),
                         onSignInSuccess = onSignInSuccess,
-                        onSignInError = {},
+                        onSignInError = onSignInError,
                     )
                 }
             }

--- a/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/mvi/compose/SettingsViewState.kt
+++ b/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/mvi/compose/SettingsViewState.kt
@@ -86,9 +86,13 @@ data class SettingsViewState(
     ) {
         var draftPreferences by remember(currentEmail, preferences) { mutableStateOf(preferences) }
         var showingGoals by remember(currentEmail, preferences.activeGoal) { mutableStateOf(false) }
+        var signInErrorMessage by remember { mutableStateOf<String?>(null) }
 
         LaunchedEffect(preferences, currentEmail) {
             draftPreferences = preferences
+            if (currentEmail != null) {
+                signInErrorMessage = null
+            }
         }
 
         if (showingGoals) {
@@ -108,6 +112,8 @@ data class SettingsViewState(
                     intent(SettingsIntent.UpdatePreferences(draftPreferences.copy(activeGoal = null)))
                 },
                 onSignInSuccess = { intent(SettingsIntent.FetchUser) },
+                onSignInError = { signInErrorMessage = it },
+                signInErrorMessage = signInErrorMessage,
             )
             return
         }
@@ -151,8 +157,10 @@ data class SettingsViewState(
                 currentEmail = currentEmail,
                 currentDisplayName = currentDisplayName,
                 displayLoading = displayLoading,
+                signInErrorMessage = signInErrorMessage,
                 onSignOut = { intent(SettingsIntent.SignOut) },
                 onSignInSuccess = { intent(SettingsIntent.FetchUser) },
+                onSignInError = { signInErrorMessage = it },
             )
 
             HighlightsRow(tier = preferences.accountTier)
@@ -207,7 +215,8 @@ data class SettingsViewState(
 @Composable
 private fun SettingsErrorCard(
     message: String,
-    onRetry: () -> Unit,
+    onRetry: (() -> Unit)? = null,
+    title: String = "Your space is unavailable",
 ) {
     Card(
         shape = RoundedCornerShape(24.dp),
@@ -221,7 +230,7 @@ private fun SettingsErrorCard(
             verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
             Text(
-                text = "Your space is unavailable",
+                text = title,
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
             )
@@ -229,8 +238,10 @@ private fun SettingsErrorCard(
                 text = message,
                 style = MaterialTheme.typography.bodyMedium,
             )
-            Button(onClick = onRetry) {
-                Text("Retry")
+            if (onRetry != null) {
+                Button(onClick = onRetry) {
+                    Text("Retry")
+                }
             }
         }
     }
@@ -449,8 +460,10 @@ private fun SessionCard(
     currentEmail: String?,
     currentDisplayName: String?,
     displayLoading: Boolean,
+    signInErrorMessage: String?,
     onSignOut: () -> Unit,
     onSignInSuccess: () -> Unit,
+    onSignInError: (String) -> Unit,
 ) {
     SettingsCard(
         title = "Session",
@@ -534,12 +547,19 @@ private fun SessionCard(
                     body = "Give the guide enough recent behavior to stay grounded instead of generic.",
                 )
 
+                signInErrorMessage?.let { message ->
+                    SettingsErrorCard(
+                        title = "Sign-in failed",
+                        message = message,
+                    )
+                }
+
                 GoogleSignInComponent(
                     modifier = Modifier
                         .fillMaxWidth()
                         .testTag(SettingsViewState.TestTags.BUTTON_SIGN_IN),
                     onSignInSuccess = onSignInSuccess,
-                    onSignInError = {},
+                    onSignInError = onSignInError,
                 )
             }
         }

--- a/libraries/authentication/presentation/mobile/build.gradle.kts
+++ b/libraries/authentication/presentation/mobile/build.gradle.kts
@@ -1,5 +1,14 @@
 import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 
+val localProperties = gradleLocalProperties(rootDir, providers)
+val requestedTasks = gradle.startParameter.taskNames.joinToString(" ").lowercase()
+val googleAuthServerClientId = when {
+    "staging" in requestedTasks -> localProperties.getProperty("google.auth.server.client.id.staging")
+        ?: localProperties.getProperty("google.auth.server.client.id")
+
+    else -> localProperties.getProperty("google.auth.server.client.id")
+}.orEmpty()
+
 plugins {
     // Use the predefined android-lib plugin for Android library modules.
     `android-lib`
@@ -20,9 +29,7 @@ android {
         buildConfigField(
             "String",
             "GOOGLE_AUTH_SERVER_CLIENT_ID",
-            gradleLocalProperties(rootDir, providers)
-                .getProperty("google.auth.server.client.id")
-                .asBuildConfigString(),
+            googleAuthServerClientId.asBuildConfigString(),
         )
     }
 

--- a/libraries/authentication/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/authentication/presentation/compose/GoogleSignInComponent.kt
+++ b/libraries/authentication/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/authentication/presentation/compose/GoogleSignInComponent.kt
@@ -55,7 +55,7 @@ import java.util.UUID
 fun GoogleSignInComponent(
     modifier: Modifier = Modifier,
     onSignInSuccess: () -> Unit,
-    onSignInError: () -> Unit,
+    onSignInError: (String) -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
@@ -109,8 +109,13 @@ private fun doGoogleSignIn(
     context: Context,
     startAddAccountIntentLauncher: ManagedActivityResultLauncher<Intent, ActivityResult>?,
     onSignInSuccess: () -> Unit,
-    onSignInError: () -> Unit
+    onSignInError: (String) -> Unit,
 ) {
+    if (BuildConfig.GOOGLE_AUTH_SERVER_CLIENT_ID.isBlank()) {
+        onSignInError("Google sign-in is not configured for this app build: missing server client id.")
+        return
+    }
+
     val credentialManager = CredentialManager.create(context)
 
     // Create Google ID Option for sign-in
@@ -136,10 +141,14 @@ private fun doGoogleSignIn(
         } catch (e: NoCredentialException) {
             Timber.e(e, "No credentials found")
             // Prompt user to add Google account if no credentials are available
-            startAddAccountIntentLauncher?.launch(getAddGoogleAccountIntent())
+            if (startAddAccountIntentLauncher != null) {
+                startAddAccountIntentLauncher.launch(getAddGoogleAccountIntent())
+            } else {
+                onSignInError("No Google account is available on this device. Add an account and try again.")
+            }
         } catch (e: Exception) {
             Timber.e(e, "Unexpected error during sign-in")
-            onSignInError()
+            onSignInError(e.toUserVisibleSignInMessage())
         }
     }
 }
@@ -154,7 +163,7 @@ private fun doGoogleSignIn(
 private suspend fun handleSignIn(
     result: GetCredentialResponse,
     onSignInSuccess: () -> Unit,
-    onSignInError: () -> Unit
+    onSignInError: (String) -> Unit,
 ) {
     val credential = result.credential
 
@@ -172,21 +181,35 @@ private suspend fun handleSignIn(
                     onSignInSuccess()
                 } catch (e: GoogleIdTokenParsingException) {
                     Timber.e(e, "Invalid Google ID Token")
-                    onSignInError()
+                    onSignInError("Google returned an invalid sign-in token. Try again.")
                 } catch (e: Exception) {
                     Timber.e(e, "Unexpected error during sign-in")
-                    onSignInError()
+                    onSignInError(e.toUserVisibleSignInMessage())
                 }
             } else {
                 Timber.e("Unexpected credential type")
-                onSignInError()
+                onSignInError("Google returned an unsupported credential type. Try again.")
             }
         }
 
         else -> {
             Timber.e("Credential is not of the expected type")
-            onSignInError()
+            onSignInError("Google returned an unsupported credential. Try again.")
         }
+    }
+}
+
+private fun Throwable.toUserVisibleSignInMessage(): String {
+    val detail = message.orEmpty()
+    return when {
+        detail.contains("28444") || detail.contains("Developer console is not set up correctly", ignoreCase = true) ->
+            "Google sign-in is not configured for this app build ([28444]). Check the OAuth client, package name, and signing certificate in Google Cloud/Firebase."
+
+        detail.isNotBlank() ->
+            "Google sign-in failed: $detail"
+
+        else ->
+            "Google sign-in failed (${javaClass.simpleName}). Try again."
     }
 }
 

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-product.version=0.14.1
+product.version=0.14.2


### PR DESCRIPTION
## Release 0.14.2

Patch release with mobile auth/config fixes and release-process hygiene.

### Included
- Show Google Sign-In failures visibly on mobile auth, settings, and goals flows instead of swallowing errors.
- Separate production and staging Google auth server client ids in mobile auth config.
- Align GitHub Actions local.properties generation for production/staging auth keys.
- Document semantic version bump policy for future releases.

### Release metadata
- Android version: 0.14.2.382
- Android tag: android/v0.14.2.382
- Web version: 0.14.2+web.382
- Web tag: web/v0.14.2+web.382

### Validation
- PR #250 Integration passed.
- PR #251 Integration passed.
- ./gradlew :apps:mobile:compileProductionDebugKotlin
- ./gradlew :apps:mobile:compileStagingDebugKotlin
- ./gradlew -q :apps:mobile:printAndroidVersionName
- ./gradlew -q :apps:mobile:printAndroidReleaseTag
- ./gradlew -q :apps:web:printWebVersionName -Psmoke.env=prod
- ./gradlew -q :apps:web:printWebReleaseTag -Psmoke.env=prod

### External follow-up
- Validate Firebase/Google Cloud OAuth SHA fingerprints for local productionDebug and Play Store installs in #253.