### PR TITLE
Fix Play Store Firebase config handling

### DIFF
--- a/.github/workflows/deployment_playstore.yml
+++ b/.github/workflows/deployment_playstore.yml
@@ -39,15 +39,23 @@ jobs:
           echo "✅ local.properties configured for production."
 
           mkdir -p ./apps/mobile/src/production/
-          echo "$GOOGLE_SERVICES_JSON" > ./apps/mobile/src/production/google-services.json.asc
-          gpg -d --passphrase "$GPG_PASSPHRASE" --batch ./apps/mobile/src/production/google-services.json.asc > ./apps/mobile/src/production/google-services.json
+          echo "$GOOGLE_SERVICES_JSON" > ./apps/mobile/src/production/google-services.json.input
+          if grep -q '"project_info"' ./apps/mobile/src/production/google-services.json.input; then
+            cp ./apps/mobile/src/production/google-services.json.input ./apps/mobile/src/production/google-services.json
+          else
+            gpg -d --passphrase "$GPG_PASSPHRASE" --batch ./apps/mobile/src/production/google-services.json.input > ./apps/mobile/src/production/google-services.json
+          fi
 
           if [ ! -s ./apps/mobile/src/production/google-services.json ]; then
             echo "❌ Decryption failed or file is empty (production)!"
             exit 1
           fi
 
-          echo "✅ Production google-services.json decrypted."
+          echo "✅ Production google-services.json prepared."
+          echo "Firebase production project_id=$(jq -r '.project_info.project_id' ./apps/mobile/src/production/google-services.json)"
+          echo "Firebase production app_id=$(jq -r '.client[0].client_info.mobilesdk_app_id' ./apps/mobile/src/production/google-services.json)"
+          echo "Firebase production package=$(jq -r '.client[0].client_info.android_client_info.package_name' ./apps/mobile/src/production/google-services.json)"
+          echo "Firebase production oauth_sha1=$(jq -r '[.client[0].oauth_client[]? | select(.client_type == 1) | .android_info.certificate_hash] | join(",")' ./apps/mobile/src/production/google-services.json)"
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -71,12 +71,22 @@ jobs:
           fi
 
           mkdir -p ./apps/mobile/src/production/
-          echo "$GOOGLE_SERVICES_JSON" > ./apps/mobile/src/production/google-services.json.asc
-          gpg -d --passphrase "$GPG_PASSPHRASE" --batch ./apps/mobile/src/production/google-services.json.asc > ./apps/mobile/src/production/google-services.json
+          echo "$GOOGLE_SERVICES_JSON" > ./apps/mobile/src/production/google-services.json.input
+          if grep -q '"project_info"' ./apps/mobile/src/production/google-services.json.input; then
+            cp ./apps/mobile/src/production/google-services.json.input ./apps/mobile/src/production/google-services.json
+          else
+            gpg -d --passphrase "$GPG_PASSPHRASE" --batch ./apps/mobile/src/production/google-services.json.input > ./apps/mobile/src/production/google-services.json
+          fi
           if [ ! -s ./apps/mobile/src/production/google-services.json ]; then
             echo "❌ Decryption failed or file is empty (production)!"
             exit 1
           fi
+
+          echo "✅ Production google-services.json prepared."
+          echo "Firebase production project_id=$(jq -r '.project_info.project_id' ./apps/mobile/src/production/google-services.json)"
+          echo "Firebase production app_id=$(jq -r '.client[0].client_info.mobilesdk_app_id' ./apps/mobile/src/production/google-services.json)"
+          echo "Firebase production package=$(jq -r '.client[0].client_info.android_client_info.package_name' ./apps/mobile/src/production/google-services.json)"
+          echo "Firebase production oauth_sha1=$(jq -r '[.client[0].oauth_client[]? | select(.client_type == 1) | .android_info.certificate_hash] | join(",")' ./apps/mobile/src/production/google-services.json)"
 
       - name: Validate coach relay function syntax
         run: node --check functions/index.js

--- a/libraries/smokes/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImpl.kt
+++ b/libraries/smokes/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImpl.kt
@@ -14,12 +14,15 @@ import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeCount
 import com.feragusper.smokeanalytics.libraries.smokes.domain.repository.SmokeRepository
