### PR TITLE
Diagnose production preference writes

### DIFF
--- a/.github/workflows/deployment_playstore.yml
+++ b/.github/workflows/deployment_playstore.yml
@@ -57,6 +57,14 @@ jobs:
           echo "Firebase production package=$(jq -r '.client[0].client_info.android_client_info.package_name' ./apps/mobile/src/production/google-services.json)"
           echo "Firebase production oauth_sha1=$(jq -r '[.client[0].oauth_client[]? | select(.client_type == 1) | .android_info.certificate_hash] | join(",")' ./apps/mobile/src/production/google-services.json)"
 
+          mkdir -p ./build/reports/release-diagnostics
+          {
+            echo "firebase_project_id=$(jq -r '.project_info.project_id' ./apps/mobile/src/production/google-services.json)"
+            echo "firebase_app_id=$(jq -r '.client[0].client_info.mobilesdk_app_id' ./apps/mobile/src/production/google-services.json)"
+            echo "firebase_package=$(jq -r '.client[0].client_info.android_client_info.package_name' ./apps/mobile/src/production/google-services.json)"
+            echo "firebase_oauth_sha1=$(jq -r '[.client[0].oauth_client[]? | select(.client_type == 1) | .android_info.certificate_hash] | join(\",\")' ./apps/mobile/src/production/google-services.json)"
+          } > ./build/reports/release-diagnostics/android-production-release.txt
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -85,6 +93,12 @@ jobs:
           echo "$PLAYSTORE_CREDENTIALS_ASC" > ./playstore.credentials.json.asc
           gpg -d --passphrase "$GPG_PASSPHRASE" --batch ./playstore.credentials.json.asc > ./playstore.credentials.json
 
+          store_password="$(sed -n 's/^storePassword=//p' ./release.keystore.properties)"
+          key_alias="$(sed -n 's/^keyAlias=//p' ./release.keystore.properties)"
+          key_password="$(sed -n 's/^keyPassword=//p' ./release.keystore.properties)"
+          release_sha1="$(keytool -list -v -keystore ./release.keystore -storepass "$store_password" -alias "$key_alias" -keypass "$key_password" | sed -n 's/^.*SHA1: //p' | head -n 1 | tr 'A-Z' 'a-z' | tr -d ':')"
+          echo "release_keystore_sha1=$release_sha1" >> ./build/reports/release-diagnostics/android-production-release.txt
+
       - name: Build Android App Bundle
         run: ./gradlew :apps:mobile:bundleProductionRelease --stacktrace
 
@@ -96,6 +110,18 @@ jobs:
         run: |
           echo "version_name=$(${{ github.workspace }}/gradlew -q :apps:mobile:printAndroidVersionName)" >> "$GITHUB_OUTPUT"
           echo "release_tag=$(${{ github.workspace }}/gradlew -q :apps:mobile:printAndroidReleaseTag)" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "android_version_name=$(${{ github.workspace }}/gradlew -q :apps:mobile:printAndroidVersionName)"
+            echo "android_release_tag=$(${{ github.workspace }}/gradlew -q :apps:mobile:printAndroidReleaseTag)"
+          } >> ./build/reports/release-diagnostics/android-production-release.txt
+
+      - name: Upload release diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playstore-release-diagnostics
+          path: ./build/reports/release-diagnostics/android-production-release.txt
 
       - name: Push Git Tag
         id: push_android_tag

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -88,6 +88,14 @@ jobs:
           echo "Firebase production package=$(jq -r '.client[0].client_info.android_client_info.package_name' ./apps/mobile/src/production/google-services.json)"
           echo "Firebase production oauth_sha1=$(jq -r '[.client[0].oauth_client[]? | select(.client_type == 1) | .android_info.certificate_hash] | join(",")' ./apps/mobile/src/production/google-services.json)"
 
