### PR TITLE
Show verbose mobile track diagnostics

### DIFF
--- a/apps/mobile/src/main/java/com/feragusper/smokeanalytics/MainActivity.kt
+++ b/apps/mobile/src/main/java/com/feragusper/smokeanalytics/MainActivity.kt
@@ -3,6 +3,7 @@ package com.feragusper.smokeanalytics
 import android.content.Intent
 import android.os.Bundle
 import android.view.animation.OvershootInterpolator
+import android.widget.Toast
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.ComponentActivity
@@ -40,6 +41,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -259,11 +261,26 @@ private fun MainContainerScreen(
         BottomNavigationScreens.You,
     )
     val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
 
     var fabAction by remember { mutableStateOf<(() -> Unit)?>(null) }
     var showFab by remember { mutableStateOf(false) }
     var fabTone by remember { mutableStateOf(ElapsedTone.Urgent) }
     var lastHandledWidgetQuickAdd by remember { mutableStateOf(0) }
+
+    fun runHomeTrackAction(source: String): Boolean {
+        val action = fabAction
+        if (action == null) {
+            Toast.makeText(
+                context,
+                "Track $source ignored: Home action is not ready. route=${activeRoute ?: "none"} showFab=$showFab",
+                Toast.LENGTH_LONG,
+            ).show()
+            return false
+        }
+        action()
+        return true
+    }
 
     LaunchedEffect(widgetQuickAddRequestId, activeRoute, fabAction) {
         if (widgetQuickAddRequestId == 0 || widgetQuickAddRequestId == lastHandledWidgetQuickAdd) return@LaunchedEffect
@@ -277,9 +294,9 @@ private fun MainContainerScreen(
             }
             return@LaunchedEffect
         }
