### PR TITLE
Diagnose Play Store Firestore writes

### DIFF
--- a/.github/workflows/deployment_playstore.yml
+++ b/.github/workflows/deployment_playstore.yml
@@ -56,6 +56,11 @@ jobs:
           echo "Firebase production app_id=$(jq -r '.client[0].client_info.mobilesdk_app_id' ./apps/mobile/src/production/google-services.json)"
           echo "Firebase production package=$(jq -r '.client[0].client_info.android_client_info.package_name' ./apps/mobile/src/production/google-services.json)"
           echo "Firebase production oauth_sha1=$(jq -r '[.client[0].oauth_client[]? | select(.client_type == 1) | .android_info.certificate_hash] | join(",")' ./apps/mobile/src/production/google-services.json)"
+          firebase_api_key="$(jq -r '.client[0].api_key[0].current_key // ""' ./apps/mobile/src/production/google-services.json)"
+          firebase_api_key_sha256="$(printf '%s' "$firebase_api_key" | shasum -a 256 | awk '{print $1}')"
+          firebase_api_key_suffix="${firebase_api_key: -6}"
+          echo "Firebase production api_key_sha256=${firebase_api_key_sha256:0:12}"
+          echo "Firebase production api_key_suffix=$firebase_api_key_suffix"
 
           mkdir -p ./build/reports/release-diagnostics
           firebase_oauth_sha1="$(jq -r '[.client[0].oauth_client[]? | select(.client_type == 1) | .android_info.certificate_hash] | join(",")' ./apps/mobile/src/production/google-services.json)"
@@ -64,6 +69,8 @@ jobs:
             echo "firebase_app_id=$(jq -r '.client[0].client_info.mobilesdk_app_id' ./apps/mobile/src/production/google-services.json)"
             echo "firebase_package=$(jq -r '.client[0].client_info.android_client_info.package_name' ./apps/mobile/src/production/google-services.json)"
             echo "firebase_oauth_sha1=$firebase_oauth_sha1"
+            echo "firebase_api_key_sha256=$firebase_api_key_sha256"
+            echo "firebase_api_key_suffix=$firebase_api_key_suffix"
           } > ./build/reports/release-diagnostics/android-production-release.txt
 
       - name: Setup Ruby
@@ -103,6 +110,52 @@ jobs:
       - name: Build Android App Bundle
         run: ./gradlew :apps:mobile:bundleProductionRelease --stacktrace
 
+      - name: Capture built AAB diagnostics
+        if: always()
+        shell: bash
+        run: |
+          diagnostics_dir="./build/reports/release-diagnostics"
+          aab_path="./apps/mobile/build/outputs/bundle/productionRelease/mobile-production-release.aab"
+          mkdir -p "$diagnostics_dir"
+
+          if [ -f "$aab_path" ]; then
+            aab_sha256="$(shasum -a 256 "$aab_path" | awk '{print $1}')"
+            {
+              echo "aab_path=$aab_path"
+              echo "aab_sha256=$aab_sha256"
+              echo "aab_size_bytes=$(wc -c < "$aab_path" | tr -d ' ')"
+            } >> "$diagnostics_dir/android-production-release.txt"
+            unzip -l "$aab_path" > "$diagnostics_dir/aab-contents.txt"
+          else
+            echo "aab_missing=$aab_path" >> "$diagnostics_dir/android-production-release.txt"
+          fi
+
+          generated_google_services_files="$(find ./apps/mobile/build/generated/res -path '*processProductionReleaseGoogleServices*' -type f | sort || true)"
+          if [ -n "$generated_google_services_files" ]; then
+            {
+              echo "# Generated Google Services resource files"
+              printf '%s\n' "$generated_google_services_files"
+              echo
+              printf '%s\n' "$generated_google_services_files" | while read -r file; do
+                echo "## $file"
+                sed -E 's/(name="[^"]*api[^"]*"[^>]*>)[^<]+(<\/string>)/\1[redacted]\2/g' "$file"
+                echo
+              done
+            } > "$diagnostics_dir/generated-google-services.txt"
+          else
+            echo "generated_google_services_missing=processProductionReleaseGoogleServices" > "$diagnostics_dir/generated-google-services.txt"
+          fi
+
+          merged_manifest="$(find ./apps/mobile/build/intermediates/merged_manifest -path '*productionRelease*AndroidManifest.xml' -type f | sort | head -n 1 || true)"
+          if [ -n "$merged_manifest" ]; then
+            {
+              echo "# $merged_manifest"
+              sed -n '1,260p' "$merged_manifest"
+            } > "$diagnostics_dir/merged-manifest.txt"
+          else
+            echo "merged_manifest_missing=productionRelease" > "$diagnostics_dir/merged-manifest.txt"
+          fi
+
       - name: Build & deploy Android release to Play Store
         run: bundler exec fastlane android deploy_playstore
 
