### PR TITLE
Clarify home widget countdown and compact cards

### DIFF
--- a/apps/mobile/src/main/java/com/feragusper/smokeanalytics/widget/HomeStatusWidget.kt
+++ b/apps/mobile/src/main/java/com/feragusper/smokeanalytics/widget/HomeStatusWidget.kt
@@ -2,6 +2,10 @@ package com.feragusper.smokeanalytics.widget
 
 import android.content.Context
 import android.content.Intent
+import android.os.Build
+import android.os.SystemClock
+import android.util.TypedValue
+import android.widget.RemoteViews
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -9,8 +13,10 @@ import androidx.compose.ui.unit.sp
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
+import androidx.glance.LocalContext
 import androidx.glance.LocalSize
 import androidx.glance.action.clickable
+import androidx.glance.appwidget.AndroidRemoteViews
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.action.actionStartActivity
@@ -31,9 +37,12 @@ import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import com.feragusper.smokeanalytics.MainActivity
+import com.feragusper.smokeanalytics.R
+import com.feragusper.smokeanalytics.features.goals.domain.EvaluateGoalProgressUseCase
 import com.feragusper.smokeanalytics.features.home.domain.FetchSmokeCountListUseCase
 import com.feragusper.smokeanalytics.libraries.architecture.domain.WidgetSnapshot
 import com.feragusper.smokeanalytics.libraries.preferences.domain.FetchUserPreferencesUseCase
