### PR TITLE
Add Play listing metadata for Wear tile

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,0 +1,10 @@
+Smoke Analytics helps you track your smoking habits, analyze patterns, and reduce consumption with insightful statistics. The app supports your phone and Wear OS watch, so you can log cigarettes and check your progress from either device.
+
+Features:
+- Mobile and Wear OS support: log and monitor smoking from your phone or smartwatch.
+- Wear OS tile: see today's status at a glance and use the quick Track action directly from the tile.
+- Daily and weekly analytics: understand smoking trends with detailed insights.
+- Reminders and goals: set personal goals and receive notifications to stay on track.
+- Cloud sync: keep your data backed up and available across devices.
+
+Take control of your smoking habits with Smoke Analytics on mobile, Wear OS, and the included Wear OS tile.

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,0 +1,1 @@
+Track smoking from your phone, Wear OS watch, and tile.


### PR DESCRIPTION
Closes #292.

## Summary
- add Fastlane Play Store metadata for the en-US short description
- add Fastlane Play Store metadata for the en-US full description with explicit Wear OS tile language

## Verification
- checked listing text lengths against Play limits
- not run: build/tests, metadata-only change