### PR TITLE
Diagnose Play Store Firestore writes

### DIFF
--- a/features/settings/presentation/mobile/build.gradle.kts
+++ b/features/settings/presentation/mobile/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     // Firebase dependencies for authentication
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.auth)
+    implementation(libs.firebase.firestore)
 
     // Dependency injection with Hilt
     implementation(libs.hilt)

--- a/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/SettingsViewModel.kt
+++ b/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/SettingsViewModel.kt
@@ -94,6 +94,17 @@ class SettingsViewModel @Inject constructor(
             infoMessage = null,
             errorMessage = null,
         )
+        SettingsResult.FirestoreDiagnosticsRunning -> previous.copy(
+            displayLoading = false,
+            firestoreDiagnosticsRunning = true,
+            errorMessage = null,
+        )
+        is SettingsResult.FirestoreDiagnosticsFinished -> previous.copy(
+            displayLoading = false,
+            firestoreDiagnosticsRunning = false,
+            firestoreDiagnosticsReport = result.report,
+            errorMessage = null,
+        )
         is SettingsResult.Error -> previous.copy(
             displayLoading = false,
             errorMessage = result.message,

--- a/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/diagnostics/FirestoreDiagnosticsRunner.kt
+++ b/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/diagnostics/FirestoreDiagnosticsRunner.kt
@@ -1,0 +1,268 @@
+package com.feragusper.smokeanalytics.features.settings.presentation.diagnostics
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+import com.google.firebase.FirebaseApp
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.FirebaseFirestoreException
+import com.google.firebase.firestore.SetOptions
+import com.google.firebase.firestore.Source
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withTimeout
+import java.security.MessageDigest
+import java.util.UUID
+import javax.inject.Inject
+
+data class FirestoreDiagnosticsReport(
+    val successful: Boolean,
+    val details: String,
+)
+
+class FirestoreDiagnosticsRunner @Inject constructor(
+    private val firestore: FirebaseFirestore,
+    private val auth: FirebaseAuth,
+    @param:ApplicationContext private val appContext: Context,
+) {
+    suspend operator fun invoke(): FirestoreDiagnosticsReport {
+        val steps = mutableListOf<String>()
+        var success = true
+        fun line(value: String) {
+            steps += value
+        }
+
+        val nowMillis = System.currentTimeMillis()
+        val probeId = "play-${nowMillis}-${UUID.randomUUID().toString().take(8)}"
+        val options = runCatching { FirebaseApp.getInstance().options }.getOrNull()
+        val signingSummary = appContext.signingDigestSummary()
+        val installer = appContext.installerPackageName()
+        val uid = auth.currentUser?.uid
+
+        line("SmokeAnalytics Firestore diagnostics")
+        line("result=pending")
+        line("probeId=$probeId")
+        line("package=${appContext.packageName}")
+        line("installer=$installer")
+        line("version=${appContext.versionSummary()}")
+        line("firebaseProject=${options?.projectId ?: "unknown"}")
+        line("firebaseAppId=${options?.applicationId ?: "unknown"}")
+        line("apiKey=${options?.apiKey.redactedApiKey()}")
+        line(signingSummary)
+        line("authUid=${uid ?: "missing"}")
+
+        if (uid == null) {
+            val details = steps.withResult("FAIL", "No authenticated Firebase user.")
+            Log.e(TAG, details)
+            return FirestoreDiagnosticsReport(successful = false, details = details)
+        }
+
+        val smokeDocument = firestore
+            .collection("users")
+            .document(uid)
+            .collection("smokes")
+            .document("_diagnostic_$probeId")
+        val preferencesDocument = firestore
+            .collection("users")
+            .document(uid)
+            .collection("profile")
+            .document("preferences")
+
+        success = runStep("smoke.set", smokeDocument.path, steps) {
+            smokeDocument.set(
+                mapOf(
+                    "timestampMillis" to 0.0,
+                    "diagnosticProbe" to true,
+                    "probeId" to probeId,
+                    "createdAtMillis" to nowMillis,
+                    "packageName" to appContext.packageName,
+                    "installer" to installer,
+                )
+            ).await()
+        } && success
+
+        success = runStep("smoke.serverRead", smokeDocument.path, steps) {
+            val snapshot = smokeDocument.get(Source.SERVER).await()
+            check(snapshot.exists()) { "document missing after set" }
+            val data = snapshot.data.orEmpty()
+            check(snapshot.getDouble("timestampMillis") == 0.0) {
+                "timestampMillis=${snapshot.getDouble("timestampMillis")}"
+            }
+            check(snapshot.getString("probeId") == probeId) {
+                "probeId=${snapshot.getString("probeId")}"
+            }
+            "keys=${data.keys.sorted()}"
+        } && success
+
+        success = runStep("smoke.delete", smokeDocument.path, steps) {
+            smokeDocument.delete().await()
+        } && success
+
+        success = runStep("smoke.deleteVerify", smokeDocument.path, steps) {
+            val snapshot = smokeDocument.get(Source.SERVER).await()
+            check(!snapshot.exists()) { "document still exists after delete" }
+        } && success
+
+        success = runStep("preferences.merge", preferencesDocument.path, steps) {
+            preferencesDocument.set(
+                mapOf(
+                    "diagnostics" to mapOf(
+                        "lastProbeId" to probeId,
+                        "lastProbeMillis" to nowMillis,
+                        "packageName" to appContext.packageName,
+                        "installer" to installer,
+                    )
+                ),
+                SetOptions.merge(),
+            ).await()
+        } && success
+
+        success = runStep("preferences.serverRead", preferencesDocument.path, steps) {
+            val snapshot = preferencesDocument.get(Source.SERVER).await()
+            check(snapshot.exists()) { "preferences document missing after merge" }
+            val diagnostics = snapshot.get("diagnostics") as? Map<*, *>
+            check(diagnostics?.get("lastProbeId") == probeId) {
+                "diagnostics.lastProbeId=${diagnostics?.get("lastProbeId")}"
+            }
+            "keys=${snapshot.data.orEmpty().keys.sorted()}"
+        } && success
+
+        val details = steps.withResult(if (success) "PASS" else "FAIL")
+        if (success) {
+            Log.i(TAG, details)
+        } else {
+            Log.e(TAG, details)
+        }
+        return FirestoreDiagnosticsReport(successful = success, details = details)
+    }
+
+    private suspend fun runStep(
+        name: String,
+        path: String,
+        steps: MutableList<String>,
+        block: suspend () -> Any? = {},
+    ): Boolean =
+        try {
+            val result = withTimeout(STEP_TIMEOUT_MILLIS) { block() }
+            steps += "$name=PASS path=$path${result?.let { " $it" }.orEmpty()}"
+            true
+        } catch (error: Throwable) {
+            steps += "$name=FAIL path=$path ${error.firestoreSummary()}"
+            false
+        }
+
+    private companion object {
+        const val TAG = "FirestoreDiagnostics"
+        const val STEP_TIMEOUT_MILLIS = 20_000L
+    }
+}
+
+private fun List<String>.withResult(result: String, reason: String? = null): String =
+    mapIndexed { index, line ->
+        if (index == 1) {
+            buildString {
+                append("result=").append(result)
+                if (reason != null) append(" reason=").append(reason)
+            }
+        } else {
+            line
+        }
+    }.joinToString(separator = "\n")
+
+private fun Throwable.firestoreSummary(): String {
+    val firestoreException = (this as? FirebaseFirestoreException) ?: (cause as? FirebaseFirestoreException)
+    val type = this::class.simpleName ?: "Throwable"
+    val code = firestoreException?.code?.name?.let { " code=$it" }.orEmpty()
+    val message = when (this) {
+        is TimeoutCancellationException -> "timed out"
+        else -> message?.takeIf { it.isNotBlank() } ?: cause?.message?.takeIf { it.isNotBlank() }
+    }
+    return buildString {
+        append(type).append(code)
+        if (message != null) append(": ").append(message)
+    }
+}
+
+private fun String?.redactedApiKey(): String =
+    when {
+        isNullOrBlank() -> "unknown"
+        length <= 8 -> "configured"
+        else -> "sha256:${sha256().take(12)},suffix:${takeLast(6)}"
+    }
+
+private fun String.sha256(): String =
+    MessageDigest.getInstance("SHA-256")
+        .digest(toByteArray())
+        .toHex()
+
+private fun Context.installerPackageName(): String =
+    runCatching {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            packageManager.getInstallSourceInfo(packageName).installingPackageName
+        } else {
+            @Suppress("DEPRECATION")
+            packageManager.getInstallerPackageName(packageName)
+        }
+    }.getOrNull() ?: "unknown"
+
+private fun Context.versionSummary(): String =
+    runCatching {
+        val info = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            packageManager.getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(0))
+        } else {
+            @Suppress("DEPRECATION")
+            packageManager.getPackageInfo(packageName, 0)
+        }
+        val code = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            info.longVersionCode.toString()
+        } else {
+            @Suppress("DEPRECATION")
+            info.versionCode.toString()
+        }
+        "${info.versionName ?: "unknown"} ($code)"
+    }.getOrElse { "unknown" }
+
+private fun Context.signingDigestSummary(): String =
+    signingCertificateBytes()
+        .firstOrNull()
+        ?.let { bytes ->
+            "runtimeSha1=${bytes.digest("SHA-1")}\nruntimeSha256=${bytes.digest("SHA-256")}"
+        }
+        ?: "runtimeSha1=unknown\nruntimeSha256=unknown"
+
+@Suppress("DEPRECATION")
+private fun Context.signingCertificateBytes(): List<ByteArray> =
+    runCatching {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            packageManager
+                .getPackageInfo(packageName, PackageManager.GET_SIGNING_CERTIFICATES)
+                .signingInfo
+                ?.let { signingInfo ->
+                    if (signingInfo.hasMultipleSigners()) {
+                        signingInfo.apkContentsSigners
+                    } else {
+                        signingInfo.signingCertificateHistory
+                    }
+                }
+                .orEmpty()
+                .map { it.toByteArray() }
+        } else {
+            packageManager
+                .getPackageInfo(packageName, PackageManager.GET_SIGNATURES)
+                .signatures
+                .orEmpty()
+                .map { it.toByteArray() }
+        }
+    }.getOrDefault(emptyList())
+
+private fun ByteArray.digest(algorithm: String): String =
+    MessageDigest.getInstance(algorithm)
+        .digest(this)
+        .toHex()
+
+private fun ByteArray.toHex(): String =
+    joinToString(separator = "") { "%02x".format(it) }