-        val action = fabAction ?: return@LaunchedEffect
-        action()
-        lastHandledWidgetQuickAdd = widgetQuickAddRequestId
+        if (runHomeTrackAction("from widget")) {
+            lastHandledWidgetQuickAdd = widgetQuickAddRequestId
+        }
     }
 
     if (inAppUpdatePrompt != null) {
@@ -309,7 +326,7 @@ private fun MainContainerScreen(
             ) {
                 ExtendedFloatingActionButton(
                     modifier = Modifier.testTag(BUTTON_ADD_SMOKE),
-                    onClick = { fabAction?.invoke() },
+                    onClick = { runHomeTrackAction("from FAB") },
                     containerColor = fabTone.buttonContainerColor(),
                     contentColor = fabTone.contentColor(),
                     elevation = FloatingActionButtonDefaults.elevation(

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/HomeViewModel.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/HomeViewModel.kt
@@ -172,7 +172,13 @@ class HomeViewModel @Inject constructor(
             DeleteSmokeSuccess, EditSmokeSuccess, AddSmokeSuccess, StartNewDaySuccess -> {
                 // Re-fetch smokes when adding, editing, or deleting a smoke.
                 intents().trySend(HomeIntent.FetchSmokes)
-                previous
+                previous.copy(
+                    displayLoading = false,
+                    displayRefreshLoading = false,
+                    error = null,
+                    toastMessage = if (result == AddSmokeSuccess) "Track saved successfully." else previous.toastMessage,
+                    toastNonce = if (result == AddSmokeSuccess) previous.toastNonce + 1 else previous.toastNonce,
+                )
             }
 
             is Error -> previous.copy(
@@ -184,7 +190,12 @@ class HomeViewModel @Inject constructor(
             FetchSmokesError -> previous.copy(
                 displayLoading = false,
                 displayRefreshLoading = false,
-                error = Error.Generic,
+                error = Error.Generic(),
+            )
+
+            is HomeResult.TrackFeedback -> previous.copy(
+                toastMessage = result.message,
+                toastNonce = previous.toastNonce + 1,
             )
         }
 }

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/HomeResult.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/HomeResult.kt
@@ -52,6 +52,13 @@ sealed interface HomeResult : MVIResult {
     data object AddSmokeSuccess : HomeResult
 
     /**
+     * Emits visible diagnostic feedback for the mobile quick track flow.
+     */
+    data class TrackFeedback(
+        val message: String,
+    ) : HomeResult
+
+    /**
      * Indicates that the current day was manually restarted.
      */
     data object StartNewDaySuccess : HomeResult
@@ -73,7 +80,9 @@ sealed interface HomeResult : MVIResult {
         /**
          * A generic error result.
          */
-        data object Generic : Error
+        data class Generic(
+            val debugMessage: String? = null,
+        ) : Error
 
         /**
          * Error indicating that the user is not logged in.

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
@@ -1,5 +1,7 @@
 package com.feragusper.smokeanalytics.features.home.presentation.mvi.compose
 
+import android.widget.Toast
+
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.VectorConverter
@@ -38,6 +40,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -84,6 +87,8 @@ data class HomeViewState(
     internal val canStartNewDay: Boolean = false,
     internal val elapsedTone: ElapsedTone = ElapsedTone.Urgent,
     internal val error: HomeResult.Error? = null,
+    internal val toastMessage: String? = null,
+    internal val toastNonce: Int = 0,
 ) : MVIViewState<HomeIntent> {
 
     internal val lastSmokeTimeLabel: String?
@@ -118,6 +123,13 @@ data class HomeViewState(
                 override suspend fun snapTo(targetValue: Float) {
                     anim.snapTo(targetValue)
                 }
+            }
+        }
+        val context = LocalContext.current
+
+        LaunchedEffect(toastNonce) {
+            toastMessage?.let {
+                Toast.makeText(context, it, Toast.LENGTH_LONG).show()
             }
         }
 
@@ -309,13 +321,14 @@ private fun HomeErrorSection(
             verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
             Text(
-                text = if (error == HomeResult.Error.NotLoggedIn) "Session required" else "Could not refresh home",
+                text = if (error == HomeResult.Error.NotLoggedIn) "Session required" else "Could not complete action",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
             )
             Text(
                 text = when {
                     error == HomeResult.Error.NotLoggedIn -> "Sign in again to keep Home, goals, and the latest gap synced."
+                    error is HomeResult.Error.Generic && error.debugMessage != null -> error.debugMessage
                     hasLoadedContent -> "Keeping the last visible state. Retry when the connection or quota recovers."
                     else -> "Home could not load your smoke data. Retry when the connection or quota recovers."
                 },

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
@@ -132,8 +132,9 @@ class HomeProcessHolder @Inject constructor(
                 widgetRefreshService.refreshHomeSnapshot(smokeCounts.toWidgetSnapshot(preferences))
             }
         }
-    }.catchAndLog {
+    }.catchAndLog { e ->
         emit(HomeResult.FetchSmokesError)
+        emit(HomeResult.TrackFeedback("Home refresh failed: ${e.debugSummary()}"))
     }
 
     /**
@@ -146,10 +147,11 @@ class HomeProcessHolder @Inject constructor(
         emit(HomeResult.Loading)
         deleteSmokeUseCase.invoke(intent.id)
         emit(HomeResult.DeleteSmokeSuccess)
-        refreshWidgetSnapshotBestEffort()
-        syncWithWearBestEffort()
-    }.catchAndLog {
-        emit(HomeResult.Error.Generic)
+        refreshWidgetSnapshotBestEffort()?.let { emit(HomeResult.TrackFeedback("Delete saved, but widget refresh failed: $it")) }
+        syncWithWearBestEffort()?.let { emit(HomeResult.TrackFeedback("Delete saved, but Wear sync failed: $it")) }
+    }.catchAndLog { e ->
+        emit(HomeResult.Error.Generic(e.debugSummary()))
+        emit(HomeResult.TrackFeedback("Delete failed: ${e.debugSummary()}"))
     }
 
     /**
@@ -162,10 +164,11 @@ class HomeProcessHolder @Inject constructor(
         emit(HomeResult.Loading)
         editSmokeUseCase.invoke(intent.id, intent.date)
         emit(HomeResult.EditSmokeSuccess)
-        refreshWidgetSnapshotBestEffort()
-        syncWithWearBestEffort()
-    }.catchAndLog {
-        emit(HomeResult.Error.Generic)
+        refreshWidgetSnapshotBestEffort()?.let { emit(HomeResult.TrackFeedback("Edit saved, but widget refresh failed: $it")) }
+        syncWithWearBestEffort()?.let { emit(HomeResult.TrackFeedback("Edit saved, but Wear sync failed: $it")) }
+    }.catchAndLog { e ->
+        emit(HomeResult.Error.Generic(e.debugSummary()))
+        emit(HomeResult.TrackFeedback("Edit failed: ${e.debugSummary()}"))
     }
 
     /**
@@ -191,30 +194,44 @@ class HomeProcessHolder @Inject constructor(
      * @return A [Flow] emitting the result of the add operation.
      */
     private fun processAddSmoke(): Flow<HomeResult> = flow {
+        Timber.i("Track smoke requested from Home")
+        emit(HomeResult.TrackFeedback("Track requested. Checking session..."))
         when (fetchSessionUseCase()) {
             is Session.Anonymous -> {
+                Timber.w("Track smoke blocked: anonymous session")
                 emit(HomeResult.Error.NotLoggedIn)
+                emit(HomeResult.TrackFeedback("Track failed: no active session. Opening sign in."))
                 emit(HomeResult.GoToAuthentication)
             }
 
             is Session.LoggedIn -> {
                 emit(HomeResult.Loading)
+                emit(HomeResult.TrackFeedback("Session ok. Reading preferences..."))
                 val preferences = fetchUserPreferencesUseCase()
+                Timber.i("Track smoke preferences loaded: locationTrackingEnabled=${preferences.locationTrackingEnabled}")
                 val location = if (preferences.locationTrackingEnabled) {
+                    emit(HomeResult.TrackFeedback("Location tracking enabled. Capturing location..."))
                     locationCaptureService.captureCurrentLocation()?.let {
+                        Timber.i("Track smoke location captured")
                         GeoPoint(latitude = it.latitude, longitude = it.longitude)
                     }
                 } else {
+                    Timber.i("Track smoke location capture skipped: disabled")
                     null
                 }
+                emit(HomeResult.TrackFeedback("Saving smoke to Firestore..."))
                 addSmokeUseCase.invoke(location = location)
+                Timber.i("Track smoke saved successfully")
                 emit(HomeResult.AddSmokeSuccess)
-                refreshWidgetSnapshotBestEffort()
-                syncWithWearBestEffort()
+                emit(HomeResult.TrackFeedback("Track saved. Refreshing home, widget, and Wear sync..."))
+                refreshWidgetSnapshotBestEffort()?.let { emit(HomeResult.TrackFeedback("Track saved, but widget refresh failed: $it")) }
+                syncWithWearBestEffort()?.let { emit(HomeResult.TrackFeedback("Track saved, but Wear sync failed: $it")) }
             }
         }
-    }.catchAndLog {
-        emit(HomeResult.Error.Generic)
+    }.catchAndLog { e ->
+        Timber.e(e, "Track smoke failed")
+        emit(HomeResult.Error.Generic(e.debugSummary()))
+        emit(HomeResult.TrackFeedback("Track failed: ${e.debugSummary()}"))
     }
 
     private fun processStartNewDay(): Flow<HomeResult> = flow {
@@ -224,8 +241,9 @@ class HomeProcessHolder @Inject constructor(
             preferences.copy(manualDayStartEpochMillis = kotlinx.datetime.Clock.System.now().toEpochMilliseconds())
         )
         emit(HomeResult.StartNewDaySuccess)
-    }.catchAndLog {
-        emit(HomeResult.Error.Generic)
+    }.catchAndLog { e ->
+        emit(HomeResult.Error.Generic(e.debugSummary()))
+        emit(HomeResult.TrackFeedback("Start new day failed: ${e.debugSummary()}"))
     }
 
     private suspend fun refreshWidgetSnapshot() {
@@ -237,14 +255,29 @@ class HomeProcessHolder @Inject constructor(
         widgetRefreshService.refreshHomeSnapshot(smokeCounts.toWidgetSnapshot(preferences))
     }
 
-    private suspend fun refreshWidgetSnapshotBestEffort() {
-        runCatching { refreshWidgetSnapshot() }
-            .onFailure { Timber.w(it, "Home mutation succeeded but widget refresh failed") }
+    private suspend fun refreshWidgetSnapshotBestEffort(): String? {
+        return runCatching { refreshWidgetSnapshot() }
+            .onFailure { Timber.w(it, "Home mutation succeeded but widget refresh failed: ${it.debugSummary()}") }
+            .exceptionOrNull()
+            ?.debugSummary()
     }
 
-    private suspend fun syncWithWearBestEffort() {
-        runCatching { syncWithWearUseCase.invoke() }
-            .onFailure { Timber.w(it, "Home mutation succeeded but Wear sync failed") }
+    private suspend fun syncWithWearBestEffort(): String? {
+        return runCatching { syncWithWearUseCase.invoke() }
+            .onFailure { Timber.w(it, "Home mutation succeeded but Wear sync failed: ${it.debugSummary()}") }
+            .exceptionOrNull()
+            ?.debugSummary()
+    }
+}
+
+private fun Throwable.debugSummary(): String {
+    val type = this::class.simpleName ?: "Throwable"
+    val message = message?.takeIf { it.isNotBlank() } ?: cause?.message?.takeIf { it.isNotBlank() }
+    val causeType = cause?.let { it::class.simpleName }?.takeIf { it != type }
+    return buildString {
+        append(type)
+        if (causeType != null) append(" caused by ").append(causeType)
+        if (message != null) append(": ").append(message)
     }
 }
 

--- a/features/home/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolderTest.kt
+++ b/features/home/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolderTest.kt
@@ -78,7 +78,7 @@ class HomeProcessHolderTest {
         coEvery { fetchUserPreferencesUseCase() } returns UserPreferences()
         coEvery { updateUserPreferencesUseCase.invoke(any()) } just Runs
         coEvery { locationCaptureService.captureCurrentLocation() } returns null
-        coEvery { fetchSmokeCountListUseCase.invoke(any()) } returns SmokeCountListResult(emptyList(), 0, 0, null)
+        coEvery { fetchSmokeCountListUseCase.invoke(any(), any()) } returns SmokeCountListResult(emptyList(), 0, 0, null)
         coEvery { fetchSmokesUseCase.invoke(any(), any()) } returns emptyList()
         coEvery { widgetRefreshService.refreshHomeSnapshot(any()) } just Runs
     }
@@ -102,8 +102,12 @@ class HomeProcessHolderTest {
             coEvery { addSmokeUseCase.invoke(any()) } just Runs
 
             processHolder.processIntent(HomeIntent.AddSmoke).test {
+                awaitItem() shouldBeEqualTo HomeResult.TrackFeedback("Track requested. Checking session...")
                 awaitItem() shouldBeEqualTo HomeResult.Loading
+                awaitItem() shouldBeEqualTo HomeResult.TrackFeedback("Session ok. Reading preferences...")
+                awaitItem() shouldBeEqualTo HomeResult.TrackFeedback("Saving smoke to Firestore...")
                 awaitItem() shouldBeEqualTo HomeResult.AddSmokeSuccess
+                awaitItem() shouldBeEqualTo HomeResult.TrackFeedback("Track saved. Refreshing home, widget, and Wear sync...")
                 coVerify(exactly = 1) { syncWithWearUseCase.invoke() }
                 awaitComplete()
             }
@@ -138,11 +142,15 @@ class HomeProcessHolderTest {
 
         @Test
         fun `WHEN adding smoke fails THEN it returns error`() = runTest {
-            coEvery { addSmokeUseCase() } throws IllegalStateException("Error")
+            coEvery { addSmokeUseCase.invoke(any()) } throws IllegalStateException("Error")
 
             processHolder.processIntent(HomeIntent.AddSmoke).test {
+                awaitItem() shouldBeEqualTo HomeResult.TrackFeedback("Track requested. Checking session...")
                 awaitItem() shouldBeEqualTo HomeResult.Loading
-                awaitItem() shouldBeEqualTo HomeResult.Error.Generic
+                awaitItem() shouldBeEqualTo HomeResult.TrackFeedback("Session ok. Reading preferences...")
+                awaitItem() shouldBeEqualTo HomeResult.TrackFeedback("Saving smoke to Firestore...")
+                awaitItem() shouldBeEqualTo HomeResult.Error.Generic("IllegalStateException: Error")
+                awaitItem() shouldBeEqualTo HomeResult.TrackFeedback("Track failed: IllegalStateException: Error")
                 coVerify(exactly = 0) { syncWithWearUseCase.invoke() }
                 awaitComplete()
             }
@@ -151,11 +159,18 @@ class HomeProcessHolderTest {
         @Test
         fun `WHEN widget refresh fails after adding smoke THEN tracking still succeeds`() = runTest {
             coEvery { addSmokeUseCase.invoke(any()) } just Runs
-            coEvery { fetchSmokeCountListUseCase.invoke(any()) } throws IllegalStateException("Quota exceeded")
+            coEvery { fetchSmokeCountListUseCase.invoke(any(), any()) } throws IllegalStateException("Quota exceeded")
 
             processHolder.processIntent(HomeIntent.AddSmoke).test {
+                awaitItem() shouldBeEqualTo HomeResult.TrackFeedback("Track requested. Checking session...")
                 awaitItem() shouldBeEqualTo HomeResult.Loading
+                awaitItem() shouldBeEqualTo HomeResult.TrackFeedback("Session ok. Reading preferences...")
+                awaitItem() shouldBeEqualTo HomeResult.TrackFeedback("Saving smoke to Firestore...")
                 awaitItem() shouldBeEqualTo HomeResult.AddSmokeSuccess
+                awaitItem() shouldBeEqualTo HomeResult.TrackFeedback("Track saved. Refreshing home, widget, and Wear sync...")
+                awaitItem() shouldBeEqualTo HomeResult.TrackFeedback(
+                    "Track saved, but widget refresh failed: IllegalStateException: Quota exceeded"
+                )
                 coVerify(exactly = 1) { syncWithWearUseCase.invoke() }
                 awaitComplete()
             }
@@ -168,6 +183,7 @@ class HomeProcessHolderTest {
             processHolder.processIntent(HomeIntent.FetchSmokes).test {
                 awaitItem() shouldBeEqualTo HomeResult.Loading
                 awaitItem() shouldBeEqualTo HomeResult.FetchSmokesError
+                awaitItem() shouldBeEqualTo HomeResult.TrackFeedback("Home refresh failed: IllegalStateException: Quota exceeded")
                 awaitComplete()
             }
         }
@@ -180,7 +196,8 @@ class HomeProcessHolderTest {
 
             processHolder.processIntent(HomeIntent.EditSmoke(id, date)).test {
                 awaitItem() shouldBeEqualTo HomeResult.Loading
-                awaitItem() shouldBeEqualTo HomeResult.Error.Generic
+                awaitItem() shouldBeEqualTo HomeResult.Error.Generic("IllegalStateException: Error")
+                awaitItem() shouldBeEqualTo HomeResult.TrackFeedback("Edit failed: IllegalStateException: Error")
                 coVerify(exactly = 0) { syncWithWearUseCase.invoke() }
                 awaitComplete()
             }
@@ -193,7 +210,8 @@ class HomeProcessHolderTest {
 
             processHolder.processIntent(HomeIntent.DeleteSmoke(id)).test {
                 awaitItem() shouldBeEqualTo HomeResult.Loading
-                awaitItem() shouldBeEqualTo HomeResult.Error.Generic
+                awaitItem() shouldBeEqualTo HomeResult.Error.Generic("IllegalStateException: Error")
+                awaitItem() shouldBeEqualTo HomeResult.TrackFeedback("Delete failed: IllegalStateException: Error")
                 coVerify(exactly = 0) { syncWithWearUseCase.invoke() }
                 awaitComplete()
             }
@@ -212,7 +230,9 @@ class HomeProcessHolderTest {
         @Test
         fun `WHEN adding smoke THEN it returns not logged in error`() = runTest {
             processHolder.processIntent(HomeIntent.AddSmoke).test {
+                awaitItem() shouldBeEqualTo HomeResult.TrackFeedback("Track requested. Checking session...")
                 awaitItem() shouldBeEqualTo HomeResult.Error.NotLoggedIn
+                awaitItem() shouldBeEqualTo HomeResult.TrackFeedback("Track failed: no active session. Opening sign in.")
                 awaitItem() shouldBeEqualTo HomeResult.GoToAuthentication
                 coVerify(exactly = 0) { syncWithWearUseCase.invoke() }
                 awaitComplete()


### PR DESCRIPTION
## Summary
- Add visible Toast diagnostics for each mobile Track stage and failure.
- Surface exception class/message in Home error state instead of silent empty/no-op UX.
- Show an explicit Toast when FAB/widget track action is not registered yet, preserving widget retry.

## Verification
- ./gradlew :features:home:presentation:mobile:testDebugUnitTest
- ./gradlew :apps:mobile:compileProductionReleaseKotlin
- git diff --check