+          mkdir -p ./build/reports/release-diagnostics
+          {
+            echo "firebase_project_id=$(jq -r '.project_info.project_id' ./apps/mobile/src/production/google-services.json)"
+            echo "firebase_app_id=$(jq -r '.client[0].client_info.mobilesdk_app_id' ./apps/mobile/src/production/google-services.json)"
+            echo "firebase_package=$(jq -r '.client[0].client_info.android_client_info.package_name' ./apps/mobile/src/production/google-services.json)"
+            echo "firebase_oauth_sha1=$(jq -r '[.client[0].oauth_client[]? | select(.client_type == 1) | .android_info.certificate_hash] | join(\",\")' ./apps/mobile/src/production/google-services.json)"
+          } > ./build/reports/release-diagnostics/android-production-firebase.txt
+
       - name: Validate coach relay function syntax
         run: node --check functions/index.js
 
@@ -103,6 +111,22 @@ jobs:
             fi
             echo "Gradle check failed on attempt $attempt. Retrying once..."
           done
+
+      - name: Capture Android release metadata
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "android_version_name=$(./gradlew -q :apps:mobile:printAndroidVersionName)"
+            echo "android_release_tag=$(./gradlew -q :apps:mobile:printAndroidReleaseTag)"
+          } >> ./build/reports/release-diagnostics/android-production-firebase.txt
+
+      - name: Upload release diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-release-diagnostics
+          path: ./build/reports/release-diagnostics/android-production-firebase.txt
 
 #      - name: Cache SonarQube packages
 #        uses: actions/cache@v3

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
@@ -15,6 +15,7 @@ import com.feragusper.smokeanalytics.libraries.architecture.domain.shouldOfferSt
 import com.feragusper.smokeanalytics.libraries.architecture.domain.WidgetRefreshService
 import com.feragusper.smokeanalytics.libraries.architecture.domain.timeElapsedSinceNow
 import com.feragusper.smokeanalytics.libraries.architecture.presentation.extensions.catchAndLog
+import com.feragusper.smokeanalytics.libraries.architecture.presentation.extensions.debugSummary
 import com.feragusper.smokeanalytics.libraries.architecture.presentation.process.MVIProcessHolder
 import com.feragusper.smokeanalytics.libraries.authentication.domain.FetchSessionUseCase
 import com.feragusper.smokeanalytics.libraries.authentication.domain.Session
@@ -267,17 +268,6 @@ class HomeProcessHolder @Inject constructor(
             .onFailure { Timber.w(it, "Home mutation succeeded but Wear sync failed: ${it.debugSummary()}") }
             .exceptionOrNull()
             ?.debugSummary()
-    }
-}
-
-private fun Throwable.debugSummary(): String {
-    val type = this::class.simpleName ?: "Throwable"
-    val message = message?.takeIf { it.isNotBlank() } ?: cause?.message?.takeIf { it.isNotBlank() }
-    val causeType = cause?.let { it::class.simpleName }?.takeIf { it != type }
-    return buildString {
-        append(type)
-        if (causeType != null) append(" caused by ").append(causeType)
-        if (message != null) append(": ").append(message)
     }
 }
 

--- a/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/process/SettingsProcessHolder.kt
+++ b/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/process/SettingsProcessHolder.kt
@@ -4,6 +4,7 @@ import com.feragusper.smokeanalytics.features.goals.domain.EvaluateGoalProgressU
 import com.feragusper.smokeanalytics.features.goals.domain.goalDataFetchStart
 import com.feragusper.smokeanalytics.features.settings.presentation.mvi.SettingsIntent
 import com.feragusper.smokeanalytics.features.settings.presentation.mvi.SettingsResult
+import com.feragusper.smokeanalytics.libraries.architecture.presentation.extensions.debugSummary
 import com.feragusper.smokeanalytics.libraries.architecture.presentation.process.MVIProcessHolder
 import com.feragusper.smokeanalytics.libraries.authentication.domain.FetchSessionUseCase
 import com.feragusper.smokeanalytics.libraries.authentication.domain.Session
@@ -72,8 +73,8 @@ class SettingsProcessHolder @Inject constructor(
                 )
             }
         }