--- a/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/mvi/SettingsIntent.kt
+++ b/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/mvi/SettingsIntent.kt
@@ -22,6 +22,8 @@ sealed class SettingsIntent : MVIIntent {
         val preferences: UserPreferences,
     ) : SettingsIntent()
 
+    data object RunFirestoreDiagnostics : SettingsIntent()
+
     /**
      * Represents an intent to sign out the current user.
      *

--- a/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/mvi/SettingsResult.kt
+++ b/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/mvi/SettingsResult.kt
@@ -2,6 +2,7 @@ package com.feragusper.smokeanalytics.features.settings.presentation.mvi
 
 import com.feragusper.smokeanalytics.libraries.architecture.presentation.mvi.MVIResult
 import com.feragusper.smokeanalytics.features.goals.domain.GoalProgress
+import com.feragusper.smokeanalytics.features.settings.presentation.diagnostics.FirestoreDiagnosticsReport
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
 
 /**
@@ -40,6 +41,12 @@ sealed class SettingsResult : MVIResult {
     object UserLoggedOut : SettingsResult()
 
     data object PreferencesSaved : SettingsResult()
+
+    data object FirestoreDiagnosticsRunning : SettingsResult()
+
+    data class FirestoreDiagnosticsFinished(
+        val report: FirestoreDiagnosticsReport,
+    ) : SettingsResult()
 
     data class Error(val message: String) : SettingsResult()
 }

--- a/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/mvi/compose/SettingsViewState.kt
+++ b/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/mvi/compose/SettingsViewState.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -45,6 +46,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -53,6 +55,7 @@ import com.feragusper.smokeanalytics.features.settings.presentation.AboutSection
 import com.feragusper.smokeanalytics.features.settings.presentation.GoalsEditorScreen
 import com.feragusper.smokeanalytics.features.settings.presentation.R
 import com.feragusper.smokeanalytics.features.goals.domain.GoalProgress
+import com.feragusper.smokeanalytics.features.settings.presentation.diagnostics.FirestoreDiagnosticsReport
 import com.feragusper.smokeanalytics.features.settings.presentation.mvi.SettingsIntent
 import com.feragusper.smokeanalytics.libraries.architecture.presentation.mvi.MVIViewState
 import com.feragusper.smokeanalytics.libraries.authentication.presentation.compose.GoogleSignInComponent
@@ -70,6 +73,8 @@ data class SettingsViewState(
     internal val goalProgress: GoalProgress? = null,
     internal val infoMessage: String? = null,
     internal val errorMessage: String? = null,
+    internal val firestoreDiagnosticsRunning: Boolean = false,
+    internal val firestoreDiagnosticsReport: FirestoreDiagnosticsReport? = null,
 ) : MVIViewState<SettingsIntent> {
 
     interface TestTags {
@@ -187,6 +192,18 @@ data class SettingsViewState(
                 onPreferencesChange = { draftPreferences = it },
                 onSave = { intent(SettingsIntent.UpdatePreferences(draftPreferences)) },
                 onReset = { draftPreferences = preferences },
+            )
+
+            SettingsSectionHeader(
+                title = "Diagnostics",
+                subtitle = "Runtime Firestore write/read probes for the installed app build.",
+            )
+
+            FirestoreDiagnosticsCard(
+                enabled = !displayLoading && !firestoreDiagnosticsRunning && currentEmail != null,
+                running = firestoreDiagnosticsRunning,
+                report = firestoreDiagnosticsReport,
+                onRun = { intent(SettingsIntent.RunFirestoreDiagnostics) },
             )
 
             SettingsSectionHeader(
@@ -887,6 +904,71 @@ private fun TimePreferenceRow(
             enabled = enabled,
         ) {
             Text("Change")
+        }
+    }
+}
+
+@Composable
+private fun FirestoreDiagnosticsCard(
+    enabled: Boolean,
+    running: Boolean,
+    report: FirestoreDiagnosticsReport?,
+    onRun: () -> Unit,
+) {
+    SettingsCard(
+        title = "Firestore diagnostics",
+        subtitle = "Production identity, smoke write/delete, and preferences merge verification.",
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                StatusBadge(
+                    text = when {
+                        running -> "Running"
+                        report?.successful == true -> "Pass"
+                        report?.successful == false -> "Fail"
+                        else -> "Ready"
+                    }
+                )
+                Button(
+                    onClick = onRun,
+                    enabled = enabled,
+                ) {
+                    Text(if (running) "Running" else "Run")
+                }
+            }
+
+            report?.let {
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = if (it.successful) {
+                            MaterialTheme.colorScheme.surfaceContainerLow
+                        } else {
+                            MaterialTheme.colorScheme.errorContainer
+                        },
+                        contentColor = if (it.successful) {
+                            MaterialTheme.colorScheme.onSurface
+                        } else {
+                            MaterialTheme.colorScheme.onErrorContainer
+                        },
+                    ),
+                    shape = RoundedCornerShape(16.dp),
+                ) {
+                    SelectionContainer {
+                        Text(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(14.dp),
+                            text = it.details,
+                            style = MaterialTheme.typography.bodySmall,
+                            fontFamily = FontFamily.Monospace,
+                        )
+                    }
+                }
+            }
         }
     }
 }

--- a/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/process/SettingsProcessHolder.kt
+++ b/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/process/SettingsProcessHolder.kt
@@ -2,6 +2,8 @@ package com.feragusper.smokeanalytics.features.settings.presentation.process
 
 import com.feragusper.smokeanalytics.features.goals.domain.EvaluateGoalProgressUseCase
 import com.feragusper.smokeanalytics.features.goals.domain.goalDataFetchStart
+import com.feragusper.smokeanalytics.features.settings.presentation.diagnostics.FirestoreDiagnosticsReport
+import com.feragusper.smokeanalytics.features.settings.presentation.diagnostics.FirestoreDiagnosticsRunner
 import com.feragusper.smokeanalytics.features.settings.presentation.mvi.SettingsIntent
 import com.feragusper.smokeanalytics.features.settings.presentation.mvi.SettingsResult
 import com.feragusper.smokeanalytics.libraries.architecture.presentation.extensions.debugSummary
@@ -34,6 +36,7 @@ class SettingsProcessHolder @Inject constructor(
     private val fetchUserPreferencesUseCase: FetchUserPreferencesUseCase,
     private val updateUserPreferencesUseCase: UpdateUserPreferencesUseCase,
     private val fetchSmokesUseCase: FetchSmokesUseCase,
+    private val firestoreDiagnosticsRunner: FirestoreDiagnosticsRunner,
     private val evaluateGoalProgressUseCase: EvaluateGoalProgressUseCase = EvaluateGoalProgressUseCase(),
 ) : MVIProcessHolder<SettingsIntent, SettingsResult> {
 
@@ -47,6 +50,7 @@ class SettingsProcessHolder @Inject constructor(
         SettingsIntent.FetchUser -> processFetchUser()
         SettingsIntent.SignOut -> processSignOut()
         is SettingsIntent.UpdatePreferences -> processUpdatePreferences(intent.preferences)
+        SettingsIntent.RunFirestoreDiagnostics -> processFirestoreDiagnostics()
     }
 
     /**
@@ -111,5 +115,19 @@ class SettingsProcessHolder @Inject constructor(
         emit(SettingsResult.PreferencesSaved)
     }.catch { error ->
         emit(SettingsResult.Error("Could not save your settings. ${error.debugSummary()}"))
+    }
+
+    private fun processFirestoreDiagnostics(): Flow<SettingsResult> = flow {
+        emit(SettingsResult.FirestoreDiagnosticsRunning)
+        emit(SettingsResult.FirestoreDiagnosticsFinished(firestoreDiagnosticsRunner()))
+    }.catch { error ->
+        emit(
+            SettingsResult.FirestoreDiagnosticsFinished(
+                FirestoreDiagnosticsReport(
+                    successful = false,
+                    details = "SmokeAnalytics Firestore diagnostics\nresult=FAIL reason=${error.debugSummary()}",
+                )
+            )
+        )
     }
 }

--- a/features/settings/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/settings/presentation/process/SettingsProcessHolderTest.kt
+++ b/features/settings/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/settings/presentation/process/SettingsProcessHolderTest.kt
@@ -1,6 +1,8 @@
 package com.feragusper.smokeanalytics.features.settings.presentation.process
 
 import app.cash.turbine.test
+import com.feragusper.smokeanalytics.features.settings.presentation.diagnostics.FirestoreDiagnosticsReport
+import com.feragusper.smokeanalytics.features.settings.presentation.diagnostics.FirestoreDiagnosticsRunner
 import com.feragusper.smokeanalytics.features.settings.presentation.mvi.SettingsIntent
 import com.feragusper.smokeanalytics.features.settings.presentation.mvi.SettingsResult
 import com.feragusper.smokeanalytics.libraries.authentication.domain.FetchSessionUseCase
@@ -35,6 +37,7 @@ class SettingsProcessHolderTest {
     private val fetchUserPreferencesUseCase: FetchUserPreferencesUseCase = mockk()
     private val updateUserPreferencesUseCase: UpdateUserPreferencesUseCase = mockk()
     private val fetchSmokesUseCase: FetchSmokesUseCase = mockk()
+    private val firestoreDiagnosticsRunner: FirestoreDiagnosticsRunner = mockk()
 
     /**
      * Sets up the test environment by initializing the process holder and configuring mock behaviors.
@@ -48,6 +51,7 @@ class SettingsProcessHolderTest {
             fetchUserPreferencesUseCase = fetchUserPreferencesUseCase,
             updateUserPreferencesUseCase = updateUserPreferencesUseCase,
             fetchSmokesUseCase = fetchSmokesUseCase,
+            firestoreDiagnosticsRunner = firestoreDiagnosticsRunner,
         )
     }
 
@@ -181,6 +185,36 @@ class SettingsProcessHolderTest {
                 awaitItem() shouldBeEqualTo SettingsResult.Error(
                     "Could not save your settings. IllegalStateException: Firestore update preferences timed out"
                 )
+                awaitComplete()
+            }
+        }
+
+    @Test
+    fun `WHEN RunFirestoreDiagnostics succeeds THEN emits diagnostic report`() =
+        runTest {
+            val report = FirestoreDiagnosticsReport(
+                successful = true,
+                details = "result=PASS",
+            )
+            coEvery { firestoreDiagnosticsRunner() } returns report
+
+            processHolder.processIntent(SettingsIntent.RunFirestoreDiagnostics).test {
+                awaitItem() shouldBeEqualTo SettingsResult.FirestoreDiagnosticsRunning
+                awaitItem() shouldBeEqualTo SettingsResult.FirestoreDiagnosticsFinished(report)
+                awaitComplete()
+            }
+        }
+
+    @Test
+    fun `WHEN RunFirestoreDiagnostics fails unexpectedly THEN emits diagnostic failure report`() =
+        runTest {
+            coEvery { firestoreDiagnosticsRunner() } throws IllegalStateException("boom")
+
+            processHolder.processIntent(SettingsIntent.RunFirestoreDiagnostics).test {
+                awaitItem() shouldBeEqualTo SettingsResult.FirestoreDiagnosticsRunning
+                val result = awaitItem() as SettingsResult.FirestoreDiagnosticsFinished
+                result.report.successful shouldBeEqualTo false
+                result.report.details.contains("boom") shouldBeEqualTo true
                 awaitComplete()
             }
         }

--- a/libraries/preferences/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImpl.kt
+++ b/libraries/preferences/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImpl.kt
@@ -35,25 +35,9 @@ class UserPreferencesRepositoryImpl @Inject constructor(
 
     override suspend fun update(preferences: UserPreferences) {
         runFirestoreProfileCall("update preferences") {
-            document().set(
-                UserPreferencesEntity(
-                    packPrice = preferences.packPrice,
-                    cigarettesPerPack = preferences.cigarettesPerPack.toLong(),
-                    dayStartHour = preferences.dayStartHour.toLong(),
-                    bedtimeHour = preferences.bedtimeHour.toLong(),
-                    manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
-                    locationTrackingEnabled = preferences.locationTrackingEnabled,
-                    currencySymbol = preferences.currencySymbol,
-                    accountTier = preferences.accountTier.name,
-                    activeGoalType = preferences.activeGoal?.type?.name,
-                    activeGoalMetricValue = preferences.activeGoal?.metricValue,
-                )
-            )
-                .await()
+            document().set(preferences.toFirestorePayload()).await()
             val serverSnapshot = document().get(Source.SERVER).await()
-            check(serverSnapshot.exists()) {
-                "Firestore update preferences verification failed: ${document().path} is missing on server."
-            }
+            serverSnapshot.requirePreferenceFields(preferences, document().path)
         }
     }
 
@@ -99,33 +83,115 @@ class UserPreferencesRepositoryImpl @Inject constructor(
     }
 }
 
+private fun UserPreferences.toFirestorePayload(): Map<String, Any?> =
+    mapOf(
+        UserPreferencesEntity.PACK_PRICE to packPrice,
+        UserPreferencesEntity.CIGARETTES_PER_PACK to cigarettesPerPack.toLong(),
+        UserPreferencesEntity.DAY_START_HOUR to dayStartHour.toLong(),
+        UserPreferencesEntity.BEDTIME_HOUR to bedtimeHour.toLong(),
+        UserPreferencesEntity.MANUAL_DAY_START_EPOCH_MILLIS to manualDayStartEpochMillis,
+        UserPreferencesEntity.LOCATION_TRACKING_ENABLED to locationTrackingEnabled,
+        UserPreferencesEntity.CURRENCY_SYMBOL to currencySymbol,
+        UserPreferencesEntity.ACCOUNT_TIER to accountTier.name,
+        UserPreferencesEntity.ACTIVE_GOAL_TYPE to activeGoal?.type?.name,
+        UserPreferencesEntity.ACTIVE_GOAL_METRIC_VALUE to activeGoal?.metricValue,
+    )
+
+private fun DocumentSnapshot.requirePreferenceFields(expected: UserPreferences, path: String) {
+    check(exists()) {
+        "Firestore update preferences verification failed: $path is missing on server."
+    }
+
+    check(numberOrNull(UserPreferencesEntity.PACK_PRICE)?.toDouble() == expected.packPrice) {
+        "Firestore update preferences verification failed: $path has invalid packPrice."
+    }
+    check(numberOrNull(UserPreferencesEntity.CIGARETTES_PER_PACK)?.toInt() == expected.cigarettesPerPack) {
+        "Firestore update preferences verification failed: $path has invalid cigarettesPerPack."
+    }
+    check(numberOrNull(UserPreferencesEntity.DAY_START_HOUR)?.toInt() == expected.dayStartHour) {
+        "Firestore update preferences verification failed: $path has invalid dayStartHour."
+    }
+    check(numberOrNull(UserPreferencesEntity.BEDTIME_HOUR)?.toInt() == expected.bedtimeHour) {
+        "Firestore update preferences verification failed: $path has invalid bedtimeHour."
+    }
+    check(numberOrNull(UserPreferencesEntity.MANUAL_DAY_START_EPOCH_MILLIS)?.toLong() == expected.manualDayStartEpochMillis) {
+        "Firestore update preferences verification failed: $path has invalid manualDayStartEpochMillis."
+    }
+    check(booleanOrNull(UserPreferencesEntity.LOCATION_TRACKING_ENABLED) == expected.locationTrackingEnabled) {
+        "Firestore update preferences verification failed: $path has invalid locationTrackingEnabled."
+    }
+    check(stringOrNull(UserPreferencesEntity.CURRENCY_SYMBOL) == expected.currencySymbol) {
+        "Firestore update preferences verification failed: $path has invalid currencySymbol."
+    }
+    check(stringOrNull(UserPreferencesEntity.ACCOUNT_TIER) == expected.accountTier.name) {
+        "Firestore update preferences verification failed: $path has invalid accountTier."
+    }
+    check(stringOrNull(UserPreferencesEntity.ACTIVE_GOAL_TYPE) == expected.activeGoal?.type?.name) {
+        "Firestore update preferences verification failed: $path has invalid activeGoalType."
+    }
+    check(numberOrNull(UserPreferencesEntity.ACTIVE_GOAL_METRIC_VALUE)?.toDouble() == expected.activeGoal?.metricValue) {
+        "Firestore update preferences verification failed: $path has invalid activeGoalMetricValue."
+    }
+}
+
 private fun DocumentSnapshot.toUserPreferencesEntity(): UserPreferencesEntity? {
     if (!exists()) return null
 
     return UserPreferencesEntity(
-        packPrice = numberOrNull(UserPreferencesEntity.PACK_PRICE)?.toDouble() ?: 0.0,
-        cigarettesPerPack = numberOrNull(UserPreferencesEntity.CIGARETTES_PER_PACK)?.toLong() ?: 20,
-        dayStartHour = numberOrNull(UserPreferencesEntity.DAY_START_HOUR)?.toLong() ?: 6,
-        bedtimeHour = numberOrNull(UserPreferencesEntity.BEDTIME_HOUR)?.toLong() ?: 22,
-        manualDayStartEpochMillis = numberOrNull(UserPreferencesEntity.MANUAL_DAY_START_EPOCH_MILLIS)?.toLong(),
-        locationTrackingEnabled = booleanOrNull(UserPreferencesEntity.LOCATION_TRACKING_ENABLED) ?: false,
-        currencySymbol = stringOrNull(UserPreferencesEntity.CURRENCY_SYMBOL) ?: "€",
-        accountTier = stringOrNull(UserPreferencesEntity.ACCOUNT_TIER) ?: "Free",
-        activeGoalType = stringOrNull(UserPreferencesEntity.ACTIVE_GOAL_TYPE),
-        activeGoalMetricValue = numberOrNull(UserPreferencesEntity.ACTIVE_GOAL_METRIC_VALUE)?.toDouble(),
+        packPrice = numberOrNull(UserPreferencesEntity.PACK_PRICE, LegacyUserPreferencesFields.PACK_PRICE)?.toDouble() ?: 0.0,
+        cigarettesPerPack = numberOrNull(
+            UserPreferencesEntity.CIGARETTES_PER_PACK,
+            LegacyUserPreferencesFields.CIGARETTES_PER_PACK,
+        )?.toLong() ?: 20,
+        dayStartHour = numberOrNull(UserPreferencesEntity.DAY_START_HOUR, LegacyUserPreferencesFields.DAY_START_HOUR)
+            ?.toLong() ?: 6,
+        bedtimeHour = numberOrNull(UserPreferencesEntity.BEDTIME_HOUR, LegacyUserPreferencesFields.BEDTIME_HOUR)
+            ?.toLong() ?: 22,
+        manualDayStartEpochMillis = numberOrNull(
+            UserPreferencesEntity.MANUAL_DAY_START_EPOCH_MILLIS,
+            LegacyUserPreferencesFields.MANUAL_DAY_START_EPOCH_MILLIS,
+        )?.toLong(),
+        locationTrackingEnabled = booleanOrNull(
+            UserPreferencesEntity.LOCATION_TRACKING_ENABLED,
+            LegacyUserPreferencesFields.LOCATION_TRACKING_ENABLED,
+        ) ?: false,
+        currencySymbol = stringOrNull(UserPreferencesEntity.CURRENCY_SYMBOL, LegacyUserPreferencesFields.CURRENCY_SYMBOL)
+            ?: "€",
+        accountTier = stringOrNull(UserPreferencesEntity.ACCOUNT_TIER, LegacyUserPreferencesFields.ACCOUNT_TIER) ?: "Free",
+        activeGoalType = stringOrNull(UserPreferencesEntity.ACTIVE_GOAL_TYPE, LegacyUserPreferencesFields.ACTIVE_GOAL_TYPE),
+        activeGoalMetricValue = numberOrNull(
+            UserPreferencesEntity.ACTIVE_GOAL_METRIC_VALUE,
+            LegacyUserPreferencesFields.ACTIVE_GOAL_METRIC_VALUE,
+        )?.toDouble(),
     )
 }
 
-private fun DocumentSnapshot.numberOrNull(field: String): Number? =
+private object LegacyUserPreferencesFields {
+    const val PACK_PRICE = "a"
+    const val CIGARETTES_PER_PACK = "b"
+    const val DAY_START_HOUR = "c"
+    const val BEDTIME_HOUR = "d"
+    const val MANUAL_DAY_START_EPOCH_MILLIS = "e"
+    const val LOCATION_TRACKING_ENABLED = "f"
+    const val CURRENCY_SYMBOL = "g"
+    const val ACCOUNT_TIER = "h"
+    const val ACTIVE_GOAL_TYPE = "i"
+    const val ACTIVE_GOAL_METRIC_VALUE = "j"
+}
+
+private fun DocumentSnapshot.numberOrNull(field: String, legacyField: String? = null): Number? =
     runCatching { getDouble(field) }.getOrNull()
         ?: runCatching { getLong(field) }.getOrNull()
         ?: stringOrNull(field)?.toDoubleOrNull()
+        ?: legacyField?.let { numberOrNull(it) }
 
-private fun DocumentSnapshot.stringOrNull(field: String): String? =
+private fun DocumentSnapshot.stringOrNull(field: String, legacyField: String? = null): String? =
     runCatching { getString(field) }.getOrNull()
+        ?: legacyField?.let { stringOrNull(it) }
 
-private fun DocumentSnapshot.booleanOrNull(field: String): Boolean? =
+private fun DocumentSnapshot.booleanOrNull(field: String, legacyField: String? = null): Boolean? =
     runCatching { getBoolean(field) }.getOrNull()
+        ?: legacyField?.let { booleanOrNull(it) }
 
 private fun Throwable.firestoreSummary(): String {
     val firestoreException = (this as? FirebaseFirestoreException) ?: (cause as? FirebaseFirestoreException)

--- a/libraries/preferences/data/mobile/src/test/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImplTest.kt
+++ b/libraries/preferences/data/mobile/src/test/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImplTest.kt
@@ -1,0 +1,205 @@
+package com.feragusper.smokeanalytics.libraries.preferences.data
+
+import android.content.Context
+import com.feragusper.smokeanalytics.libraries.preferences.domain.AccountTier
+import com.feragusper.smokeanalytics.libraries.preferences.domain.SmokingGoal
+import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
+import com.google.android.gms.tasks.Task
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Source
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class UserPreferencesRepositoryImplTest {
+
+    private val firestore: FirebaseFirestore = mockk()
+    private val auth: FirebaseAuth = mockk()
+    private val appContext: Context = mockk(relaxed = true)
+    private val usersCollection: CollectionReference = mockk()
+    private val userDocument: DocumentReference = mockk()
+    private val profileCollection: CollectionReference = mockk()
+    private val preferencesDocument: DocumentReference = mockk()
+
+    private val repository = UserPreferencesRepositoryImpl(
+        firestore = firestore,
+        auth = auth,
+        appContext = appContext,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        val user = mockk<FirebaseUser>()
+        every { user.uid } returns UID
+        every { auth.currentUser } returns user
+
+        every { firestore.collection("users") } returns usersCollection
+        every { usersCollection.document(UID) } returns userDocument
+        every { userDocument.collection("profile") } returns profileCollection
+        every { profileCollection.document(UserPreferencesEntity.DOCUMENT) } returns preferencesDocument
+        every { preferencesDocument.path } returns "users/$UID/profile/${UserPreferencesEntity.DOCUMENT}"
+    }
+
+    @Test
+    fun `GIVEN preferences WHEN update is called THEN it writes explicit Firestore field names`() = runTest {
+        val preferences = UserPreferences(
+            packPrice = 12.5,
+            cigarettesPerPack = 25,
+            dayStartHour = 7,
+            bedtimeHour = 23,
+            manualDayStartEpochMillis = 1_714_000_000_000,
+            locationTrackingEnabled = true,
+            currencySymbol = "$",
+            accountTier = AccountTier.Free,
+            activeGoal = SmokingGoal.MindfulGap(targetMinutes = 120),
+        )
+        val payloadSlot = slot<Map<String, Any?>>()
+
+        every { preferencesDocument.set(capture(payloadSlot)) } returns voidTask()
+        every { preferencesDocument.get(Source.SERVER) } returns taskOf(preferencesSnapshot(preferences))
+
+        repository.update(preferences)
+
+        val payload = payloadSlot.captured
+        assertEquals(preferences.packPrice, payload[UserPreferencesEntity.PACK_PRICE])
+        assertEquals(preferences.cigarettesPerPack.toLong(), payload[UserPreferencesEntity.CIGARETTES_PER_PACK])
+        assertEquals(preferences.dayStartHour.toLong(), payload[UserPreferencesEntity.DAY_START_HOUR])
+        assertEquals(preferences.bedtimeHour.toLong(), payload[UserPreferencesEntity.BEDTIME_HOUR])
+        assertEquals(preferences.manualDayStartEpochMillis, payload[UserPreferencesEntity.MANUAL_DAY_START_EPOCH_MILLIS])
+        assertEquals(preferences.locationTrackingEnabled, payload[UserPreferencesEntity.LOCATION_TRACKING_ENABLED])
+        assertEquals(preferences.currencySymbol, payload[UserPreferencesEntity.CURRENCY_SYMBOL])
+        assertEquals(preferences.accountTier.name, payload[UserPreferencesEntity.ACCOUNT_TIER])
+        assertEquals(preferences.activeGoal?.type?.name, payload[UserPreferencesEntity.ACTIVE_GOAL_TYPE])
+        assertEquals(preferences.activeGoal?.metricValue, payload[UserPreferencesEntity.ACTIVE_GOAL_METRIC_VALUE])
+    }
+
+    @Test
+    fun `GIVEN server verification misses active goal WHEN update completes THEN it throws`() = runTest {
+        val preferences = UserPreferences(activeGoal = SmokingGoal.DailyCap(maxCigarettesPerDay = 8))
+
+        every { preferencesDocument.set(any<Map<String, Any?>>()) } returns voidTask()
+        every { preferencesDocument.get(Source.SERVER) } returns taskOf(
+            preferencesSnapshot(preferences, activeGoalType = null)
+        )
+
+        val error = assertThrows<IllegalStateException> {
+            repository.update(preferences)
+        }
+
+        assertTrue(error.message.orEmpty().contains(UserPreferencesEntity.ACTIVE_GOAL_TYPE))
+    }
+
+    @Test
+    fun `GIVEN Play Store release wrote obfuscated preferences fields WHEN fetch is called THEN it restores them`() =
+        runTest {
+            val preferences = UserPreferences(
+                packPrice = 11.0,
+                cigarettesPerPack = 24,
+                dayStartHour = 8,
+                bedtimeHour = 1,
+                manualDayStartEpochMillis = 1_714_000_000_000,
+                locationTrackingEnabled = true,
+                currencySymbol = "$",
+                accountTier = AccountTier.Free,
+                activeGoal = SmokingGoal.ReductionVsPreviousWeek(reductionPercent = 20.0),
+            )
+
+            every { preferencesDocument.get(Source.SERVER) } returns taskOf(
+                preferencesSnapshot(
+                    preferences = preferences,
+                    canonicalFields = false,
+                    legacyFields = true,
+                )
+            )
+
+            val result = repository.fetch()
+
+            assertEquals(preferences, result)
+        }
+
+    private fun preferencesSnapshot(
+        preferences: UserPreferences,
+        activeGoalType: String? = preferences.activeGoal?.type?.name,
+        canonicalFields: Boolean = true,
+        legacyFields: Boolean = false,
+    ): DocumentSnapshot = mockk<DocumentSnapshot>().apply {
+        every { exists() } returns true
+        val doubleFields = buildMap {
+            if (canonicalFields) {
+                put(UserPreferencesEntity.PACK_PRICE, preferences.packPrice)
+                put(UserPreferencesEntity.ACTIVE_GOAL_METRIC_VALUE, preferences.activeGoal?.metricValue)
+            }
+            if (legacyFields) {
+                put("a", preferences.packPrice)
+                put("j", preferences.activeGoal?.metricValue)
+            }
+        }
+        val longFields = buildMap {
+            if (canonicalFields) {
+                put(UserPreferencesEntity.CIGARETTES_PER_PACK, preferences.cigarettesPerPack.toLong())
+                put(UserPreferencesEntity.DAY_START_HOUR, preferences.dayStartHour.toLong())
+                put(UserPreferencesEntity.BEDTIME_HOUR, preferences.bedtimeHour.toLong())
+                put(UserPreferencesEntity.MANUAL_DAY_START_EPOCH_MILLIS, preferences.manualDayStartEpochMillis)
+            }
+            if (legacyFields) {
+                put("b", preferences.cigarettesPerPack.toLong())
+                put("c", preferences.dayStartHour.toLong())
+                put("d", preferences.bedtimeHour.toLong())
+                put("e", preferences.manualDayStartEpochMillis)
+            }
+        }
+        val booleanFields = buildMap {
+            if (canonicalFields) put(UserPreferencesEntity.LOCATION_TRACKING_ENABLED, preferences.locationTrackingEnabled)
+            if (legacyFields) put("f", preferences.locationTrackingEnabled)
+        }
+        val stringFields = buildMap {
+            if (canonicalFields) {
+                put(UserPreferencesEntity.CURRENCY_SYMBOL, preferences.currencySymbol)
+                put(UserPreferencesEntity.ACCOUNT_TIER, preferences.accountTier.name)
+                put(UserPreferencesEntity.ACTIVE_GOAL_TYPE, activeGoalType)
+            }
+            if (legacyFields) {
+                put("g", preferences.currencySymbol)
+                put("h", preferences.accountTier.name)
+                put("i", activeGoalType)
+            }
+        }
+        every { getDouble(any<String>()) } answers { doubleFields[firstArg()] }
+        every { getLong(any<String>()) } answers { longFields[firstArg()] }
+        every { getBoolean(any<String>()) } answers { booleanFields[firstArg()] }
+        every { getString(any<String>()) } answers { stringFields[firstArg()] }
+    }
+
+    private fun voidTask(): Task<Void> =
+        mockk<Task<Void>>().apply {
+            every { isComplete } returns true
+            every { isSuccessful } returns true
+            every { isCanceled } returns false
+            every { exception } returns null
+            every { result } returns null
+        }
+
+    private fun <T> taskOf(value: T): Task<T> =
+        mockk<Task<T>>().apply {
+            every { isComplete } returns true
+            every { isSuccessful } returns true
+            every { isCanceled } returns false
+            every { exception } returns null
+            every { result } returns value
+        }
+
+    private companion object {
+        const val UID = "uid"
+    }
+}

--- a/libraries/smokes/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImpl.kt
+++ b/libraries/smokes/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImpl.kt
@@ -51,17 +51,9 @@ class SmokeRepositoryImpl @Inject constructor(
     override suspend fun addSmoke(date: Instant, location: GeoPoint?) {
         runFirestoreCall("add smoke", smokesPath()) {
             val document = smokesQuery().document()
-            document.set(
-                SmokeEntity(
-                    timestampMillis = date.toEpochMilliseconds().toDouble(),
-                    latitude = location?.latitude,
-                    longitude = location?.longitude,
-                )
-            ).await()
+            document.set(smokePayload(date, location)).await()
             val serverSnapshot = document.get(Source.SERVER).await()
-            check(serverSnapshot.exists()) {
-                "Firestore add smoke verification failed: ${document.path} is missing on server."
-            }
+            serverSnapshot.requireSmokeFields(date, "add smoke", document.path)
         }
     }
 
@@ -73,17 +65,9 @@ class SmokeRepositoryImpl @Inject constructor(
                 .await()
                 .getGeoPoint()
 
-            document.set(
-                SmokeEntity(
-                    timestampMillis = date.toEpochMilliseconds().toDouble(),
-                    latitude = preservedLocation?.latitude,
-                    longitude = preservedLocation?.longitude,
-                )
-            ).await()
+            document.set(smokePayload(date, preservedLocation)).await()
             val serverSnapshot = document.get(Source.SERVER).await()
-            check(serverSnapshot.exists()) {
-                "Firestore edit smoke verification failed: ${document.path} is missing on server."
-            }
+            serverSnapshot.requireSmokeFields(date, "edit smoke", document.path)
         }
     }
 
@@ -105,34 +89,26 @@ class SmokeRepositoryImpl @Inject constructor(
         val startMillis = (startDate ?: firstInstantThisMonth()).toEpochMilliseconds().toDouble()
         val endMillis = (endDate ?: nextDayStartInstant()).toEpochMilliseconds().toDouble()
 
-        val query: Query = smokesQuery()
-            .orderBy(SmokeEntity.Fields.TIMESTAMP_MILLIS, Direction.DESCENDING)
-            .whereGreaterThanOrEqualTo(SmokeEntity.Fields.TIMESTAMP_MILLIS, startMillis)
-            .whereLessThan(SmokeEntity.Fields.TIMESTAMP_MILLIS, endMillis)
-
         return runFirestoreCall("fetch smokes", smokesPath()) {
-            val result = query.get(Source.SERVER).await()
-            val previousDocument = smokesQuery()
-                .orderBy(SmokeEntity.Fields.TIMESTAMP_MILLIS, Direction.DESCENDING)
-                .whereLessThan(SmokeEntity.Fields.TIMESTAMP_MILLIS, startMillis)
-                .limit(1)
-                .get(Source.SERVER)
-                .await()
-                .documents
-                .firstOrNull()
+            val canonicalDocuments = fetchSmokeQuery(SmokeEntity.Fields.TIMESTAMP_MILLIS, startMillis, endMillis)
+            val legacyDocuments = fetchSmokeQuery(LegacySmokeFields.TIMESTAMP_MILLIS, startMillis, endMillis)
 
-            val documents = previousDocument?.let { result.documents + it } ?: result.documents
-            val instants = documents.mapNotNull { it.getInstant() }
+            val currentRecords = (canonicalDocuments.current + legacyDocuments.current)
+                .mapNotNull { it.toSmokeRecord() }
+                .distinctBy { it.id }
+                .sortedByDescending { it.instant }
+            val previousRecord = listOfNotNull(canonicalDocuments.previous, legacyDocuments.previous)
+                .mapNotNull { it.toSmokeRecord() }
+                .maxByOrNull { it.instant }
+            val timelineInstants = currentRecords.map { it.instant } + listOfNotNull(previousRecord?.instant)
 
-            result.documents.mapIndexedNotNull { index, document ->
-                val currentInstant = instants.getOrNull(index) ?: return@mapIndexedNotNull null
-                val previousInstant = instants.getOrNull(index + 1)
-
+            currentRecords.mapIndexed { index, record ->
+                val previousInstant = timelineInstants.getOrNull(index + 1)
                 Smoke(
-                    id = document.id,
-                    date = currentInstant,
-                    timeElapsedSincePreviousSmoke = currentInstant.timeAfter(previousInstant),
-                    location = document.getGeoPoint(),
+                    id = record.id,
+                    date = record.instant,
+                    timeElapsedSincePreviousSmoke = record.instant.timeAfter(previousInstant),
+                    location = record.location,
                 )
             }
         }
@@ -178,6 +154,30 @@ class SmokeRepositoryImpl @Inject constructor(
 
     private fun smokesPath(uid: String = firebaseAuth.currentUser?.uid ?: "missing") = "$USERS/$uid/$SMOKES"
 
+    private suspend fun fetchSmokeQuery(
+        timestampField: String,
+        startMillis: Double,
+        endMillis: Double,
+    ): SmokeDocuments {
+        val result = queryByTimestamp(timestampField)
+            .whereGreaterThanOrEqualTo(timestampField, startMillis)
+            .whereLessThan(timestampField, endMillis)
+            .get(Source.SERVER)
+            .await()
+        val previousDocument = queryByTimestamp(timestampField)
+            .whereLessThan(timestampField, startMillis)
+            .limit(1)
+            .get(Source.SERVER)
+            .await()
+            .documents
+            .firstOrNull()
+
+        return SmokeDocuments(current = result.documents, previous = previousDocument)
+    }
+
+    private fun queryByTimestamp(timestampField: String): Query =
+        smokesQuery().orderBy(timestampField, Direction.DESCENDING)
+
     private suspend fun <T> runFirestoreCall(operation: String, path: String, block: suspend () -> T): T =
         try {
             withTimeout(FIRESTORE_TIMEOUT_MILLIS) {
@@ -210,18 +210,65 @@ class SmokeRepositoryImpl @Inject constructor(
     }
 
     private fun DocumentSnapshot.getInstant(): Instant? {
-        val millis = getDouble(SmokeEntity.Fields.TIMESTAMP_MILLIS) ?: return null
+        val millis = getDouble(SmokeEntity.Fields.TIMESTAMP_MILLIS)
+            ?: getDouble(LegacySmokeFields.TIMESTAMP_MILLIS)
+            ?: return null
         return Instant.fromEpochMilliseconds(millis.toLong())
     }
 
     private fun DocumentSnapshot.getGeoPoint(): GeoPoint? {
-        val latitude = getDouble(SmokeEntity.Fields.LATITUDE) ?: return null
-        val longitude = getDouble(SmokeEntity.Fields.LONGITUDE) ?: return null
+        val latitude = getDouble(SmokeEntity.Fields.LATITUDE) ?: getDouble(LegacySmokeFields.LATITUDE) ?: return null
+        val longitude = getDouble(SmokeEntity.Fields.LONGITUDE) ?: getDouble(LegacySmokeFields.LONGITUDE) ?: return null
         return GeoPoint(latitude = latitude, longitude = longitude)
+    }
+
+    private fun DocumentSnapshot.toSmokeRecord(): SmokeRecord? {
+        val instant = getInstant() ?: return null
+        return SmokeRecord(
+            id = id,
+            instant = instant,
+            location = getGeoPoint(),
+        )
+    }
+
+    private fun smokePayload(date: Instant, location: GeoPoint?): Map<String, Any?> =
+        mapOf(
+            SmokeEntity.Fields.TIMESTAMP_MILLIS to date.toEpochMilliseconds().toDouble(),
+            SmokeEntity.Fields.LATITUDE to location?.latitude,
+            SmokeEntity.Fields.LONGITUDE to location?.longitude,
+        )
+
+    private fun DocumentSnapshot.requireSmokeFields(expectedDate: Instant, operation: String, path: String) {
+        check(exists()) {
+            "Firestore $operation verification failed: $path is missing on server."
+        }
+
+        val expectedMillis = expectedDate.toEpochMilliseconds().toDouble()
+        val actualMillis = getDouble(SmokeEntity.Fields.TIMESTAMP_MILLIS)
+        check(actualMillis == expectedMillis) {
+            "Firestore $operation verification failed: $path has timestampMillis=$actualMillis, expected=$expectedMillis."
+        }
     }
 
     private companion object {
         const val FIRESTORE_TIMEOUT_MILLIS = 15_000L
+    }
+
+    private data class SmokeDocuments(
+        val current: List<DocumentSnapshot>,
+        val previous: DocumentSnapshot?,
+    )
+
+    private data class SmokeRecord(
+        val id: String,
+        val instant: Instant,
+        val location: GeoPoint?,
+    )
+
+    private object LegacySmokeFields {
+        const val TIMESTAMP_MILLIS = "a"
+        const val LATITUDE = "b"
+        const val LONGITUDE = "c"
     }
 }
 

--- a/libraries/smokes/data/mobile/src/test/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImplTest.kt
+++ b/libraries/smokes/data/mobile/src/test/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImplTest.kt
@@ -131,14 +131,43 @@ class SmokeRepositoryImplTest {
             }
 
         @Test
+        fun `GIVEN Play Store release wrote obfuscated smoke fields WHEN fetch smokes is called THEN it restores them`() =
+            runTest {
+                mockFetchSmokes(
+                    resultDocuments = emptyList(),
+                    legacyResultDocuments = listOf(
+                        mockDocumentSnapshot(
+                            id = id1,
+                            date = instant1,
+                            timestampMillis = null,
+                            legacyTimestampMillis = instant1.toEpochMilliseconds().toDouble(),
+                        )
+                    ),
+                )
+
+                val result = smokeRepository.fetchSmokes(instant1, Instant.fromEpochMilliseconds(1_672_580_000_000))
+
+                assertEquals(
+                    listOf(
+                        Smoke(
+                            id = id1,
+                            date = instant1,
+                            timeElapsedSincePreviousSmoke = timeAfterNothing,
+                        )
+                    ),
+                    result,
+                )
+            }
+
+        @Test
         fun `GIVEN user is logged in WHEN add smoke is called THEN it should finish`() = runTest {
             val date = Instant.fromEpochMilliseconds(1_672_574_400_000)
-            val smokeEntitySlot = slot<SmokeEntity>()
+            val smokePayloadSlot = slot<Map<String, Any?>>()
             val documentRef = mockk<DocumentReference>()
 
             every { collectionReference.document() } returns documentRef
             every { documentRef.path } returns "$USERS/$uid/$SMOKES/generated"
-            every { documentRef.set(capture(smokeEntitySlot)) } answers {
+            every { documentRef.set(capture(smokePayloadSlot)) } answers {
                 mockk<Task<Void>>().apply {
                     every { isComplete } returns true
                     every { isSuccessful } returns true
@@ -153,11 +182,13 @@ class SmokeRepositoryImplTest {
 
             smokeRepository.addSmoke(date)
 
-            assertTrue(smokeEntitySlot.isCaptured)
+            assertTrue(smokePayloadSlot.isCaptured)
             assertEquals(
                 date.toEpochMilliseconds().toDouble(),
-                smokeEntitySlot.captured.timestampMillis
+                smokePayloadSlot.captured[SmokeEntity.Fields.TIMESTAMP_MILLIS]
             )
+            assertTrue(smokePayloadSlot.captured.containsKey(SmokeEntity.Fields.LATITUDE))
+            assertTrue(smokePayloadSlot.captured.containsKey(SmokeEntity.Fields.LONGITUDE))
         }
 
         @Test
@@ -170,7 +201,7 @@ class SmokeRepositoryImplTest {
             every { documentRef.path } returns "$USERS/$uid/$SMOKES/$id"
             every { documentRef.get(Source.SERVER) } answers { taskOf(mockDocumentSnapshot(id, date)) }
 
-            every { documentRef.set(any<SmokeEntity>()) } answers {
+            every { documentRef.set(any<Map<String, Any?>>()) } answers {
                 mockk<Task<Void>>().apply {
                     every { isComplete } returns true
                     every { isSuccessful } returns true
@@ -182,6 +213,34 @@ class SmokeRepositoryImplTest {
 
             smokeRepository.editSmoke(id, date)
         }
+
+        @Test
+        fun `GIVEN server write omits timestamp WHEN add smoke verifies server state THEN it should throw`() =
+            runTest {
+                val date = Instant.fromEpochMilliseconds(1_672_574_400_000)
+                val documentRef = mockk<DocumentReference>()
+
+                every { collectionReference.document() } returns documentRef
+                every { documentRef.path } returns "$USERS/$uid/$SMOKES/generated"
+                every { documentRef.set(any<Map<String, Any?>>()) } answers {
+                    mockk<Task<Void>>().apply {
+                        every { isComplete } returns true
+                        every { isSuccessful } returns true
+                        every { result } returns null
+                        every { exception } returns null
+                        every { isCanceled } returns false
+                    }
+                }
+                every { documentRef.get(Source.SERVER) } answers {
+                    taskOf(mockDocumentSnapshot("generated", date, timestampMillis = null))
+                }
+
+                val error = assertThrows<IllegalStateException> {
+                    smokeRepository.addSmoke(date)
+                }
+
+                assertTrue(error.message.orEmpty().contains("timestampMillis"))
+            }
 
         @Test
         fun `GIVEN user is logged in WHEN delete smoke is called THEN it should finish`() =
@@ -214,6 +273,25 @@ class SmokeRepositoryImplTest {
                 mockDocumentSnapshot(id2, instant2),
             ),
             previousDocument: DocumentSnapshot? = null,
+            legacyResultDocuments: List<DocumentSnapshot> = emptyList(),
+            legacyPreviousDocument: DocumentSnapshot? = null,
+        ) {
+            mockSmokeQuery(
+                field = SmokeEntity.Fields.TIMESTAMP_MILLIS,
+                resultDocuments = resultDocuments,
+                previousDocument = previousDocument,
+            )
+            mockSmokeQuery(
+                field = "a",
+                resultDocuments = legacyResultDocuments,
+                previousDocument = legacyPreviousDocument,
+            )
+        }
+
+        private fun mockSmokeQuery(
+            field: String,
+            resultDocuments: List<DocumentSnapshot>,
+            previousDocument: DocumentSnapshot?,
         ) {
             val query = mockk<Query>(relaxed = true)
             val finalQuery = mockk<Query>(relaxed = true)
@@ -222,20 +300,20 @@ class SmokeRepositoryImplTest {
 
             every {
                 collectionReference.orderBy(
-                    SmokeEntity.Fields.TIMESTAMP_MILLIS,
+                    field,
                     Query.Direction.DESCENDING
                 )
             } returns query
 
             every {
-                query.whereGreaterThanOrEqualTo(any<String>(), any())
+                query.whereGreaterThanOrEqualTo(field, any())
             } returns finalQuery
 
             every {
-                finalQuery.whereLessThan(any<String>(), any())
+                finalQuery.whereLessThan(field, any())
             } returns finalQuery
             every {
-                query.whereLessThan(any<String>(), any())
+                query.whereLessThan(field, any())
             } returns previousQuery
             every {
                 previousQuery.limit(1)
@@ -269,14 +347,22 @@ class SmokeRepositoryImplTest {
             }
         }
 
-        private fun mockDocumentSnapshot(id: String, date: Instant, exists: Boolean = true): DocumentSnapshot {
+        private fun mockDocumentSnapshot(
+            id: String,
+            date: Instant,
+            exists: Boolean = true,
+            timestampMillis: Double? = date.toEpochMilliseconds().toDouble(),
+            legacyTimestampMillis: Double? = null,
+        ): DocumentSnapshot {
             return mockk<DocumentSnapshot>().apply {
                 every { this@apply.id } returns id
                 every { exists() } returns exists
-                every { getDouble(SmokeEntity.Fields.TIMESTAMP_MILLIS) } returns date.toEpochMilliseconds()
-                    .toDouble()
+                every { getDouble(SmokeEntity.Fields.TIMESTAMP_MILLIS) } returns timestampMillis
                 every { getDouble(SmokeEntity.Fields.LATITUDE) } returns null
                 every { getDouble(SmokeEntity.Fields.LONGITUDE) } returns null
+                every { getDouble("a") } returns legacyTimestampMillis
+                every { getDouble("b") } returns null
+                every { getDouble("c") } returns null
             }
         }
 
@@ -288,5 +374,6 @@ class SmokeRepositoryImplTest {
                 every { exception } returns null
                 every { result } returns value
             }
+
     }
 }


### PR DESCRIPTION
This PR hardens mobile Firestore smoke/preference writes with explicit field maps, adds legacy obfuscated-field read fallback, and adds a production-accessible Settings diagnostics panel. The diagnostic records package, installer, runtime signing SHA-1/SHA-256, Firebase project/app metadata, authenticated uid, and server-verified smoke write/read/delete plus preferences merge/read probes. This is intentionally aimed at the Play Store-only failure where local productionRelease works but the installed Store artifact does not.