+import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.FetchSmokesUseCase
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
@@ -65,7 +74,9 @@ class HomeStatusWidgetReceiver : GlanceAppWidgetReceiver() {
 @EntryPoint
 @InstallIn(SingletonComponent::class)
 internal interface HomeStatusWidgetEntryPoint {
+    fun evaluateGoalProgressUseCase(): EvaluateGoalProgressUseCase
     fun fetchSmokeCountListUseCase(): FetchSmokeCountListUseCase
+    fun fetchSmokesUseCase(): FetchSmokesUseCase
     fun fetchUserPreferencesUseCase(): FetchUserPreferencesUseCase
 }
 
@@ -80,7 +91,6 @@ private fun WidgetContent(
     val elapsedMinutes = snapshot.elapsedHours * 60L + snapshot.elapsedMinutes
     val remainingMinutes = snapshot.remainingMinutesUntilNextSmoke()
     val progressFraction = snapshot.progressFraction()
-    val status = snapshot.gapStatus()
 
     Column(
         modifier = GlanceModifier
@@ -98,8 +108,7 @@ private fun WidgetContent(
         )
         Spacer(GlanceModifier.height(if (compact) 6.dp else 10.dp))
         GapHeroCard(
-            remainingLabel = remainingMinutes.toNextSmokeLabel(),
-            status = status,
+            remainingMinutes = remainingMinutes,
             targetLabel = snapshot.targetGapMinutes.toGapLabel(),
             progressFraction = progressFraction,
             compact = compact,
@@ -111,14 +120,12 @@ private fun WidgetContent(
             horizontalAlignment = Alignment.Horizontal.CenterHorizontally,
         ) {
             MetricCard(
-                marker = "TOD",
                 label = "Today",
                 value = snapshot.todayCount.toString(),
                 modifier = GlanceModifier.defaultWeight(),
             )
             Spacer(GlanceModifier.width(6.dp))
             MetricCard(
-                marker = "AVG",
                 label = "7d avg",
                 value = snapshot.averageSmokesPerDayWeek.formatOneDecimal(),
                 modifier = GlanceModifier.defaultWeight(),
@@ -126,7 +133,6 @@ private fun WidgetContent(
             if (!compact) {
                 Spacer(GlanceModifier.width(6.dp))
                 MetricCard(
-                    marker = "SIN",
                     label = "Since last",
                     value = elapsedMinutes.toDurationLabel(),
                     modifier = GlanceModifier.defaultWeight(),
@@ -180,8 +186,7 @@ private fun WidgetHeader(
 
 @Composable
 private fun GapHeroCard(
-    remainingLabel: String,
-    status: GapStatus,
+    remainingMinutes: Long,
     targetLabel: String,
     progressFraction: Float,
     compact: Boolean,
@@ -203,24 +208,26 @@ private fun GapHeroCard(
             verticalAlignment = Alignment.Vertical.CenterVertically,
             horizontalAlignment = Alignment.Horizontal.CenterHorizontally,
         ) {
-            StatusMarker(status)
-            Spacer(GlanceModifier.width(8.dp))
             Column(
                 modifier = GlanceModifier.defaultWeight(),
                 verticalAlignment = Alignment.Vertical.CenterVertically,
                 horizontalAlignment = Alignment.Horizontal.Start,
             ) {
                 Text(
-                    text = remainingLabel,
+                    text = "Next smoke",
                     style = TextStyle(
-                        color = WidgetColors.Text,
-                        fontSize = if (compact) 20.sp else 26.sp,
+                        color = WidgetColors.Primary,
+                        fontSize = if (compact) 11.sp else 12.sp,
                         fontWeight = FontWeight.Bold,
                     ),
                     maxLines = 1,
                 )
+                NextSmokeCountdown(
+                    remainingMinutes = remainingMinutes,
+                    compact = compact,
+                )
                 Text(
-                    text = status.message(targetLabel),
+                    text = "Target wait $targetLabel",
                     style = TextStyle(
                         color = WidgetColors.Muted,
                         fontSize = if (compact) 11.sp else 12.sp,
@@ -237,20 +244,51 @@ private fun GapHeroCard(
 }
 
 @Composable
-private fun StatusMarker(status: GapStatus) {
-    Text(
-        text = status.marker,
-        modifier = GlanceModifier
-            .background(status.container)
-            .cornerRadius(14.dp)
-            .padding(horizontal = 7.dp, vertical = 5.dp),
-        style = TextStyle(
-            color = status.content,
-            fontSize = 11.sp,
-            fontWeight = FontWeight.Bold,
+private fun NextSmokeCountdown(
+    remainingMinutes: Long,
+    compact: Boolean,
+) {
+    if (remainingMinutes <= 0L) {
+        Text(
+            text = "Ready now",
+            style = TextStyle(
+                color = WidgetColors.Text,
+                fontSize = if (compact) 22.sp else 28.sp,
+                fontWeight = FontWeight.Bold,
+            ),
+            maxLines = 1,
+        )
+        return
+    }
+
+    AndroidRemoteViews(
+        remoteViews = nextSmokeChronometerRemoteViews(
+            context = LocalContext.current,
+            remainingMinutes = remainingMinutes,
+            compact = compact,
         ),
-        maxLines = 1,
+        modifier = GlanceModifier.fillMaxWidth(),
     )
+}
+
+private fun nextSmokeChronometerRemoteViews(
+    context: Context,
+    remainingMinutes: Long,
+    compact: Boolean,
+): RemoteViews {
+    val base = SystemClock.elapsedRealtime() + remainingMinutes * MILLIS_PER_MINUTE
+    return RemoteViews(context.packageName, R.layout.widget_next_smoke_chronometer).apply {
+        setChronometer(R.id.widgetNextSmokeChronometer, base, null, true)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            setChronometerCountDown(R.id.widgetNextSmokeChronometer, true)
+        }
+        setTextColor(R.id.widgetNextSmokeChronometer, WidgetColorInts.Text)
+        setTextViewTextSize(
+            R.id.widgetNextSmokeChronometer,
+            TypedValue.COMPLEX_UNIT_SP,
+            if (compact) 22f else 28f,
+        )
+    }
 }
 
 @Composable
@@ -288,7 +326,6 @@ private fun ProgressDot(
 
 @Composable
 private fun MetricCard(
-    marker: String,
     label: String,
     value: String,
     modifier: GlanceModifier = GlanceModifier,
@@ -301,15 +338,6 @@ private fun MetricCard(
         verticalAlignment = Alignment.Vertical.CenterVertically,
         horizontalAlignment = Alignment.Horizontal.Start,
     ) {
-        Text(
-            text = marker,
-            style = TextStyle(
-                color = WidgetColors.Primary,
-                fontSize = 9.sp,
-                fontWeight = FontWeight.Bold,
-            ),
-            maxLines = 1,
-        )
         Text(
             text = value,
             style = TextStyle(
@@ -341,10 +369,10 @@ private fun QuickAddChip(
             .background(WidgetColors.Primary)
             .cornerRadius(999.dp)
             .clickable(actionStartActivity(intent))
-            .padding(horizontal = 10.dp, vertical = 7.dp),
+            .padding(horizontal = 16.dp, vertical = 10.dp),
         style = TextStyle(
             color = WidgetColors.OnPrimary,
-            fontSize = 12.sp,
+            fontSize = 14.sp,
             fontWeight = FontWeight.Bold,
         ),
         maxLines = 1,
@@ -371,9 +399,6 @@ private fun Long.toDurationLabel(): String {
     }
 }
 
-private fun Long.toNextSmokeLabel(): String =
-    if (this <= 0L) "Ready now" else "${toDurationLabel()} left"
-
 private fun WidgetSnapshot.remainingMinutesUntilNextSmoke(): Long {
     val target = targetGapMinutes.takeIf { it > 0 } ?: return 0L
     val elapsed = elapsedHours * 60L + elapsedMinutes
@@ -386,54 +411,14 @@ private fun WidgetSnapshot.progressFraction(): Float {
     return (elapsed.toFloat() / target.toFloat()).coerceIn(0f, 1f)
 }
 
-private fun WidgetSnapshot.gapStatus(): GapStatus {
-    val target = targetGapMinutes
-    val elapsed = elapsedHours * 60L + elapsedMinutes
-    return when {
-        target <= 0 -> GapStatus.Steady
-        elapsed >= target -> GapStatus.Ready
-        progressFraction() >= 0.66f -> GapStatus.Near
-        else -> GapStatus.Building
-    }
-}
-
 private fun Double.formatOneDecimal(): String = String.format("%.1f", this)
 
-private enum class GapStatus(
-    val marker: String,
-    val container: ColorProvider,
-    val content: ColorProvider,
-) {
-    Ready(
-        marker = "OK",
-        container = ColorProvider(Color(0xFFD9F1E3)),
-        content = ColorProvider(Color(0xFF0E5B35)),
-    ),
-    Near(
-        marker = "GAP",
-        container = ColorProvider(Color(0xFFFFE8C2)),
-        content = ColorProvider(Color(0xFF7A4A00)),
-    ),
-    Building(
-        marker = "GAP",
-        container = ColorProvider(Color(0xFFFFDAD6)),
-        content = ColorProvider(Color(0xFF8C1D18)),
-    ),
-    Steady(
-        marker = "NOW",
-        container = ColorProvider(Color(0xFFE0EEF0)),
-        content = ColorProvider(Color(0xFF234F55)),
-    );
-
-    fun message(targetLabel: String): String = when (this) {
-        Ready -> "Next smoke is past target $targetLabel"
-        Near -> "Almost at target $targetLabel"
-        Building -> "Wait until target $targetLabel"
-        Steady -> "Live countdown from latest data"
-    }
-}
-
 private const val ProgressDotCount = 5
+private const val MILLIS_PER_MINUTE = 60_000L
+
+private object WidgetColorInts {
+    const val Text = 0xFF101414.toInt()
+}
 
 private object WidgetColors {
     val Background = ColorProvider(Color(0xFFF5FAF8))

--- a/apps/mobile/src/main/java/com/feragusper/smokeanalytics/widget/WidgetSnapshotStore.kt
+++ b/apps/mobile/src/main/java/com/feragusper/smokeanalytics/widget/WidgetSnapshotStore.kt
@@ -1,6 +1,7 @@
 package com.feragusper.smokeanalytics.widget
 
 import android.content.Context
+import com.feragusper.smokeanalytics.features.goals.domain.goalDataFetchStart
 import com.feragusper.smokeanalytics.features.home.domain.toWidgetSnapshot
 import com.feragusper.smokeanalytics.libraries.architecture.domain.WidgetSnapshot
 import dagger.hilt.android.EntryPointAccessors
@@ -51,6 +52,12 @@ internal object WidgetSnapshotStore {
             dayStartHour = preferences.dayStartHour,
             manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
         )
-        return smokeCounts.toWidgetSnapshot(preferences)
+        val goalSmokes = entryPoint.fetchSmokesUseCase().invoke(start = goalDataFetchStart(preferences))
+        val goalProgress = entryPoint.evaluateGoalProgressUseCase().invoke(
+            activeGoal = preferences.activeGoal,
+            smokes = goalSmokes,
+            preferences = preferences,
+        )
+        return smokeCounts.toWidgetSnapshot(preferences, goalProgress)
     }
 }

--- a/apps/mobile/src/main/res/layout/widget_next_smoke_chronometer.xml
+++ b/apps/mobile/src/main/res/layout/widget_next_smoke_chronometer.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Chronometer xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widgetNextSmokeChronometer"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:fontFamily="sans-serif-medium"
+    android:includeFontPadding="false"
+    android:singleLine="true"
+    android:textStyle="bold" />

--- a/features/home/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/domain/HomeInsights.kt
+++ b/features/home/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/domain/HomeInsights.kt
@@ -237,6 +237,7 @@ fun gamificationSummary(smokes: List<Smoke>): GamificationSummary {
 
 fun SmokeCountListResult.toWidgetSnapshot(
     preferences: UserPreferences,
+    goalProgress: GoalProgress? = null,
     now: Instant = Clock.System.now(),
     timeZone: TimeZone = TimeZone.currentSystemDefault(),
 ): WidgetSnapshot {
@@ -247,11 +248,23 @@ fun SmokeCountListResult.toWidgetSnapshot(
         timeZone = timeZone,
     )
     val elapsed = timeSinceLastCigarette
+    val elapsedMinutes = elapsed.first * 60L + elapsed.second
+    val gapFocus = gapFocusSummary(
+        elapsedMinutes = elapsedMinutes,
+        rateSummary = rate,
+        goalProgress = goalProgress,
+        smokesPerDay = countByToday,
+        awakeMinutesPerDay = preferences.awakeMinutesPerDay,
+        dayStartHour = preferences.dayStartHour,
+        bedtimeHour = preferences.bedtimeHour,
+        now = now,
+        timeZone = timeZone,
+    )
     return WidgetSnapshot(
         todayCount = countByToday,
         elapsedHours = elapsed.first,
         elapsedMinutes = elapsed.second,
-        targetGapMinutes = rate.averageIntervalMinutesToday ?: preferences.awakeMinutesPerDay,
+        targetGapMinutes = gapFocus.targetMinutes ?: rate.averageIntervalMinutesToday ?: preferences.awakeMinutesPerDay,
         averageSmokesPerDayWeek = rate.averageSmokesPerDayWeek,
     )
 }

--- a/features/home/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/features/home/domain/HomeInsightsTest.kt
+++ b/features/home/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/features/home/domain/HomeInsightsTest.kt
@@ -121,6 +121,50 @@ class HomeInsightsTest {
     }
 
     @Test
+    fun `toWidgetSnapshot uses active daily cap pace for next smoke wait`() {
+        val now = Instant.parse("2026-03-25T15:34:00Z")
+        val smokeCount = SmokeCountListResult(
+            todaysSmokes = List(13) { index ->
+                Smoke(
+                    id = "$index",
+                    date = now,
+                    timeElapsedSincePreviousSmoke = 1L to 0L,
+                )
+            },
+            countByWeek = 21,
+            countByMonth = 64,
+            lastSmoke = Smoke(
+                id = "last",
+                date = now,
+                timeElapsedSincePreviousSmoke = 1L to 0L,
+            ),
+        )
+        val preferences = UserPreferences(
+            dayStartHour = 9,
+            bedtimeHour = 22,
+            activeGoal = SmokingGoal.DailyCap(maxCigarettesPerDay = 15),
+        )
+        val goalProgress = GoalProgress(
+            goal = SmokingGoal.DailyCap(maxCigarettesPerDay = 15),
+            title = "Daily cap",
+            targetLabel = "Target: at most 15 today",
+            progressLabel = "13 / 15 smoked today",
+            supportingText = "2 left before reaching today's cap.",
+            status = GoalStatus.OnTrack,
+        )
+
+        val snapshot = smokeCount.toWidgetSnapshot(
+            preferences = preferences,
+            goalProgress = goalProgress,
+            now = now,
+            timeZone = utc,
+        )
+
+        assertEquals(13, snapshot.todayCount)
+        assertEquals(193, snapshot.targetGapMinutes)
+    }
+
+    @Test
     fun `gapFocusSummary uses mindful gap goal as the source of truth when active`() {
         val now = Instant.parse("2026-03-25T12:00:00Z")
         val summary = gapFocusSummary(

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
@@ -576,11 +576,11 @@ private fun GoalHeroMetricCard(
     ) {
         Column(
             modifier = Modifier
-                .heightIn(min = 114.dp)
-                .padding(14.dp),
-            verticalArrangement = Arrangement.SpaceBetween,
+                .heightIn(min = 86.dp)
+                .padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                 Text(
                     text = label,
                     style = MaterialTheme.typography.labelMedium,
@@ -597,13 +597,15 @@ private fun GoalHeroMetricCard(
                     overflow = TextOverflow.Ellipsis,
                 )
             }
-            Text(
-                text = supporting ?: " ",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-            )
+            supporting?.takeIf { it.isNotBlank() }?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
         }
     }
 }
@@ -621,9 +623,9 @@ private fun GoalHeroMetricSkeleton(
     ) {
         Column(
             modifier = Modifier
-                .heightIn(min = 114.dp)
-                .padding(14.dp),
-            verticalArrangement = Arrangement.SpaceBetween,
+                .heightIn(min = 86.dp)
+                .padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 SkeletonBlock(
@@ -732,9 +734,9 @@ private fun LastCigaretteValueCard(
     ) {
         Column(
             modifier = Modifier
-                .height(104.dp)
-                .padding(16.dp),
-            verticalArrangement = Arrangement.SpaceBetween,
+                .heightIn(min = 74.dp)
+                .padding(horizontal = 16.dp, vertical = 14.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Text(
                 text = label,

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
@@ -96,6 +96,7 @@ class HomeProcessHolder @Inject constructor(
                     manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
                 )
                 val goalSmokes = fetchSmokesUseCase(start = goalDataFetchStart(preferences))
+                val goalProgress = evaluateGoalProgressUseCase(preferences.activeGoal, goalSmokes, preferences)
                 val greetingState = greetingStateFor(
                     hourOfDay = kotlinx.datetime.Clock.System.now()
                         .toLocalDateTime(kotlinx.datetime.TimeZone.currentSystemDefault()).hour,
@@ -123,14 +124,14 @@ class HomeProcessHolder @Inject constructor(
                             preferences = preferences,
                         ),
                         gamificationSummary = gamificationSummary(smokeCounts.todaysSmokes),
-                        goalProgress = evaluateGoalProgressUseCase(preferences.activeGoal, goalSmokes, preferences),
+                        goalProgress = goalProgress,
                         canStartNewDay = shouldOfferStartNewDay(
                             dayStartHour = preferences.dayStartHour,
                             manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
                         ),
                     )
                 )
-                widgetRefreshService.refreshHomeSnapshot(smokeCounts.toWidgetSnapshot(preferences))
+                widgetRefreshService.refreshHomeSnapshot(smokeCounts.toWidgetSnapshot(preferences, goalProgress))
             }
         }
     }.catchAndLog { e ->
@@ -236,7 +237,9 @@ class HomeProcessHolder @Inject constructor(
             dayStartHour = preferences.dayStartHour,
             manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
         )
-        widgetRefreshService.refreshHomeSnapshot(smokeCounts.toWidgetSnapshot(preferences))
+        val goalSmokes = fetchSmokesUseCase(start = goalDataFetchStart(preferences))
+        val goalProgress = evaluateGoalProgressUseCase(preferences.activeGoal, goalSmokes, preferences)
+        widgetRefreshService.refreshHomeSnapshot(smokeCounts.toWidgetSnapshot(preferences, goalProgress))
     }
 
     private suspend fun refreshWidgetSnapshotBestEffort() {


### PR DESCRIPTION
## Summary
- Make the widget countdown use the same active-goal pace as the Home screen, including daily cap pace.
- Render the widget next-smoke countdown with a native Android Chronometer so it updates live on the launcher.
- Remove redundant widget metric labels and enlarge the quick track target.
- Compact Home goal and last-cigarette value cards by removing forced vertical spacing.

## Verification
- ./gradlew :features:home:domain:jvmTest --tests com.feragusper.smokeanalytics.features.home.domain.HomeInsightsTest
- ./gradlew :apps:mobile:compileStagingDebugKotlin
- ./gradlew :features:home:presentation:mobile:compileDebugKotlin