### PR TITLE
Publish Wear OS artifact to Play

### DIFF
--- a/.github/workflows/deployment_playstore.yml
+++ b/.github/workflows/deployment_playstore.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Build Android App Bundle
         run: ./gradlew :apps:mobile:bundleProductionRelease --stacktrace
 
+      - name: Build Wear OS App Bundle
+        run: ./gradlew :apps:wear:bundleProductionRelease --stacktrace
+
       - name: Build & deploy Android release to Play Store
         run: bundler exec fastlane android deploy_playstore
 
@@ -92,6 +95,8 @@ jobs:
         run: |
           echo "version_name=$(${{ github.workspace }}/gradlew -q :apps:mobile:printAndroidVersionName)" >> "$GITHUB_OUTPUT"
           echo "release_tag=$(${{ github.workspace }}/gradlew -q :apps:mobile:printAndroidReleaseTag)" >> "$GITHUB_OUTPUT"
+          echo "wear_version_name=$(${{ github.workspace }}/gradlew -q :apps:wear:printWearVersionName)" >> "$GITHUB_OUTPUT"
+          echo "wear_version_code=$(${{ github.workspace }}/gradlew -q :apps:wear:printWearVersionCode)" >> "$GITHUB_OUTPUT"
 
       - name: Push Git Tag
         id: push_android_tag

--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ GitHub Actions drive the main repository automation:
 - `deployment_playstore.yml`: Android release path
 - `deploy-web-hosting.yml`: production web deploy path
 
+Wear OS Play setup is documented in [docs/play-store-wear-os.md](docs/play-store-wear-os.md).
+
 Release notes are expected in GitHub Releases, not as a growing set of historical markdown files in the repo.
 
 ## Contributor Notes

--- a/apps/wear/build.gradle.kts
+++ b/apps/wear/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.google.common.base.Charsets
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import java.io.ByteArrayOutputStream
 import java.io.FileInputStream
 import java.io.InputStreamReader
 import java.util.Properties
@@ -12,26 +11,8 @@ plugins {
     alias(libs.plugins.compose.compiler)
 }
 