@@ -122,7 +175,16 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: playstore-release-diagnostics
-          path: ./build/reports/release-diagnostics/android-production-release.txt
+          path: ./build/reports/release-diagnostics/
+          if-no-files-found: warn
+
+      - name: Upload production AAB
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playstore-production-aab
+          path: ./apps/mobile/build/outputs/bundle/productionRelease/mobile-production-release.aab
+          if-no-files-found: warn
 
       - name: Push Git Tag
         id: push_android_tag

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -87,6 +87,11 @@ jobs:
           echo "Firebase production app_id=$(jq -r '.client[0].client_info.mobilesdk_app_id' ./apps/mobile/src/production/google-services.json)"
           echo "Firebase production package=$(jq -r '.client[0].client_info.android_client_info.package_name' ./apps/mobile/src/production/google-services.json)"
           echo "Firebase production oauth_sha1=$(jq -r '[.client[0].oauth_client[]? | select(.client_type == 1) | .android_info.certificate_hash] | join(",")' ./apps/mobile/src/production/google-services.json)"
+          firebase_api_key="$(jq -r '.client[0].api_key[0].current_key // ""' ./apps/mobile/src/production/google-services.json)"
+          firebase_api_key_sha256="$(printf '%s' "$firebase_api_key" | shasum -a 256 | awk '{print $1}')"
+          firebase_api_key_suffix="${firebase_api_key: -6}"
+          echo "Firebase production api_key_sha256=${firebase_api_key_sha256:0:12}"
+          echo "Firebase production api_key_suffix=$firebase_api_key_suffix"
 
           mkdir -p ./build/reports/release-diagnostics
           firebase_oauth_sha1="$(jq -r '[.client[0].oauth_client[]? | select(.client_type == 1) | .android_info.certificate_hash] | join(",")' ./apps/mobile/src/production/google-services.json)"
@@ -95,6 +100,8 @@ jobs:
             echo "firebase_app_id=$(jq -r '.client[0].client_info.mobilesdk_app_id' ./apps/mobile/src/production/google-services.json)"
             echo "firebase_package=$(jq -r '.client[0].client_info.android_client_info.package_name' ./apps/mobile/src/production/google-services.json)"
             echo "firebase_oauth_sha1=$firebase_oauth_sha1"
+            echo "firebase_api_key_sha256=$firebase_api_key_sha256"
+            echo "firebase_api_key_suffix=$firebase_api_key_suffix"
           } > ./build/reports/release-diagnostics/android-production-firebase.txt
 
       - name: Validate coach relay function syntax

--- a/libraries/preferences/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImpl.kt
+++ b/libraries/preferences/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImpl.kt
@@ -1,14 +1,21 @@
 package com.feragusper.smokeanalytics.libraries.preferences.data
 
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferencesRepository
 import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.FirebaseFirestoreException
+import com.google.firebase.firestore.Source
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withTimeout
+import java.security.MessageDigest
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -16,11 +23,12 @@ import javax.inject.Singleton
 class UserPreferencesRepositoryImpl @Inject constructor(
     private val firestore: FirebaseFirestore,
     private val auth: FirebaseAuth,
+    @ApplicationContext private val appContext: Context,
 ) : UserPreferencesRepository {
 
     override suspend fun fetch(): UserPreferences {
         val snapshot = runFirestoreProfileCall("fetch preferences") {
-            document().get().await()
+            document().get(Source.SERVER).await()
         }
         return snapshot.toUserPreferencesEntity()?.toDomain() ?: UserPreferences()
     }
@@ -42,6 +50,10 @@ class UserPreferencesRepositoryImpl @Inject constructor(
                 )
             )
                 .await()