+import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.Query.Direction
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withTimeout
 import kotlinx.datetime.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -38,39 +41,45 @@ class SmokeRepositoryImpl @Inject constructor(
     }
 
     override suspend fun addSmoke(date: Instant, location: GeoPoint?) {
-        smokesQuery().add(
-            SmokeEntity(
-                timestampMillis = date.toEpochMilliseconds().toDouble(),
-                latitude = location?.latitude,
-                longitude = location?.longitude,
-            )
-        ).await()
+        runFirestoreWrite("add smoke") {
+            smokesQuery().add(
+                SmokeEntity(
+                    timestampMillis = date.toEpochMilliseconds().toDouble(),
+                    latitude = location?.latitude,
+                    longitude = location?.longitude,
+                )
+            ).await()
+        }
     }
 
     override suspend fun editSmoke(id: String, date: Instant, location: GeoPoint?) {
-        val preservedLocation = location ?: smokesQuery()
-            .document(id)
-            .get()
-            .await()
-            .getGeoPoint()
+        runFirestoreWrite("edit smoke") {
+            val preservedLocation = location ?: smokesQuery()
+                .document(id)
+                .get()
+                .await()
+                .getGeoPoint()
 
-        smokesQuery()
-            .document(id)
-            .set(
-                SmokeEntity(
-                    timestampMillis = date.toEpochMilliseconds().toDouble(),
-                    latitude = preservedLocation?.latitude,
-                    longitude = preservedLocation?.longitude,
+            smokesQuery()
+                .document(id)
+                .set(
+                    SmokeEntity(
+                        timestampMillis = date.toEpochMilliseconds().toDouble(),
+                        latitude = preservedLocation?.latitude,
+                        longitude = preservedLocation?.longitude,
+                    )
                 )
-            )
-            .await()
+                .await()
+        }
     }
 
     override suspend fun deleteSmoke(id: String) {
-        smokesQuery()
-            .document(id)
-            .delete()
-            .await()
+        runFirestoreWrite("delete smoke") {
+            smokesQuery()
+                .document(id)
+                .delete()
+                .await()
+        }
     }
 
     override suspend fun fetchSmokes(
@@ -149,6 +158,23 @@ class SmokeRepositoryImpl @Inject constructor(
         firebaseFirestore.collection("$USERS/$uid/$SMOKES")
     } ?: throw IllegalStateException("User not logged in")
 
+    private suspend fun <T> runFirestoreWrite(operation: String, block: suspend () -> T): T =
+        try {
+            withTimeout(FIRESTORE_WRITE_TIMEOUT_MILLIS) {
+                block()
+            }
+        } catch (e: TimeoutCancellationException) {
+            throw IllegalStateException(
+                "Firestore $operation timed out after ${FIRESTORE_WRITE_TIMEOUT_MILLIS / 1_000}s. ${firebaseDiagnostics()}",
+                e,
+            )
+        }
+
+    private fun firebaseDiagnostics(): String {
+        val options = FirebaseApp.getInstance().options
+        return "Firebase project=${options.projectId ?: "unknown"}, appId=${options.applicationId}."
+    }
+
     private fun DocumentSnapshot.getInstant(): Instant? {
         val millis = getDouble(SmokeEntity.Fields.TIMESTAMP_MILLIS) ?: return null
         return Instant.fromEpochMilliseconds(millis.toLong())
@@ -158,5 +184,9 @@ class SmokeRepositoryImpl @Inject constructor(
         val latitude = getDouble(SmokeEntity.Fields.LATITUDE) ?: return null
         val longitude = getDouble(SmokeEntity.Fields.LONGITUDE) ?: return null
         return GeoPoint(latitude = latitude, longitude = longitude)
+    }
+
+    private companion object {
+        const val FIRESTORE_WRITE_TIMEOUT_MILLIS = 15_000L
     }
 }


### PR DESCRIPTION
## Summary
- allow CI to consume the production google-services.json secret as raw JSON while keeping the old encrypted GPG format compatible
- log non-sensitive Firebase production config metadata during integration/deploy so Play Store builds can be audited
- add a 15s Firestore write timeout for smoke writes so Play Store-only hangs surface as visible app errors with Firebase diagnostics

## Context
The Play Store production build was the only variant failing to write smoke tracking data, while local production and staging worked. The production GOOGLE_SERVICES_JSON GitHub secret was stale, so I updated it from the current local production Firebase config and patched CI before triggering another store release.

## Verification
- git diff --check
- ./gradlew :libraries:smokes:data:mobile:testDebugUnitTest :features:home:presentation:mobile:testDebugUnitTest
- ./gradlew :apps:mobile:compileProductionReleaseKotlin