-val gitCode: Int by lazy {
-    val stdout = ByteArrayOutputStream()
-    val process = ProcessBuilder("git", "rev-list", "--count", "HEAD")
-        .directory(rootProject.projectDir)
-        .redirectErrorStream(true)
-        .start()
-
-    process.inputStream.use { inputStream ->
-        inputStream.copyTo(stdout)
-    }
-
-    val exitCode = process.waitFor()
-    if (exitCode != 0) {
-        throw IllegalStateException("Git command failed with exit code $exitCode")
-    }
-
-    stdout.toString().trim().toInt()
-}
-
-val majorMinorPatchVersionName = "0.3.0.$gitCode"
+val wearVersionCode: Int by lazy { smokeWearVersionCode(rootProject.projectDir) }
+val wearVersionName = smokeAndroidVersionName(rootProject.projectDir)
 
 android {
     namespace = "com.feragusper.smokeanalytics"
@@ -41,8 +22,8 @@ android {
         applicationId = "com.feragusper.smokeanalytics"
         minSdk = Android.MIN_SDK
         targetSdk = Android.TARGET_SDK
-        versionCode = gitCode
-        versionName = majorMinorPatchVersionName
+        versionCode = wearVersionCode
+        versionName = wearVersionName
     }
 
     signingConfigs {
@@ -154,4 +135,12 @@ dependencies {
     implementation(libs.androidx.tiles.material)
 
     ksp(libs.hilt.compiler)
+}
+
+tasks.register("printWearVersionCode") {
+    doLast { println(wearVersionCode) }
+}
+
+tasks.register("printWearVersionName") {
+    doLast { println(wearVersionName) }
 }

--- a/buildSrc/src/main/kotlin/SmokeVersioning.kt
+++ b/buildSrc/src/main/kotlin/SmokeVersioning.kt
@@ -45,6 +45,9 @@ fun smokeProductVersion(rootDir: File): String =
 fun smokeAndroidVersionName(rootDir: File): String =
     "${smokeProductVersion(rootDir)}.${smokeGitCode(rootDir)}"
 
+fun smokeWearVersionCode(rootDir: File): Int =
+    1_000_000_000 + smokeGitCode(rootDir)
+
 fun smokeWebVersionName(
     rootDir: File,
     env: String,

--- a/docs/play-store-wear-os.md
+++ b/docs/play-store-wear-os.md
@@ -1,0 +1,46 @@
+# Play Store Wear OS Publishing
+
+SmokeAnalytics publishes Wear OS as a separate Play artifact under the same app listing as mobile.
+
+## One-Time Play Console Setup
+
+Before the GitHub release workflow can publish Wear OS, configure the form factor in Play Console:
+
+1. Open the SmokeAnalytics app in Play Console.
+2. Go to `Test and release > Setup > Advanced settings`.
+3. Open the `Form factors` tab.
+4. Add `Wear OS`.
+5. Upload at least one Wear OS screenshot for the store listing.
+6. Upload a Wear OS app bundle or APK to Open testing once when prompted.
+7. Return to `Advanced settings > Form factors > Wear OS > Manage`.
+8. Opt in to Wear OS distribution and accept the terms.
+
+Google reviews the Wear OS experience before it becomes available on Play.
+
+## Automated Release Behavior
+
+The `deployment_playstore.yml` workflow builds:
+
+- `:apps:mobile:bundleProductionRelease`
+- `:apps:wear:bundleProductionRelease`
+
+Fastlane uploads to Open testing:
+
+- mobile AAB to `beta`
+- Wear OS AAB to `wear:beta`
+
+Google Play Console labels this track as Open testing. The Google Play Publishing API and Fastlane still use `beta` for the same track, and Wear OS uses the form factor prefix: `wear:beta`.
+
+## Versioning
+
+Wear OS uses the same package name and version name as mobile, but an independent version code:
+
+```text
+wearVersionCode = 1_000_000_000 + gitCommitCount
+```
+
+Google Play requires version codes to be unique across form factors in the same app listing.
+
+## Local Testing Note
+
+Wear Data Layer communication requires the phone and watch apps to use the same package name and signing certificate. A Play-installed mobile app cannot reliably communicate with a locally installed Wear app if they are signed with different keys.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,21 +1,28 @@
 default_platform(:android)
 
 platform :android do
-  desc "Deploy the production release to Google Play Store beta channel"
+  desc "Deploy the production release to Google Play Store open testing tracks"
   lane :deploy_playstore do |options|
-    upload_options = {
+    common_upload_options = {
       release_status: "completed",                       # Marks the release as final.
-      track: "beta",                                     # Deploys to the beta channel.
       timeout: 600,                                      # Timeout for the upload process (in seconds).
       json_key: "playstore.credentials.json",            # Path to the service account JSON key.
       package_name: "com.feragusper.smokeanalytics",     # The package name of the application.
-      aab: "apps/mobile/build/outputs/bundle/productionRelease/mobile-production-release.aab", # Path to the AAB file.
       skip_upload_apk: true
     }
 
-    # Upload the Android App Bundle (AAB) to Google Play.
-    # Ensure the service account JSON key is available at the specified path.
-    # This lane deploys to the beta track with a 'completed' release status.
-    upload_to_play_store(upload_options)
+    upload_to_play_store(
+      common_upload_options.merge(
+        track: "wear:beta",
+        aab: "apps/wear/build/outputs/bundle/productionRelease/wear-production-release.aab"
+      )
+    )
+
+    upload_to_play_store(
+      common_upload_options.merge(
+        track: "beta",
+        aab: "apps/mobile/build/outputs/bundle/productionRelease/mobile-production-release.aab"
+      )
+    )
   end
 end


### PR DESCRIPTION
Closes #279\n\n## Summary\n- build the Wear OS production release bundle in the Play Store deployment workflow\n- upload Wear OS to the dedicated `wear:beta` Open testing track, then mobile to the existing `beta` Open testing track\n- keep the deploy fail-fast: if Wear OS is not configured in Play Console, mobile is not uploaded afterward\n- move Wear versioning onto shared product version metadata and a separate high-range versionCode scheme\n- document the Play Console setup and clarify that Play Console Open testing maps to Fastlane/API `beta`\n\n## Play Console prerequisite\nThe Wear OS form factor is already active in Play Console. Before running the release workflow, make sure Open testing has the required Wear OS store listing/screenshot and accepts a Wear artifact.\n\n## Verification\n- `ruby -c fastlane/Fastfile`\n- `./gradlew -q :apps:mobile:printAndroidVersionName :apps:mobile:printAndroidReleaseTag :apps:wear:printWearVersionName :apps:wear:printWearVersionCode -Psmoke.env=prod`\n- `./gradlew :apps:mobile:bundleProductionRelease :apps:wear:bundleProductionRelease --stacktrace`\n- `git diff --check`\n\n## Notes\n- Play Console labels the track as Open testing; Google Play Publishing API/Fastlane call that same track `beta`.\n- Current local metadata on this branch: mobile/wear versionName `0.15.1.411`, Wear versionCode `1000000411`.\n- The local build produced `mobile-production-release.aab` and `wear-production-release.aab`.