+            val serverSnapshot = document().get(Source.SERVER).await()
+            check(serverSnapshot.exists()) {
+                "Firestore update preferences verification failed: ${document().path} is missing on server."
+            }
         }
     }
 
@@ -60,11 +72,26 @@ class UserPreferencesRepositoryImpl @Inject constructor(
                 "Firestore $operation timed out after ${FIRESTORE_PROFILE_TIMEOUT_MILLIS / 1_000}s. ${firebaseDiagnostics()}",
                 e,
             )
+        } catch (e: Exception) {
+            throw IllegalStateException(
+                "Firestore $operation failed: ${e.firestoreSummary()}. ${firebaseDiagnostics()}",
+                e,
+            )
         }
 
     private fun firebaseDiagnostics(): String {
-        val options = FirebaseApp.getInstance().options
-        return "Firebase project=${options.projectId ?: "unknown"}, appId=${options.applicationId}, path=users/${auth.currentUser?.uid ?: "missing"}/profile/${UserPreferencesEntity.DOCUMENT}."
+        val options = runCatching { FirebaseApp.getInstance().options }.getOrNull()
+        return buildString {
+            append("Firebase project=").append(options?.projectId ?: "unknown")
+            append(", appId=").append(options?.applicationId ?: "unknown")
+            append(", apiKey=").append((options?.apiKey).redactedApiKey())
+            append(", path=users/").append(auth.currentUser?.uid ?: "missing")
+            append("/profile/").append(UserPreferencesEntity.DOCUMENT)
+            append(", package=").append(appContext.packageName)
+            append(", installer=").append(appContext.installerPackageName())
+            append(", ").append(appContext.signingDigestSummary())
+            append(".")
+        }
     }
 
     private companion object {
@@ -99,3 +126,77 @@ private fun DocumentSnapshot.stringOrNull(field: String): String? =
 
 private fun DocumentSnapshot.booleanOrNull(field: String): Boolean? =
     runCatching { getBoolean(field) }.getOrNull()
+
+private fun Throwable.firestoreSummary(): String {
+    val firestoreException = (this as? FirebaseFirestoreException) ?: (cause as? FirebaseFirestoreException)
+    val type = this::class.simpleName ?: "Throwable"
+    val code = firestoreException?.code?.name?.let { " code=$it" }.orEmpty()
+    val message = message?.takeIf { it.isNotBlank() } ?: cause?.message?.takeIf { it.isNotBlank() }
+    return buildString {
+        append(type).append(code)
+        if (message != null) append(": ").append(message)
+    }
+}
+
+private fun String?.redactedApiKey(): String =
+    when {
+        isNullOrBlank() -> "unknown"
+        length <= 8 -> "configured"
+        else -> "sha256:${sha256().take(12)},suffix:${takeLast(6)}"
+    }
+
+private fun String.sha256(): String =
+    MessageDigest.getInstance("SHA-256")
+        .digest(toByteArray())
+        .toHex()
+
+private fun Context.installerPackageName(): String =
+    runCatching {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            packageManager.getInstallSourceInfo(packageName).installingPackageName
+        } else {
+            @Suppress("DEPRECATION")
+            packageManager.getInstallerPackageName(packageName)
+        }
+    }.getOrNull() ?: "unknown"
+
+private fun Context.signingDigestSummary(): String =
+    signingCertificateBytes()
+        .firstOrNull()
+        ?.let { bytes ->
+            "runtimeSha1=${bytes.digest("SHA-1")},runtimeSha256=${bytes.digest("SHA-256")}"
+        }
+        ?: "runtimeSha1=unknown,runtimeSha256=unknown"
+
+@Suppress("DEPRECATION")
+private fun Context.signingCertificateBytes(): List<ByteArray> =
+    runCatching {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            packageManager
+                .getPackageInfo(packageName, PackageManager.GET_SIGNING_CERTIFICATES)
+                .signingInfo
+                ?.let { signingInfo ->
+                    if (signingInfo.hasMultipleSigners()) {
+                        signingInfo.apkContentsSigners
+                    } else {
+                        signingInfo.signingCertificateHistory
+                    }
+                }
+                .orEmpty()
+                .map { it.toByteArray() }
+        } else {
+            packageManager
+                .getPackageInfo(packageName, PackageManager.GET_SIGNATURES)
+                .signatures
+                .orEmpty()
+                .map { it.toByteArray() }
+        }
+    }.getOrDefault(emptyList())
+
+private fun ByteArray.digest(algorithm: String): String =
+    MessageDigest.getInstance(algorithm)
+        .digest(this)
+        .toHex()
+
+private fun ByteArray.toHex(): String =
+    joinToString(separator = "") { "%02x".format(it) }