-    }.catch {
-        emit(SettingsResult.Error("Could not load your settings. Try again."))
+    }.catch { error ->
+        emit(SettingsResult.Error("Could not load your settings. ${error.debugSummary()}"))
     }
 
     /**
@@ -87,8 +88,8 @@ class SettingsProcessHolder @Inject constructor(
         emit(SettingsResult.Loading)
         signOutUseCase()
         emit(SettingsResult.UserLoggedOut)
-    }.catch {
-        emit(SettingsResult.Error("Could not sign out. Try again."))
+    }.catch { error ->
+        emit(SettingsResult.Error("Could not sign out. ${error.debugSummary()}"))
     }
 
     private fun processUpdatePreferences(preferences: UserPreferences): Flow<SettingsResult> = flow {
@@ -108,7 +109,7 @@ class SettingsProcessHolder @Inject constructor(
             )
         }
         emit(SettingsResult.PreferencesSaved)
-    }.catch {
-        emit(SettingsResult.Error("Could not save your settings. Try again."))
+    }.catch { error ->
+        emit(SettingsResult.Error("Could not save your settings. ${error.debugSummary()}"))
     }
 }

--- a/features/settings/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/settings/presentation/process/SettingsProcessHolderTest.kt
+++ b/features/settings/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/settings/presentation/process/SettingsProcessHolderTest.kt
@@ -103,7 +103,9 @@ class SettingsProcessHolderTest {
 
             processHolder.processIntent(SettingsIntent.FetchUser).test {
                 awaitItem() shouldBeEqualTo SettingsResult.Loading
-                awaitItem() shouldBeEqualTo SettingsResult.Error("Could not load your settings. Try again.")
+                awaitItem() shouldBeEqualTo SettingsResult.Error(
+                    "Could not load your settings. IllegalStateException: Quota exceeded"
+                )
                 awaitComplete()
             }
         }
@@ -161,7 +163,24 @@ class SettingsProcessHolderTest {
 
             processHolder.processIntent(SettingsIntent.UpdatePreferences(preferences)).test {
                 awaitItem() shouldBeEqualTo SettingsResult.Loading
-                awaitItem() shouldBeEqualTo SettingsResult.Error("Could not save your settings. Try again.")
+                awaitItem() shouldBeEqualTo SettingsResult.Error(
+                    "Could not save your settings. IllegalStateException: Quota exceeded"
+                )
+                awaitComplete()
+            }
+        }
+
+    @Test
+    fun `WHEN UpdatePreferences write fails THEN emits diagnostic save error`() =
+        runTest {
+            val preferences = UserPreferences(activeGoal = SmokingGoal.DailyCap(15))
+            coEvery { updateUserPreferencesUseCase(preferences) } throws IllegalStateException("Firestore update preferences timed out")
+
+            processHolder.processIntent(SettingsIntent.UpdatePreferences(preferences)).test {
+                awaitItem() shouldBeEqualTo SettingsResult.Loading
+                awaitItem() shouldBeEqualTo SettingsResult.Error(
+                    "Could not save your settings. IllegalStateException: Firestore update preferences timed out"
+                )
                 awaitComplete()
             }
         }

--- a/libraries/architecture/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/architecture/presentation/extensions/ErrorHandling.kt
+++ b/libraries/architecture/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/architecture/presentation/extensions/ErrorHandling.kt
@@ -19,3 +19,14 @@ fun <T> Flow<T>.catchAndLog(
     Timber.e(throwable, "Error caught")
     action(throwable)
 }
+
+fun Throwable.debugSummary(): String {
+    val type = this::class.simpleName ?: "Throwable"
+    val message = message?.takeIf { it.isNotBlank() } ?: cause?.message?.takeIf { it.isNotBlank() }
+    val causeType = cause?.let { it::class.simpleName }?.takeIf { it != type }
+    return buildString {
+        append(type)
+        if (causeType != null) append(" caused by ").append(causeType)
+        if (message != null) append(": ").append(message)
+    }
+}

--- a/libraries/preferences/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImpl.kt
+++ b/libraries/preferences/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImpl.kt
@@ -2,10 +2,13 @@ package com.feragusper.smokeanalytics.libraries.preferences.data
 
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferencesRepository
+import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withTimeout
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -16,31 +19,57 @@ class UserPreferencesRepositoryImpl @Inject constructor(
 ) : UserPreferencesRepository {
 
     override suspend fun fetch(): UserPreferences {
-        val snapshot = document().get().await()
+        val snapshot = runFirestoreProfileCall("fetch preferences") {
+            document().get().await()
+        }
         return snapshot.toUserPreferencesEntity()?.toDomain() ?: UserPreferences()
     }
 
     override suspend fun update(preferences: UserPreferences) {
-        document().set(
-            UserPreferencesEntity(
-                packPrice = preferences.packPrice,
-                cigarettesPerPack = preferences.cigarettesPerPack.toLong(),
-                dayStartHour = preferences.dayStartHour.toLong(),
-                bedtimeHour = preferences.bedtimeHour.toLong(),
-                manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
-                locationTrackingEnabled = preferences.locationTrackingEnabled,
-                currencySymbol = preferences.currencySymbol,
-                accountTier = preferences.accountTier.name,
-                activeGoalType = preferences.activeGoal?.type?.name,
-                activeGoalMetricValue = preferences.activeGoal?.metricValue,
+        runFirestoreProfileCall("update preferences") {
+            document().set(
+                UserPreferencesEntity(
+                    packPrice = preferences.packPrice,
+                    cigarettesPerPack = preferences.cigarettesPerPack.toLong(),
+                    dayStartHour = preferences.dayStartHour.toLong(),
+                    bedtimeHour = preferences.bedtimeHour.toLong(),
+                    manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
+                    locationTrackingEnabled = preferences.locationTrackingEnabled,
+                    currencySymbol = preferences.currencySymbol,
+                    accountTier = preferences.accountTier.name,
+                    activeGoalType = preferences.activeGoal?.type?.name,
+                    activeGoalMetricValue = preferences.activeGoal?.metricValue,
+                )
             )
-        ).await()
+                .await()
+        }
     }
 
     private fun document() = firestore.collection("users")
         .document(auth.currentUser?.uid ?: throw IllegalStateException("User not logged in"))
         .collection("profile")
         .document(UserPreferencesEntity.DOCUMENT)
+
+    private suspend fun <T> runFirestoreProfileCall(operation: String, block: suspend () -> T): T =
+        try {
+            withTimeout(FIRESTORE_PROFILE_TIMEOUT_MILLIS) {
+                block()
+            }
+        } catch (e: TimeoutCancellationException) {
+            throw IllegalStateException(
+                "Firestore $operation timed out after ${FIRESTORE_PROFILE_TIMEOUT_MILLIS / 1_000}s. ${firebaseDiagnostics()}",
+                e,
+            )
+        }
+
+    private fun firebaseDiagnostics(): String {
+        val options = FirebaseApp.getInstance().options
+        return "Firebase project=${options.projectId ?: "unknown"}, appId=${options.applicationId}, path=users/${auth.currentUser?.uid ?: "missing"}/profile/${UserPreferencesEntity.DOCUMENT}."
+    }
+
+    private companion object {
+        const val FIRESTORE_PROFILE_TIMEOUT_MILLIS = 15_000L
+    }
 }
 
 private fun DocumentSnapshot.toUserPreferencesEntity(): UserPreferencesEntity? {


### PR DESCRIPTION
## Summary
- add the same 15s timeout and Firebase diagnostics to production user preference fetch/update calls that we already added to smoke writes
- surface detailed settings load/save failures instead of generic messages so location/goals/profile write issues stop looking like silent no-ops
- upload release diagnostics artifacts from Integration and Play Store deploy with Firebase production metadata, release keystore SHA1, and derived Android version/tag

## Why
Production from Play Store is still showing silent failures around tracking, location toggle, and goals persistence. Those symptoms all depend on the preferences profile document, which still had unbounded Firestore calls and generic error handling.

## Verification
- ./gradlew :features:settings:presentation:mobile:testDebugUnitTest :libraries:preferences:data:mobile:testDebugUnitTest
- ./gradlew :apps:mobile:compileProductionReleaseKotlin