### PR TITLE
Fix Wear tile data refresh

### DIFF
--- a/apps/mobile/build.gradle.kts
+++ b/apps/mobile/build.gradle.kts
@@ -169,12 +169,14 @@ fun properties(propertiesFileName: String): Properties {
 
 dependencies {
     implementation(project(":libraries:architecture:domain"))
+    implementation(project(":libraries:architecture:common"))
     implementation(project(":libraries:architecture:presentation:mobile"))
     implementation(project(":libraries:authentication:domain"))
     implementation(project(":libraries:design:mobile"))
     implementation(project(":libraries:preferences:domain"))
     implementation(project(":libraries:preferences:data:mobile"))
     implementation(project(":libraries:smokes:domain"))
+    implementation(project(":libraries:wear:domain"))
     implementation(project(":features:authentication:presentation:mobile"))
     implementation(project(":features:chatbot:presentation"))
     implementation(project(":features:chatbot:domain"))
@@ -198,6 +200,7 @@ dependencies {
     implementation(libs.play.app.update.ktx)
     implementation(libs.play.review.ktx)
     implementation(libs.play.services.maps)
+    implementation(libs.play.services.wearable)
 
     debugImplementation(project(":features:devtools:presentation"))
 

--- a/apps/mobile/src/main/AndroidManifest.xml
+++ b/apps/mobile/src/main/AndroidManifest.xml
@@ -40,6 +40,18 @@
                 android:resource="@xml/home_status_widget_info" />
         </receiver>
 
+        <service
+            android:name=".wear.WearMessageListenerService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.google.android.gms.wearable.MESSAGE_RECEIVED" />
+                <data
+                    android:host="*"
+                    android:pathPrefix="/"
+                    android:scheme="wear" />
+            </intent-filter>
+        </service>
+
         <!-- Meta-data to indicate wearable standalone support -->
         <meta-data
             android:name="com.google.android.wearable.standalone"

--- a/apps/mobile/src/main/java/com/feragusper/smokeanalytics/wear/WearMessageListenerService.kt
+++ b/apps/mobile/src/main/java/com/feragusper/smokeanalytics/wear/WearMessageListenerService.kt
@@ -1,0 +1,38 @@
+package com.feragusper.smokeanalytics.wear
+
+import com.feragusper.smokeanalytics.libraries.architecture.common.coroutines.DispatcherProvider
+import com.feragusper.smokeanalytics.libraries.wear.domain.WearSyncManager
+import com.google.android.gms.wearable.MessageEvent
+import com.google.android.gms.wearable.WearableListenerService
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class WearMessageListenerService : WearableListenerService() {
+
+    @Inject
+    lateinit var wearSyncManager: WearSyncManager.Mobile
+
+    @Inject
+    lateinit var dispatcherProvider: DispatcherProvider
+
+    private val serviceJob = SupervisorJob()
+
+    override fun onMessageReceived(messageEvent: MessageEvent) {
+        super.onMessageReceived(messageEvent)
+        CoroutineScope(serviceJob + dispatcherProvider.io()).launch {
+            runCatching { wearSyncManager.handleWearRequest(messageEvent.path) }
+                .onFailure { Timber.w(it, "Failed to handle Wear request: ${messageEvent.path}") }
+        }
+    }
+
+    override fun onDestroy() {
+        serviceJob.cancel()
+        super.onDestroy()
+    }
+}

--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/MainTileService.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/MainTileService.kt
@@ -28,9 +28,7 @@ import java.util.concurrent.TimeUnit
 class MainTileService : SuspendingTileService() {
 
     // ViewModel for the tile UI state management
-    private val viewModel = TileViewModel.apply {
-        initialize(this@MainTileService)
-    }
+    private val viewModel = TileViewModel
 
     // Tile update requester to request updates
     private val tileUpdateRequester: TileUpdateRequester by lazy {
@@ -40,6 +38,7 @@ class MainTileService : SuspendingTileService() {
     // Called when the service is created
     override fun onCreate() {
         super.onCreate()
+        viewModel.initialize(this)
 
         // Debugging setup for Timber logging in debug mode
         if (BuildConfig.DEBUG && Timber.forest().isEmpty()) {
@@ -55,7 +54,8 @@ class MainTileService : SuspendingTileService() {
                     old.todayCount == new.todayCount &&
                         old.targetGapMinutes == new.targetGapMinutes &&
                         old.averageSmokesPerDayWeek == new.averageSmokesPerDayWeek &&
-                        old.lastSmokeTimestamp == new.lastSmokeTimestamp
+                        old.lastSmokeTimestamp == new.lastSmokeTimestamp &&
+                        old.addSmokePendingCount == new.addSmokePendingCount
                 }
                 .collect {
                     Timber.d("onCreate: collect: $it")
@@ -66,12 +66,16 @@ class MainTileService : SuspendingTileService() {
 
     // Handles tile request to render the tile UI based on current state
     override suspend fun tileRequest(requestParams: RequestBuilders.TileRequest): TileBuilders.Tile {
-        val state = viewModel.states().value
+        var state = viewModel.states().value
 
         // Handle action when "add_smoke_action" is clicked
         if (requestParams.currentState.lastClickableId == ADD_SMOKE_ACTION_ID) {
+            val now = System.currentTimeMillis()
             Timber.d("Add Smoke clicked! Updating ViewModel...")
-            viewModel.intents().trySend(TileIntent.AddSmoke)
+            state = state.withOptimisticAddSmoke(now)
+            viewModel.intents().trySend(TileIntent.AddSmoke(now))
+        } else {
+            viewModel.intents().trySend(TileIntent.RefreshSmokes)
         }
 
         // Return the tile based on the state
@@ -118,41 +122,31 @@ class MainTileService : SuspendingTileService() {
             .setScreenHeightDp(resources.configuration.screenHeightDp)
             .build()
 
-        // Format last smoke time
         val lastSmokeText = formatLastSmokeTime(state.lastSmokeTimestamp)
+        val nextSmokeText = formatNextSmokePaceTime(
+            targetMinutes = state.targetGapMinutes,
+            lastSmokeTimestamp = state.lastSmokeTimestamp,
+        )
         val statsText = Text.Builder(this, getString(R.string.stats_today_short, state.todayCount ?: 0))
             .setTypography(Typography.TYPOGRAPHY_TITLE3)
-            .setColor(androidx.wear.protolayout.ColorBuilders.argb(0xFF00897B.toInt()))
+            .setColor(androidx.wear.protolayout.ColorBuilders.argb(WEAR_PRIMARY))
             .setMaxLines(1)
             .build()
 
         val content = Text.Builder(
             this,
             buildString {
-                append(lastSmokeText)
+                append(getString(R.string.next_pace_short, nextSmokeText))
                 append('\n')
-                append(getString(R.string.target_gap_short, (state.targetGapMinutes ?: 0).toGapLabel()))
-                append('\n')
-                append(getString(R.string.average_week_short, (state.averageSmokesPerDayWeek ?: 0.0).formatOneDecimal()))
+                append(getString(R.string.last_smoke_short, lastSmokeText))
             }
         )
             .setTypography(Typography.TYPOGRAPHY_BODY2)
-            .setColor(androidx.wear.protolayout.ColorBuilders.argb(0xFF00897B.toInt()))
-            .setMaxLines(3)
+            .setColor(androidx.wear.protolayout.ColorBuilders.argb(WEAR_ON_SURFACE))
+            .setMaxLines(2)
             .build()
 
-        // Create the "Add Smoke" chip button
-        val addSmokeChip = CompactChip.Builder(
-            this,
-            androidx.wear.protolayout.ModifiersBuilders.Clickable.Builder()
-                .setId(ADD_SMOKE_ACTION_ID)
-                .setOnClick(ActionBuilders.LoadAction.Builder().build())
-                .build(),
-            deviceParameters
-        )
-            .setIconContent("smoke_icon")
-            .setChipColors(ChipDefaults.PRIMARY_COLORS)
-            .build()
+        val addSmokeChip = addSmokeChip(deviceParameters)
 
         // Build the layout using the created elements
         return LayoutElementBuilders.Layout.Builder()
@@ -166,6 +160,22 @@ class MainTileService : SuspendingTileService() {
             )
             .build()
     }
+
+    private fun addSmokeChip(
+        deviceParameters: DeviceParametersBuilders.DeviceParameters,
+    ): CompactChip =
+        CompactChip.Builder(
+            this,
+            androidx.wear.protolayout.ModifiersBuilders.Clickable.Builder()
+                .setId(ADD_SMOKE_ACTION_ID)
+                .setOnClick(ActionBuilders.LoadAction.Builder().build())
+                .build(),
+            deviceParameters
+        )
+            .setTextContent(getString(R.string.add_smoke_track))
+            .setIconContent("smoke_icon")
+            .setChipColors(ChipDefaults.PRIMARY_COLORS)
+            .build()
 
     // Formats the last smoke time into a human-readable format
     private fun formatLastSmokeTime(timestamp: Long?): String {
@@ -190,15 +200,34 @@ class MainTileService : SuspendingTileService() {
         }
     }
 
+    private fun formatNextSmokePaceTime(
+        targetMinutes: Int?,
+        lastSmokeTimestamp: Long?,
+    ): String {
+        if (targetMinutes == null || targetMinutes <= 0 || lastSmokeTimestamp == null || lastSmokeTimestamp == 0L) {
+            return getString(R.string.pace_time_na)
+        }
+
+        val elapsedMinutes = TimeUnit.MILLISECONDS.toMinutes(System.currentTimeMillis() - lastSmokeTimestamp)
+        val remainingMinutes = (targetMinutes.toLong() - elapsedMinutes).coerceAtLeast(0L)
+
+        return if (remainingMinutes == 0L) {
+            getString(R.string.pace_ready_now)
+        } else {
+            remainingMinutes.toDurationLabel()
+        }
+    }
+
     companion object {
         private const val ADD_SMOKE_ACTION_ID = "add_smoke_action"
         private const val RESOURCES_VERSION = "1"
+        private const val WEAR_PRIMARY = 0xFF80F2D7.toInt()
+        private const val WEAR_ON_SURFACE = 0xFFF5FAF8.toInt()
     }
 
 }
 
-private fun Int.toGapLabel(): String {
-    if (this <= 0) return "--"
+private fun Long.toDurationLabel(): String {
     val hours = this / 60
     val minutes = this % 60
     return when {
@@ -207,5 +236,3 @@ private fun Int.toGapLabel(): String {
         else -> "${minutes}m"
     }
 }
-
-private fun Double.formatOneDecimal(): String = String.format("%.1f", this)

--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileIntent.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileIntent.kt
@@ -16,8 +16,13 @@ sealed class TileIntent : MVIIntent {
     data object FetchSmokes : TileIntent()
 
     /**
+     * Requests a fresh mobile snapshot without creating another DataLayer listener.
+     */
+    data object RefreshSmokes : TileIntent()
+
+    /**
      * Represents the intent to add a new smoke entry.
      * This is triggered when the user performs the "Add Smoke" action on the tile.
      */
-    data object AddSmoke : TileIntent()
+    data class AddSmoke(val requestedAtMillis: Long) : TileIntent()
 }

--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileProcessHolder.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileProcessHolder.kt
@@ -37,18 +37,36 @@ class TileProcessHolder @Inject constructor(
                     emit(TileResult.Error)  // Emitting an error result in case of failure
                 }
 
+        TileIntent.RefreshSmokes -> callbackFlow {
+            launch {
+                try {
+                    wearSyncManager.sendRequestToMobile(WearPaths.REQUEST_SMOKES)
+                } catch (e: Exception) {
+                    Timber.e(e, "Error requesting smoke count from mobile.")
+                    trySend(TileResult.Error)
+                } finally {
+                    close()
+                }
+            }
+
+            awaitClose { Timber.d("Closed refresh smoke action.") }
+        }
+
         // Handles the "Add Smoke" action by sending a request to the mobile app.
         is TileIntent.AddSmoke -> callbackFlow {
             Timber.d("Adding smoke.")
+            trySend(TileResult.AddSmokeStarted(intent.requestedAtMillis))
             // Launched within the callbackFlow to ensure it runs as a coroutine
             launch {
                 try {
                     wearSyncManager.sendRequestToMobile(WearPaths.ADD_SMOKE)
                     // Emit success after sending the request
-                    trySend(TileResult.AddSmokeSuccess)  // Emit success result here
+                    trySend(TileResult.AddSmokeRequestSent)
                 } catch (e: Exception) {
                     Timber.e(e, "Error sending request to mobile.")
                     trySend(TileResult.Error)  // Emitting error if the request fails
+                } finally {
+                    close()
                 }
             }
             awaitClose { Timber.d("Closed add smoke action.") }
@@ -62,11 +80,8 @@ class TileProcessHolder @Inject constructor(
     private fun listenForSmokeUpdates(): Flow<TileResult> = callbackFlow {
         Timber.d("Fetching smoke count.")
 
-        // Request initial data from the mobile app
-        wearSyncManager.sendRequestToMobile(WearPaths.REQUEST_SMOKES)
-
-        // Listen for real-time updates
-        wearSyncManager.listenForDataUpdates { todayCount, targetGapMinutes, averageSmokesPerDayWeek, lastSmokeTimestamp ->
+        // Listen before requesting data so the first mobile response cannot be missed.
+        val subscription = wearSyncManager.listenForDataUpdates { todayCount, targetGapMinutes, averageSmokesPerDayWeek, lastSmokeTimestamp ->
             trySend(
                 TileResult.FetchSmokesSuccess(
                     todayCount = todayCount,
@@ -77,9 +92,18 @@ class TileProcessHolder @Inject constructor(
             )
         }
 
-        // Close the callbackFlow when cancelled
+        launch {
+            try {
+                wearSyncManager.sendRequestToMobile(WearPaths.REQUEST_SMOKES)
+            } catch (e: Exception) {
+                Timber.e(e, "Error requesting smoke count from mobile.")
+                trySend(TileResult.Error)
+            }
+        }
+
         awaitClose {
             Timber.d("Stopped listening for data updates.")
+            subscription.close()
         }
     }
 }

--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileResult.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileResult.kt
@@ -3,6 +3,8 @@ package com.feragusper.smokeanalytics.tile
 import com.feragusper.smokeanalytics.libraries.architecture.presentation.mvi.MVIResult
 
 sealed class TileResult : MVIResult {
+    data class AddSmokeStarted(val requestedAtMillis: Long) : TileResult()
+
     data class FetchSmokesSuccess(
         val todayCount: Int,
         val targetGapMinutes: Int,
@@ -10,7 +12,7 @@ sealed class TileResult : MVIResult {
         val lastSmokeTimestamp: Long?,
     ) : TileResult()
 
-    data object AddSmokeSuccess : TileResult()
+    data object AddSmokeRequestSent : TileResult()
 
     data object Error : TileResult()
 }

--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileViewModel.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileViewModel.kt
@@ -18,11 +18,10 @@ object TileViewModel : MVIViewModel<TileIntent, TileViewState, TileResult, MVINa
     // Lazy initialization for the WearSyncManager
     @SuppressLint("StaticFieldLeak")
     private lateinit var wearSyncManager: WearSyncManager.Wear
+    private var isListeningForData = false
 
     // The TileProcessHolder is responsible for handling the intents for the tile
-    private val processHolder: TileProcessHolder by lazy {
-        TileProcessHolder(wearSyncManager)
-    }
+    private lateinit var processHolder: TileProcessHolder
 
     // Navigator to handle navigation actions
     override lateinit var navigator: MVINavigator
@@ -30,15 +29,18 @@ object TileViewModel : MVIViewModel<TileIntent, TileViewState, TileResult, MVINa
     // Initialize the WearSyncManager with the given context
     fun initialize(context: Context) {
         wearSyncManager = WearSyncManagerImpl(
-            context = context,
+            context = context.applicationContext,
             dispatcherProvider = DispatcherProviderImpl()
         ).Wear()
+        processHolder = TileProcessHolder(wearSyncManager)
+        if (!isListeningForData) {
+            isListeningForData = true
+            intents().trySend(TileIntent.FetchSmokes)
+        }
     }
 
     init {
         Timber.d("TileViewModel initialized")
-        // Send an initial intent to fetch smoke data
-        intents().trySend(TileIntent.FetchSmokes)
     }
 
     // Transformer function to process the TileIntent and return the corresponding TileResult
@@ -50,15 +52,42 @@ object TileViewModel : MVIViewModel<TileIntent, TileViewState, TileResult, MVINa
         previous: TileViewState,
         result: TileResult
     ): TileViewState = when (result) {
-        is TileResult.FetchSmokesSuccess -> previous.copy(
+        is TileResult.AddSmokeStarted -> previous.withOptimisticAddSmoke(result.requestedAtMillis)
+
+        is TileResult.FetchSmokesSuccess -> previous.updatedWithSmokeSnapshot(result)
+
+        is TileResult.AddSmokeRequestSent -> previous.copy()
+
+        is TileResult.Error -> previous.withPendingAddSmokeRolledBack()
+    }
+
+    private fun TileViewState.updatedWithSmokeSnapshot(result: TileResult.FetchSmokesSuccess): TileViewState {
+        val keepPending = shouldKeepAddSmokePending(result)
+        if (keepPending) return copy(error = null)
+
+        return copy(
             todayCount = result.todayCount,
             targetGapMinutes = result.targetGapMinutes,
             averageSmokesPerDayWeek = result.averageSmokesPerDayWeek,
             lastSmokeTimestamp = result.lastSmokeTimestamp,
+            addSmokePendingCount = 0,
+            addSmokePendingBaseline = null,
+            error = null,
         )
-
-        is TileResult.AddSmokeSuccess -> previous.copy()
-
-        is TileResult.Error -> previous.copy(error = result)
     }
+
+    private fun TileViewState.shouldKeepAddSmokePending(result: TileResult.FetchSmokesSuccess): Boolean {
+        if (addSmokePendingCount <= 0) return false
+        val baseline = addSmokePendingBaseline ?: return false
+        val baselineCount = baseline.todayCount ?: 0
+        val expectedTodayCount = baselineCount + addSmokePendingCount
+        val todayCountAcknowledged = result.todayCount >= expectedTodayCount
+        val pendingSince = lastSmokeTimestamp ?: return false
+        val timestampAcknowledged = result.lastSmokeTimestamp != null &&
+            result.lastSmokeTimestamp >= pendingSince - ADD_SMOKE_CLOCK_SKEW_TOLERANCE_MILLIS
+
+        return !todayCountAcknowledged && !timestampAcknowledged
+    }
+
+    private const val ADD_SMOKE_CLOCK_SKEW_TOLERANCE_MILLIS = 30_000L
 }

--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileViewState.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileViewState.kt
@@ -8,5 +8,52 @@ data class TileViewState(
     val targetGapMinutes: Int? = null,
     val averageSmokesPerDayWeek: Double? = null,
     val lastSmokeTimestamp: Long? = null,
+    val addSmokePendingCount: Int = 0,
+    val addSmokePendingBaseline: TileSmokeSnapshot? = null,
     val error: TileResult? = null,
 ) : MVIViewState<TileIntent>
+
+data class TileSmokeSnapshot(
+    val todayCount: Int?,
+    val targetGapMinutes: Int?,
+    val averageSmokesPerDayWeek: Double?,
+    val lastSmokeTimestamp: Long?,
+)
+
+fun TileViewState.withOptimisticAddSmoke(requestedAtMillis: Long): TileViewState {
+    val countBefore = todayCount ?: 0
+    val countAfter = countBefore + 1
+    val baseline = addSmokePendingBaseline ?: TileSmokeSnapshot(
+        todayCount = todayCount,
+        targetGapMinutes = targetGapMinutes,
+        averageSmokesPerDayWeek = averageSmokesPerDayWeek,
+        lastSmokeTimestamp = lastSmokeTimestamp,
+    )
+
+    return copy(
+        todayCount = countAfter,
+        targetGapMinutes = targetGapMinutes,
+        averageSmokesPerDayWeek = averageSmokesPerDayWeek?.plus(1.0 / 7.0),
+        lastSmokeTimestamp = requestedAtMillis,
+        addSmokePendingCount = addSmokePendingCount + 1,
+        addSmokePendingBaseline = baseline,
+        error = null,
+    )
+}
+
+fun TileViewState.withPendingAddSmokeRolledBack(): TileViewState {
+    val baseline = addSmokePendingBaseline ?: return copy(
+        addSmokePendingCount = 0,
+        error = TileResult.Error,
+    )
+
+    return copy(
+        todayCount = baseline.todayCount,
+        targetGapMinutes = baseline.targetGapMinutes,
+        averageSmokesPerDayWeek = baseline.averageSmokesPerDayWeek,
+        lastSmokeTimestamp = baseline.lastSmokeTimestamp,
+        addSmokePendingCount = 0,
+        addSmokePendingBaseline = null,
+        error = TileResult.Error,
+    )
+}

--- a/apps/wear/src/main/res/values/strings.xml
+++ b/apps/wear/src/main/res/values/strings.xml
@@ -4,7 +4,10 @@
     <string name="last_smoke_minutes_ago">Last smoke %1$d min ago</string>
     <string name="last_smoke_hours_ago">Last smoke %1$d h ago</string>
     <string name="last_smoke_days_ago">Last smoke %1$d d ago</string>
+    <string name="last_smoke_short">%1$s</string>
+    <string name="next_pace_short">Next in %1$s</string>
+    <string name="pace_ready_now">now</string>
+    <string name="pace_time_na">--</string>
     <string name="stats_today_short">Today %1$d</string>
-    <string name="target_gap_short">Target gap %1$s</string>
-    <string name="average_week_short">7d avg %1$s</string>
+    <string name="add_smoke_track">Track</string>
 </resources>

--- a/libraries/wear/data/src/main/java/com/feragusper/smokeanalytics/libraries/wear/data/WearSyncManagerImpl.kt
+++ b/libraries/wear/data/src/main/java/com/feragusper/smokeanalytics/libraries/wear/data/WearSyncManagerImpl.kt
@@ -3,6 +3,8 @@ package com.feragusper.smokeanalytics.libraries.wear.data
 import android.content.Context
 import com.feragusper.smokeanalytics.libraries.architecture.common.coroutines.DispatcherProvider
 import com.feragusper.smokeanalytics.libraries.architecture.domain.utcMillis
+import com.feragusper.smokeanalytics.libraries.preferences.domain.SmokingGoal
+import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferencesRepository
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeCount
 import com.feragusper.smokeanalytics.libraries.smokes.domain.repository.SmokeRepository
@@ -11,15 +13,15 @@ import com.google.android.gms.wearable.DataClient
 import com.google.android.gms.wearable.DataEvent
 import com.google.android.gms.wearable.DataMapItem
 import com.google.android.gms.wearable.MessageClient
-import com.google.android.gms.wearable.MessageEvent
 import com.google.android.gms.wearable.PutDataMapRequest
 import com.google.android.gms.wearable.Wearable
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import timber.log.Timber
+import java.io.Closeable
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -38,20 +40,11 @@ class WearSyncManagerImpl(
      * Handles communication from the mobile app to the Wear OS device.
      *
      * @param smokeRepository The repository to fetch smoke data.
-     * @param coroutineScope The coroutine scope to execute async operations.
      */
     inner class Mobile(
         private val smokeRepository: SmokeRepository,
         private val userPreferencesRepository: UserPreferencesRepository,
-        private val coroutineScope: CoroutineScope,
-    ) : WearSyncManager.Mobile, MessageClient.OnMessageReceivedListener {
-
-        /**
-         * Initializes the WearSyncManager by registering the message listener.
-         */
-        init {
-            Wearable.getMessageClient(context).addListener(this)
-        }
+    ) : WearSyncManager.Mobile {
 
         /**
          * Synchronizes the smoke count data with the connected Wear OS device.
@@ -64,26 +57,20 @@ class WearSyncManagerImpl(
             )
             respondToWearWithSmokeCount(
                 smokeCount = smokeCount,
-                targetGapMinutes = smokeCount.targetGapMinutes(preferences.awakeMinutesPerDay),
+                targetGapMinutes = smokeCount.dailyCapPaceMinutes(preferences)
+                    ?: smokeCount.targetGapMinutes(preferences.awakeMinutesPerDay),
                 averageSmokesPerDayWeek = smokeCount.averageSmokesPerDayWeek(),
             )
         }
 
-        /**
-         * Handles incoming messages from Wear OS devices.
-         *
-         * @param messageEvent The received message event.
-         */
-        override fun onMessageReceived(messageEvent: MessageEvent) {
-            Timber.d("onMessageReceived: ${messageEvent.path}")
-            coroutineScope.launch(dispatcherProvider.io()) {
-                when (messageEvent.path) {
-                    WearPaths.REQUEST_SMOKES -> syncWithWear()
-                    WearPaths.ADD_SMOKE -> {
-                        smokeRepository.addSmoke(Clock.System.now())
-                        syncWithWear()
-                    }
+        override suspend fun handleWearRequest(path: String) {
+            when (path) {
+                WearPaths.REQUEST_SMOKES -> syncWithWear()
+                WearPaths.ADD_SMOKE -> {
+                    smokeRepository.addSmoke(Clock.System.now())
+                    syncWithWear()
                 }
+                else -> Timber.w("Ignoring unknown Wear request: $path")
             }
         }
 
@@ -141,27 +128,43 @@ class WearSyncManagerImpl(
                 averageSmokesPerDayWeek: Double,
                 lastSmokeTimestamp: Long?,
             ) -> Unit
-        ) {
+        ): Closeable {
             Timber.d("listenForDataUpdates")
+
+            fun dispatchDataItem(dataItem: com.google.android.gms.wearable.DataItem) {
+                if (dataItem.uri.path != WearPaths.SMOKE_DATA) return
+
+                val dataMap = DataMapItem.fromDataItem(dataItem).dataMap
+                onDataReceived(
+                    dataMap.getInt(WearPaths.SMOKE_COUNT_TODAY),
+                    dataMap.getInt(WearPaths.TARGET_GAP_MINUTES),
+                    dataMap.getDouble(WearPaths.AVERAGE_SMOKES_PER_DAY_WEEK),
+                    dataMap.takeIf { it.containsKey(WearPaths.LAST_SMOKE_TIMESTAMP) }
+                        ?.getLong(WearPaths.LAST_SMOKE_TIMESTAMP),
+                )
+            }
 
             val dataChangedListener = DataClient.OnDataChangedListener { dataEvents ->
                 for (event in dataEvents) {
                     if (event.type == DataEvent.TYPE_CHANGED) {
-                        val dataItem = event.dataItem
-                        if (dataItem.uri.path == WearPaths.SMOKE_DATA) {
-                            val dataMap = DataMapItem.fromDataItem(dataItem).dataMap
-
-                            onDataReceived(
-                                dataMap.getInt(WearPaths.SMOKE_COUNT_TODAY),
-                                dataMap.getInt(WearPaths.TARGET_GAP_MINUTES),
-                                dataMap.getDouble(WearPaths.AVERAGE_SMOKES_PER_DAY_WEEK),
-                                dataMap.getLong(WearPaths.LAST_SMOKE_TIMESTAMP),
-                            )
-                        }
+                        dispatchDataItem(event.dataItem)
                     }
                 }
             }
             dataClient.addListener(dataChangedListener)
+
+            dataClient.dataItems
+                .addOnSuccessListener { dataItems ->
+                    dataItems.forEach(::dispatchDataItem)
+                    dataItems.release()
+                }
+                .addOnFailureListener { error ->
+                    Timber.w(error, "Could not read latest Wear data item")
+                }
+
+            return Closeable {
+                dataClient.removeListener(dataChangedListener)
+            }
         }
 
         /**
@@ -210,6 +213,41 @@ class WearSyncManagerImpl(
 private fun SmokeCount.targetGapMinutes(awakeMinutesPerDay: Int): Int = when (val count = today.size) {
     0 -> awakeMinutesPerDay
     else -> (awakeMinutesPerDay / count).coerceAtLeast(1)
+}
+
+private fun SmokeCount.dailyCapPaceMinutes(preferences: UserPreferences): Int? {
+    val goal = preferences.activeGoal as? SmokingGoal.DailyCap ?: return null
+    val remainingSmokes = goal.maxCigarettesPerDay - today.size
+    if (remainingSmokes <= 0) return null
+
+    val remainingMinutes = preferences.remainingActiveMinutes()
+    return (remainingMinutes / remainingSmokes).coerceAtLeast(1)
+}
+
+private fun UserPreferences.remainingActiveMinutes(): Int {
+    if (dayStartHour !in 0..23 || bedtimeHour !in 0..23 || awakeMinutesPerDay <= 0) {
+        return awakeMinutesPerDay.coerceAtLeast(0)
+    }
+
+    val localTime = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).time
+    val currentMinutes = localTime.hour * 60 + localTime.minute
+    val dayStartMinutes = dayStartHour * 60
+    val bedtimeMinutes = bedtimeHour * 60
+
+    if (bedtimeHour > dayStartHour) {
+        return when {
+            currentMinutes <= dayStartMinutes -> awakeMinutesPerDay
+            currentMinutes >= bedtimeMinutes -> 0
+            else -> (awakeMinutesPerDay - (currentMinutes - dayStartMinutes)).coerceAtLeast(0)
+        }
+    }
+
+    val minutesSinceStart = (currentMinutes - dayStartMinutes).mod(24 * 60)
+    return if (minutesSinceStart >= awakeMinutesPerDay) {
+        0
+    } else {
+        (awakeMinutesPerDay - minutesSinceStart).coerceAtLeast(0)
+    }
 }
 
 private fun SmokeCount.averageSmokesPerDayWeek(): Double = week / 7.0

--- a/libraries/wear/data/src/main/java/com/feragusper/smokeanalytics/libraries/wear/data/di/WearSyncModule.kt
+++ b/libraries/wear/data/src/main/java/com/feragusper/smokeanalytics/libraries/wear/data/di/WearSyncModule.kt
@@ -11,8 +11,6 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import javax.inject.Singleton
 
 /**
@@ -42,7 +40,6 @@ object WearSyncModule {
         dispatcherProvider: DispatcherProvider
     ): WearSyncManager.Mobile {
         return WearSyncManagerImpl(context, dispatcherProvider).Mobile(
-            coroutineScope = CoroutineScope(SupervisorJob() + dispatcherProvider.default()),
             smokeRepository = smokeRepository,
             userPreferencesRepository = userPreferencesRepository,
         )

--- a/libraries/wear/domain/src/main/java/com/feragusper/smokeanalytics/libraries/wear/domain/WearSyncManager.kt
+++ b/libraries/wear/domain/src/main/java/com/feragusper/smokeanalytics/libraries/wear/domain/WearSyncManager.kt
@@ -1,5 +1,7 @@
 package com.feragusper.smokeanalytics.libraries.wear.domain
 
+import java.io.Closeable
+
 /**
  * Defines the contract for synchronizing smoke data between a mobile app and a Wear OS device.
  *
@@ -15,6 +17,11 @@ sealed interface WearSyncManager {
          * Synchronizes smoke data with the connected Wear OS device.
          */
         suspend fun syncWithWear()
+
+        /**
+         * Handles a message sent by a Wear OS device.
+         */
+        suspend fun handleWearRequest(path: String)
     }
 
     /**
@@ -40,6 +47,6 @@ sealed interface WearSyncManager {
                 averageSmokesPerDayWeek: Double,
                 lastSmokeTimestamp: Long?,
             ) -> Unit
-        )
+        ): Closeable
     }
 }


### PR DESCRIPTION
Closes #276

## What changed
- Fixed Wear tile startup so the TileViewModel initializes only after Android attaches the service context, avoiding the productionRelease black tile crash.
- Added a mobile WearableListenerService so production mobile answers REQUEST_SMOKES and ADD_SMOKE even when the phone app process is not already open.
- Made Wear read the latest cached DataLayer smoke snapshot, then request a fresh phone snapshot without creating duplicate long-lived listeners.
- Routed Wear messages through one mobile handler to avoid duplicate Add Smoke processing while keeping the phone as the source of truth.
- Made Track taps update the Wear tile optimistically, queue every tap as an independent ADD_SMOKE request, ignore stale DataLayer snapshots, and reconcile once the phone confirms the queued count or timestamp.
- Simplified the tile UI to Today, Next in daily-cap pace, Last smoke, and Track; removed Target gap, 7d avg, and Saving copy.
- Tuned Wear tile colors toward the mobile green/mint palette with stronger contrast.

## Verification
- ./gradlew :apps:wear:compileStagingDebugKotlin
- ./gradlew :apps:wear:assembleProductionRelease
- ./gradlew :apps:mobile:compileProductionReleaseKotlin :apps:wear:assembleProductionRelease
- adb install -r apps/wear/build/outputs/apk/production/release/wear-production-release.apk on Pixel Watch 2
- Pixel Watch logcat no longer reports MainTileService getApplicationContext() crash after installing the fixed productionRelease build