--- a/libraries/smokes/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImpl.kt
+++ b/libraries/smokes/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImpl.kt
@@ -1,5 +1,8 @@
 package com.feragusper.smokeanalytics.libraries.smokes.data
 
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
 import com.feragusper.smokeanalytics.libraries.architecture.domain.firstInstantThisMonth
 import com.feragusper.smokeanalytics.libraries.architecture.domain.currentMonthStartInstant
 import com.feragusper.smokeanalytics.libraries.architecture.domain.currentWeekStartInstant
@@ -17,13 +20,17 @@ import com.feragusper.smokeanalytics.libraries.smokes.domain.repository.SmokeRep
 import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FirebaseFirestoreException
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.Query.Direction
+import com.google.firebase.firestore.Source
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withTimeout
 import kotlinx.datetime.Instant
+import java.security.MessageDigest
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -31,6 +38,7 @@ import javax.inject.Singleton
 class SmokeRepositoryImpl @Inject constructor(
     private val firebaseFirestore: FirebaseFirestore,
     private val firebaseAuth: FirebaseAuth,
+    @ApplicationContext private val appContext: Context,
 ) : SmokeRepository {
 
     interface FirestoreCollection {
@@ -41,44 +49,52 @@ class SmokeRepositoryImpl @Inject constructor(
     }
 
     override suspend fun addSmoke(date: Instant, location: GeoPoint?) {
-        runFirestoreWrite("add smoke") {
-            smokesQuery().add(
+        runFirestoreCall("add smoke", smokesPath()) {
+            val document = smokesQuery().document()
+            document.set(
                 SmokeEntity(
                     timestampMillis = date.toEpochMilliseconds().toDouble(),
                     latitude = location?.latitude,
                     longitude = location?.longitude,
                 )
             ).await()
+            val serverSnapshot = document.get(Source.SERVER).await()
+            check(serverSnapshot.exists()) {
+                "Firestore add smoke verification failed: ${document.path} is missing on server."
+            }
         }
     }
 
     override suspend fun editSmoke(id: String, date: Instant, location: GeoPoint?) {
-        runFirestoreWrite("edit smoke") {
-            val preservedLocation = location ?: smokesQuery()
-                .document(id)
-                .get()
+        runFirestoreCall("edit smoke", "${smokesPath()}/$id") {
+            val document = smokesQuery().document(id)
+            val preservedLocation = location ?: document
+                .get(Source.SERVER)
                 .await()
                 .getGeoPoint()
 
-            smokesQuery()
-                .document(id)
-                .set(
-                    SmokeEntity(
-                        timestampMillis = date.toEpochMilliseconds().toDouble(),
-                        latitude = preservedLocation?.latitude,
-                        longitude = preservedLocation?.longitude,
-                    )
+            document.set(
+                SmokeEntity(
+                    timestampMillis = date.toEpochMilliseconds().toDouble(),
+                    latitude = preservedLocation?.latitude,
+                    longitude = preservedLocation?.longitude,
                 )
-                .await()
+            ).await()
+            val serverSnapshot = document.get(Source.SERVER).await()
+            check(serverSnapshot.exists()) {
+                "Firestore edit smoke verification failed: ${document.path} is missing on server."
+            }
         }
     }
 
     override suspend fun deleteSmoke(id: String) {
-        runFirestoreWrite("delete smoke") {
-            smokesQuery()
-                .document(id)
-                .delete()
-                .await()
+        runFirestoreCall("delete smoke", "${smokesPath()}/$id") {
+            val document = smokesQuery().document(id)
+            document.delete().await()
+            val serverSnapshot = document.get(Source.SERVER).await()
+            check(!serverSnapshot.exists()) {
+                "Firestore delete smoke verification failed: ${document.path} still exists on server."
+            }
         }
     }
 
@@ -94,29 +110,31 @@ class SmokeRepositoryImpl @Inject constructor(
             .whereGreaterThanOrEqualTo(SmokeEntity.Fields.TIMESTAMP_MILLIS, startMillis)
             .whereLessThan(SmokeEntity.Fields.TIMESTAMP_MILLIS, endMillis)
 
-        val result = query.get().await()
-        val previousDocument = smokesQuery()
-            .orderBy(SmokeEntity.Fields.TIMESTAMP_MILLIS, Direction.DESCENDING)
-            .whereLessThan(SmokeEntity.Fields.TIMESTAMP_MILLIS, startMillis)
-            .limit(1)
-            .get()
-            .await()
-            .documents
-            .firstOrNull()
+        return runFirestoreCall("fetch smokes", smokesPath()) {
+            val result = query.get(Source.SERVER).await()
+            val previousDocument = smokesQuery()
+                .orderBy(SmokeEntity.Fields.TIMESTAMP_MILLIS, Direction.DESCENDING)
+                .whereLessThan(SmokeEntity.Fields.TIMESTAMP_MILLIS, startMillis)
+                .limit(1)
+                .get(Source.SERVER)
+                .await()
+                .documents
+                .firstOrNull()
 
-        val documents = previousDocument?.let { result.documents + it } ?: result.documents
-        val instants = documents.mapNotNull { it.getInstant() }
+            val documents = previousDocument?.let { result.documents + it } ?: result.documents
+            val instants = documents.mapNotNull { it.getInstant() }
 
-        return result.documents.mapIndexedNotNull { index, document ->
-            val currentInstant = instants.getOrNull(index) ?: return@mapIndexedNotNull null
-            val previousInstant = instants.getOrNull(index + 1)
+            result.documents.mapIndexedNotNull { index, document ->
+                val currentInstant = instants.getOrNull(index) ?: return@mapIndexedNotNull null
+                val previousInstant = instants.getOrNull(index + 1)
 
-            Smoke(
-                id = document.id,
-                date = currentInstant,
-                timeElapsedSincePreviousSmoke = currentInstant.timeAfter(previousInstant),
-                location = document.getGeoPoint(),
-            )
+                Smoke(
+                    id = document.id,
+                    date = currentInstant,
+                    timeElapsedSincePreviousSmoke = currentInstant.timeAfter(previousInstant),
+                    location = document.getGeoPoint(),
+                )
+            }
         }
     }
 
@@ -155,24 +173,40 @@ class SmokeRepositoryImpl @Inject constructor(
         filter { it.date.isInCurrentMonthBucket(dayStartHour = dayStartHour, manualDayStartEpochMillis = manualDayStartEpochMillis) }
 
     private fun smokesQuery() = firebaseAuth.currentUser?.uid?.let { uid ->
-        firebaseFirestore.collection("$USERS/$uid/$SMOKES")
+        firebaseFirestore.collection(smokesPath(uid))
     } ?: throw IllegalStateException("User not logged in")
 
-    private suspend fun <T> runFirestoreWrite(operation: String, block: suspend () -> T): T =
+    private fun smokesPath(uid: String = firebaseAuth.currentUser?.uid ?: "missing") = "$USERS/$uid/$SMOKES"
+
+    private suspend fun <T> runFirestoreCall(operation: String, path: String, block: suspend () -> T): T =
         try {
-            withTimeout(FIRESTORE_WRITE_TIMEOUT_MILLIS) {
+            withTimeout(FIRESTORE_TIMEOUT_MILLIS) {
                 block()
             }
         } catch (e: TimeoutCancellationException) {
             throw IllegalStateException(
-                "Firestore $operation timed out after ${FIRESTORE_WRITE_TIMEOUT_MILLIS / 1_000}s. ${firebaseDiagnostics()}",
+                "Firestore $operation timed out after ${FIRESTORE_TIMEOUT_MILLIS / 1_000}s. ${firebaseDiagnostics(path)}",
+                e,
+            )
+        } catch (e: Exception) {
+            throw IllegalStateException(
+                "Firestore $operation failed: ${e.firestoreSummary()}. ${firebaseDiagnostics(path)}",
                 e,
             )
         }
 
-    private fun firebaseDiagnostics(): String {
-        val options = FirebaseApp.getInstance().options
-        return "Firebase project=${options.projectId ?: "unknown"}, appId=${options.applicationId}."
+    private fun firebaseDiagnostics(path: String): String {
+        val options = runCatching { FirebaseApp.getInstance().options }.getOrNull()
+        return buildString {
+            append("Firebase project=").append(options?.projectId ?: "unknown")
+            append(", appId=").append(options?.applicationId ?: "unknown")
+            append(", apiKey=").append((options?.apiKey).redactedApiKey())
+            append(", path=").append(path)
+            append(", package=").append(appContext.packageName)
+            append(", installer=").append(appContext.installerPackageName())
+            append(", ").append(appContext.signingDigestSummary())
+            append(".")
+        }
     }
 
     private fun DocumentSnapshot.getInstant(): Instant? {
@@ -187,6 +221,80 @@ class SmokeRepositoryImpl @Inject constructor(
     }
 
     private companion object {
-        const val FIRESTORE_WRITE_TIMEOUT_MILLIS = 15_000L
+        const val FIRESTORE_TIMEOUT_MILLIS = 15_000L
     }
 }
+
+private fun Throwable.firestoreSummary(): String {
+    val firestoreException = (this as? FirebaseFirestoreException) ?: (cause as? FirebaseFirestoreException)
+    val type = this::class.simpleName ?: "Throwable"
+    val code = firestoreException?.code?.name?.let { " code=$it" }.orEmpty()
+    val message = message?.takeIf { it.isNotBlank() } ?: cause?.message?.takeIf { it.isNotBlank() }
+    return buildString {
+        append(type).append(code)
+        if (message != null) append(": ").append(message)
+    }
+}
+
+private fun String?.redactedApiKey(): String =
+    when {
+        isNullOrBlank() -> "unknown"
+        length <= 8 -> "configured"
+        else -> "sha256:${sha256().take(12)},suffix:${takeLast(6)}"
+    }
+
+private fun String.sha256(): String =
+    MessageDigest.getInstance("SHA-256")
+        .digest(toByteArray())
+        .toHex()
+
+private fun Context.installerPackageName(): String =
+    runCatching {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            packageManager.getInstallSourceInfo(packageName).installingPackageName
+        } else {
+            @Suppress("DEPRECATION")
+            packageManager.getInstallerPackageName(packageName)
+        }
+    }.getOrNull() ?: "unknown"
+
+private fun Context.signingDigestSummary(): String =
+    signingCertificateBytes()
+        .firstOrNull()
+        ?.let { bytes ->
+            "runtimeSha1=${bytes.digest("SHA-1")},runtimeSha256=${bytes.digest("SHA-256")}"
+        }
+        ?: "runtimeSha1=unknown,runtimeSha256=unknown"
+
+@Suppress("DEPRECATION")
+private fun Context.signingCertificateBytes(): List<ByteArray> =
+    runCatching {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            packageManager
+                .getPackageInfo(packageName, PackageManager.GET_SIGNING_CERTIFICATES)
+                .signingInfo
+                ?.let { signingInfo ->
+                    if (signingInfo.hasMultipleSigners()) {
+                        signingInfo.apkContentsSigners
+                    } else {
+                        signingInfo.signingCertificateHistory
+                    }
+                }
+                .orEmpty()
+                .map { it.toByteArray() }
+        } else {
+            packageManager
+                .getPackageInfo(packageName, PackageManager.GET_SIGNATURES)
+                .signatures
+                .orEmpty()
+                .map { it.toByteArray() }
+        }
+    }.getOrDefault(emptyList())
+
+private fun ByteArray.digest(algorithm: String): String =
+    MessageDigest.getInstance(algorithm)
+        .digest(this)
+        .toHex()
+
+private fun ByteArray.toHex(): String =
+    joinToString(separator = "") { "%02x".format(it) }

--- a/libraries/smokes/data/mobile/src/test/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImplTest.kt
+++ b/libraries/smokes/data/mobile/src/test/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImplTest.kt
@@ -1,5 +1,6 @@
 package com.feragusper.smokeanalytics.libraries.smokes.data
 
+import android.content.Context
 import com.feragusper.smokeanalytics.libraries.architecture.domain.timeAfter
 import com.feragusper.smokeanalytics.libraries.smokes.data.SmokeRepositoryImpl.FirestoreCollection.Companion.SMOKES
 import com.feragusper.smokeanalytics.libraries.smokes.data.SmokeRepositoryImpl.FirestoreCollection.Companion.USERS
@@ -13,6 +14,7 @@ import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.QuerySnapshot
+import com.google.firebase.firestore.Source
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -29,9 +31,11 @@ class SmokeRepositoryImplTest {
 
     private val firebaseAuth: FirebaseAuth = mockk()
     private val firebaseFirestore: FirebaseFirestore = mockk()
+    private val appContext: Context = mockk(relaxed = true)
     private val smokeRepository = SmokeRepositoryImpl(
         firebaseAuth = firebaseAuth,
-        firebaseFirestore = firebaseFirestore
+        firebaseFirestore = firebaseFirestore,
+        appContext = appContext,
     )
 
     @Test
@@ -130,15 +134,21 @@ class SmokeRepositoryImplTest {
         fun `GIVEN user is logged in WHEN add smoke is called THEN it should finish`() = runTest {
             val date = Instant.fromEpochMilliseconds(1_672_574_400_000)
             val smokeEntitySlot = slot<SmokeEntity>()
+            val documentRef = mockk<DocumentReference>()
 
-            every { collectionReference.add(capture(smokeEntitySlot)) } answers {
-                mockk<Task<DocumentReference>>().apply {
+            every { collectionReference.document() } returns documentRef
+            every { documentRef.path } returns "$USERS/$uid/$SMOKES/generated"
+            every { documentRef.set(capture(smokeEntitySlot)) } answers {
+                mockk<Task<Void>>().apply {
                     every { isComplete } returns true
                     every { isSuccessful } returns true
-                    every { result } returns mockk()
+                    every { result } returns null
                     every { exception } returns null
                     every { isCanceled } returns false
                 }
+            }
+            every { documentRef.get(Source.SERVER) } answers {
+                taskOf(mockDocumentSnapshot("generated", date))
             }
 
             smokeRepository.addSmoke(date)
@@ -157,15 +167,8 @@ class SmokeRepositoryImplTest {
 
             val documentRef = mockk<DocumentReference>()
             every { collectionReference.document(id) } returns documentRef
-            every { documentRef.get() } answers {
-                mockk<Task<DocumentSnapshot>>().apply {
-                    every { isComplete } returns true
-                    every { isSuccessful } returns true
-                    every { exception } returns null
-                    every { isCanceled } returns false
-                    every { result } returns mockDocumentSnapshot(id, date)
-                }
-            }
+            every { documentRef.path } returns "$USERS/$uid/$SMOKES/$id"
+            every { documentRef.get(Source.SERVER) } answers { taskOf(mockDocumentSnapshot(id, date)) }
 
             every { documentRef.set(any<SmokeEntity>()) } answers {
                 mockk<Task<Void>>().apply {
@@ -187,6 +190,7 @@ class SmokeRepositoryImplTest {
 
                 val documentRef = mockk<DocumentReference>()
                 every { collectionReference.document(id) } returns documentRef
+                every { documentRef.path } returns "$USERS/$uid/$SMOKES/$id"
 
                 every { documentRef.delete() } answers {
                     mockk<Task<Void>>().apply {
@@ -196,6 +200,9 @@ class SmokeRepositoryImplTest {
                         every { isCanceled } returns false
                         every { result } returns mockk()
                     }
+                }
+                every { documentRef.get(Source.SERVER) } answers {
+                    taskOf(mockDocumentSnapshot(id, instant1, exists = false))
                 }
 
                 smokeRepository.deleteSmoke(id)
@@ -234,7 +241,7 @@ class SmokeRepositoryImplTest {
                 previousQuery.limit(1)
             } returns previousLimitedQuery
 
-            every { finalQuery.get() } answers {
+            every { finalQuery.get(Source.SERVER) } answers {
                 mockk<Task<QuerySnapshot>>().apply {
                     every { isComplete } returns true
                     every { isSuccessful } returns true
@@ -247,7 +254,7 @@ class SmokeRepositoryImplTest {
                     every { exception } returns null
                 }
             }
-            every { previousLimitedQuery.get() } answers {
+            every { previousLimitedQuery.get(Source.SERVER) } answers {
                 mockk<Task<QuerySnapshot>>().apply {
                     every { isComplete } returns true
                     every { isSuccessful } returns true
@@ -262,14 +269,24 @@ class SmokeRepositoryImplTest {
             }
         }
 
-        private fun mockDocumentSnapshot(id: String, date: Instant): DocumentSnapshot {
+        private fun mockDocumentSnapshot(id: String, date: Instant, exists: Boolean = true): DocumentSnapshot {
             return mockk<DocumentSnapshot>().apply {
                 every { this@apply.id } returns id
+                every { exists() } returns exists
                 every { getDouble(SmokeEntity.Fields.TIMESTAMP_MILLIS) } returns date.toEpochMilliseconds()
                     .toDouble()
                 every { getDouble(SmokeEntity.Fields.LATITUDE) } returns null
                 every { getDouble(SmokeEntity.Fields.LONGITUDE) } returns null
             }
         }
+
+        private fun <T> taskOf(value: T): Task<T> =
+            mockk<Task<T>>().apply {
+                every { isComplete } returns true
+                every { isSuccessful } returns true
+                every { isCanceled } returns false
+                every { exception } returns null
+                every { result } returns value
+            }
     }
 }


### PR DESCRIPTION
## Summary
- force mobile Firestore smoke/preference reads and write verification through server responses so Play-only failures surface instead of looking like empty/stale UI
- include Firebase project/app/api-key hash, installer package, and runtime signing cert SHA1/SHA256 in mobile Firestore error diagnostics
- upload Play deploy diagnostics as a directory and keep the production AAB as a downloadable artifact for post-release inspection

## Firebase keys to check if the next Play build still fails
- Firebase Console > Project settings > Android app com.feragusper.smokeanalytics: include the Play App Signing SHA-1/SHA-256 and the upload/release SHA-1/SHA-256
- Play Console > Setup > App integrity: compare App signing key certificate and Upload key certificate with the runtimeSha1/runtimeSha256 shown by the app error
- Google Cloud Console > APIs & Services > Credentials: for API key suffix/hash shown in diagnostics, ensure Android app restrictions allow com.feragusper.smokeanalytics with Play App Signing SHA-1
- Firebase Console > App Check: if Firestore enforcement is on, ensure the Android production app is registered for Play Integrity with the Play signing certificate

## Verification
- ./gradlew :libraries:smokes:data:mobile:testDebugUnitTest :libraries:preferences:data:mobile:compileDebugKotlin :features:home:presentation:mobile:testDebugUnitTest :features:settings:presentation:mobile:testDebugUnitTest
- ./gradlew :apps:mobile:assembleProductionDebug :apps:mobile:compileProductionReleaseKotlin
- git diff --check
- Ruby YAML parse for deployment_playstore.yml and integration.yml