### PR TITLE
Show location tracking readiness on Home

### DIFF
--- a/apps/mobile/src/main/java/com/feragusper/smokeanalytics/platform/AndroidLocationCaptureService.kt
+++ b/apps/mobile/src/main/java/com/feragusper/smokeanalytics/platform/AndroidLocationCaptureService.kt
@@ -8,6 +8,7 @@ import android.location.LocationManager
 import androidx.core.content.ContextCompat
 import com.feragusper.smokeanalytics.libraries.architecture.domain.Coordinate
 import com.feragusper.smokeanalytics.libraries.architecture.domain.LocationCaptureService
+import com.feragusper.smokeanalytics.libraries.architecture.domain.LocationTrackingAvailability
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -17,18 +18,20 @@ class AndroidLocationCaptureService @Inject constructor(
     @ApplicationContext private val context: Context,
 ) : LocationCaptureService {
 
+    override suspend fun locationTrackingAvailability(preferenceEnabled: Boolean): LocationTrackingAvailability {
+        val permissionGranted = hasLocationPermission()
+        return LocationTrackingAvailability(
+            preferenceEnabled = preferenceEnabled,
+            permissionGranted = permissionGranted,
+            providerEnabled = locationManager()?.let(::hasEnabledLocationProvider) == true,
+        )
+    }
+
     @SuppressLint("MissingPermission")
     override suspend fun captureCurrentLocation(): Coordinate? {
         if (!hasLocationPermission()) return null
 
-        val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as? LocationManager
-            ?: return null
-
-        val providers = buildList {
-            add(LocationManager.GPS_PROVIDER)
-            add(LocationManager.NETWORK_PROVIDER)
-            add(LocationManager.PASSIVE_PROVIDER)
-        }
+        val locationManager = locationManager() ?: return null
 
         val bestLocation = providers
             .filter(locationManager::isProviderEnabled)
@@ -49,5 +52,21 @@ class AndroidLocationCaptureService @Inject constructor(
         val fine = ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
         val coarse = ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION)
         return fine == PackageManager.PERMISSION_GRANTED || coarse == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun locationManager(): LocationManager? =
+        context.getSystemService(Context.LOCATION_SERVICE) as? LocationManager
+
+    private fun hasEnabledLocationProvider(locationManager: LocationManager): Boolean =
+        providers.any { provider ->
+            runCatching { locationManager.isProviderEnabled(provider) }.getOrDefault(false)
+        }
+
+    private companion object {
+        val providers = listOf(
+            LocationManager.GPS_PROVIDER,
+            LocationManager.NETWORK_PROVIDER,
+            LocationManager.PASSIVE_PROVIDER,
+        )
     }
 }

--- a/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/WebAppGraph.kt
+++ b/apps/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/WebAppGraph.kt
@@ -4,6 +4,7 @@ import com.feragusper.smokeanalytics.features.home.domain.FetchSmokeCountListUse
 import com.feragusper.smokeanalytics.features.home.presentation.web.process.HomeProcessHolder
 import com.feragusper.smokeanalytics.libraries.architecture.domain.Coordinate
 import com.feragusper.smokeanalytics.libraries.architecture.domain.LocationCaptureService
+import com.feragusper.smokeanalytics.libraries.architecture.domain.LocationTrackingAvailability
 import com.feragusper.smokeanalytics.libraries.authentication.data.AuthenticationRepositoryImpl
 import com.feragusper.smokeanalytics.libraries.authentication.domain.AuthenticationRepository
 import com.feragusper.smokeanalytics.libraries.authentication.domain.FetchSessionUseCase
@@ -70,6 +71,56 @@ data class WebAppGraph(
             val fetchPreferences = FetchUserPreferencesUseCase(prefsRepo)
             val updatePreferences = UpdateUserPreferencesUseCase(prefsRepo)
             val locationCaptureService = object : LocationCaptureService {
+                override suspend fun locationTrackingAvailability(
+                    preferenceEnabled: Boolean,
+                ): LocationTrackingAvailability = suspendCancellableCoroutine { continuation ->
+                    val navigator = js("window.navigator")
+                    val geolocation = navigator?.geolocation
+                    if (geolocation == null) {
+                        continuation.resume(
+                            LocationTrackingAvailability(
+                                preferenceEnabled = preferenceEnabled,
+                                permissionGranted = false,
+                                providerEnabled = false,
+                            )
+                        )
+                        return@suspendCancellableCoroutine
+                    }
+
+                    val permissions = navigator.permissions
+                    if (permissions == null) {
+                        continuation.resume(
+                            LocationTrackingAvailability(
+                                preferenceEnabled = preferenceEnabled,
+                                permissionGranted = preferenceEnabled,
+                                providerEnabled = true,
+                            )
+                        )
+                        return@suspendCancellableCoroutine
+                    }
+
+                    permissions.query(js("{ name: 'geolocation' }")).then(
+                        { status: dynamic ->
+                            continuation.resume(
+                                LocationTrackingAvailability(
+                                    preferenceEnabled = preferenceEnabled,
+                                    permissionGranted = status.state == "granted",
+                                    providerEnabled = true,
+                                )
+                            )
+                        },
+                        { _: dynamic ->
+                            continuation.resume(
+                                LocationTrackingAvailability(
+                                    preferenceEnabled = preferenceEnabled,
+                                    permissionGranted = false,
+                                    providerEnabled = true,
+                                )
+                            )
+                        },
+                    )
+                }
+
                 override suspend fun captureCurrentLocation(): Coordinate? = suspendCancellableCoroutine { continuation ->
                     val navigator = js("window.navigator")
                     val geolocation = navigator?.geolocation

--- a/features/history/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/history/presentation/process/HistoryProcessHolder.kt
+++ b/features/history/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/history/presentation/process/HistoryProcessHolder.kt
@@ -225,7 +225,10 @@ class HistoryProcessHolder @Inject constructor(
                 emit(HistoryResult.Loading)
                 val preferences = fetchUserPreferencesUseCase()
                 val timeZone = TimeZone.currentSystemDefault()
-                val location = if (preferences.locationTrackingEnabled) {
+                val locationAvailability = locationCaptureService.locationTrackingAvailability(
+                    preferences.locationTrackingEnabled
+                )
+                val location = if (locationAvailability.isReady) {
                     locationCaptureService.captureCurrentLocation()?.let {
                         GeoPoint(latitude = it.latitude, longitude = it.longitude)
                     }

--- a/features/history/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/history/presentation/process/HistoryProcessHolderTest.kt
+++ b/features/history/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/history/presentation/process/HistoryProcessHolderTest.kt
@@ -6,6 +6,7 @@ import com.feragusper.smokeanalytics.features.home.domain.SmokeCountListResult
 import com.feragusper.smokeanalytics.features.history.presentation.mvi.HistoryIntent
 import com.feragusper.smokeanalytics.features.history.presentation.mvi.HistoryResult
 import com.feragusper.smokeanalytics.libraries.architecture.domain.LocationCaptureService
+import com.feragusper.smokeanalytics.libraries.architecture.domain.LocationTrackingAvailability
 import com.feragusper.smokeanalytics.libraries.architecture.domain.WidgetRefreshService
 import com.feragusper.smokeanalytics.libraries.authentication.domain.FetchSessionUseCase
 import com.feragusper.smokeanalytics.libraries.authentication.domain.Session
@@ -81,6 +82,14 @@ class HistoryProcessHolderTest {
         coEvery { syncWithWearUseCase.invoke() } just Runs
         coEvery { fetchUserPreferencesUseCase() } returns UserPreferences()
         coEvery { fetchSmokeCountListUseCase.invoke(any()) } returns SmokeCountListResult(emptyList(), 0, 0, null)
+        coEvery { locationCaptureService.locationTrackingAvailability(any()) } answers {
+            val preferenceEnabled = firstArg<Boolean>()
+            LocationTrackingAvailability(
+                preferenceEnabled = preferenceEnabled,
+                permissionGranted = preferenceEnabled,
+                providerEnabled = preferenceEnabled,
+            )
+        }
         coEvery { locationCaptureService.captureCurrentLocation() } returns null
         coEvery { widgetRefreshService.refreshHomeSnapshot(any()) } just Runs
     }

--- a/features/history/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/history/presentation/process/HistoryProcessHolder.kt
+++ b/features/history/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/history/presentation/process/HistoryProcessHolder.kt
@@ -151,7 +151,10 @@ class HistoryProcessHolder(
                 emit(HistoryResult.Loading)
                 val preferences = fetchUserPreferencesUseCase()
                 val tz = TimeZone.currentSystemDefault()
-                val location = if (preferences.locationTrackingEnabled) {
+                val locationAvailability = locationCaptureService.locationTrackingAvailability(
+                    preferences.locationTrackingEnabled
+                )
+                val location = if (locationAvailability.isReady) {
                     locationCaptureService.captureCurrentLocation()?.let {
                         GeoPoint(latitude = it.latitude, longitude = it.longitude)
                     }

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/HomeViewModel.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/HomeViewModel.kt
@@ -150,6 +150,7 @@ class HomeViewModel @Inject constructor(
                     dayStartHour = result.preferences.dayStartHour,
                     bedtimeHour = result.preferences.bedtimeHour,
                     canStartNewDay = result.canStartNewDay,
+                    locationTrackingAvailability = result.locationTrackingAvailability,
                     elapsedTone = elapsedToneFrom(
                         result.smokeCountListResult.timeSinceLastCigarette.first,
                         result.smokeCountListResult.timeSinceLastCigarette.second,

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/HomeResult.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/HomeResult.kt
@@ -6,6 +6,7 @@ import com.feragusper.smokeanalytics.features.home.domain.GamificationSummary
 import com.feragusper.smokeanalytics.features.home.domain.GreetingState
 import com.feragusper.smokeanalytics.features.home.domain.RateSummary
 import com.feragusper.smokeanalytics.features.goals.domain.GoalProgress
+import com.feragusper.smokeanalytics.libraries.architecture.domain.LocationTrackingAvailability
 import com.feragusper.smokeanalytics.libraries.architecture.presentation.mvi.MVIResult
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
@@ -97,6 +98,7 @@ sealed interface HomeResult : MVIResult {
         val gamificationSummary: GamificationSummary,
         val goalProgress: GoalProgress?,
         val canStartNewDay: Boolean,
+        val locationTrackingAvailability: LocationTrackingAvailability,
     ) : HomeResult
 
     /**

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -57,6 +58,7 @@ import com.feragusper.smokeanalytics.features.home.domain.toElapsedGapLabel
 import com.feragusper.smokeanalytics.features.home.domain.toHomeClockLabel
 import com.feragusper.smokeanalytics.features.home.presentation.mvi.HomeIntent
 import com.feragusper.smokeanalytics.features.home.presentation.mvi.HomeResult
+import com.feragusper.smokeanalytics.libraries.architecture.domain.LocationTrackingAvailability
 import com.feragusper.smokeanalytics.libraries.architecture.presentation.mvi.MVIViewState
 import com.feragusper.smokeanalytics.libraries.design.compose.CombinedPreviews
 import com.feragusper.smokeanalytics.libraries.design.compose.theme.SmokeAnalyticsTheme
@@ -83,6 +85,11 @@ data class HomeViewState(
     internal val bedtimeHour: Int = 0,
     internal val canStartNewDay: Boolean = false,
     internal val elapsedTone: ElapsedTone = ElapsedTone.Urgent,
+    internal val locationTrackingAvailability: LocationTrackingAvailability = LocationTrackingAvailability(
+        preferenceEnabled = false,
+        permissionGranted = false,
+        providerEnabled = false,
+    ),
     internal val error: HomeResult.Error? = null,
 ) : MVIViewState<HomeIntent> {
 
@@ -162,6 +169,7 @@ data class HomeViewState(
                 bedtimeHour = bedtimeHour,
                 canStartNewDay = canStartNewDay,
                 elapsedTone = elapsedTone,
+                locationTrackingAvailability = locationTrackingAvailability,
                 isLoading = displayLoading,
                 error = error,
                 intent = intent,
@@ -186,6 +194,7 @@ private fun HomeContent(
     bedtimeHour: Int,
     canStartNewDay: Boolean,
     elapsedTone: ElapsedTone,
+    locationTrackingAvailability: LocationTrackingAvailability,
     isLoading: Boolean,
     error: HomeResult.Error?,
     intent: (HomeIntent) -> Unit,
@@ -236,6 +245,7 @@ private fun HomeContent(
             HomeHeaderSection(
                 greetingTitle = greetingTitle,
                 greetingMessage = greetingMessage,
+                locationTrackingAvailability = locationTrackingAvailability,
                 isLoading = isLoading,
             )
         }
@@ -338,6 +348,7 @@ private fun HomeErrorSection(
 private fun HomeHeaderSection(
     greetingTitle: String?,
     greetingMessage: String?,
+    locationTrackingAvailability: LocationTrackingAvailability,
     isLoading: Boolean,
 ) {
     Column(
@@ -360,6 +371,59 @@ private fun HomeHeaderSection(
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+        LocationTrackingChip(locationTrackingAvailability = locationTrackingAvailability)
+    }
+}
+
+@Composable
+private fun LocationTrackingChip(
+    locationTrackingAvailability: LocationTrackingAvailability,
+) {
+    val isReady = locationTrackingAvailability.isReady
+    val label = when {
+        isReady -> "Location On"
+        !locationTrackingAvailability.preferenceEnabled -> "Location Off"
+        !locationTrackingAvailability.permissionGranted -> "Location Off - permission"
+        !locationTrackingAvailability.providerEnabled -> "Location Off - system"
+        else -> "Location Off"
+    }
+    val containerColor = if (isReady) {
+        MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.52f)
+    } else {
+        MaterialTheme.colorScheme.surfaceContainerHigh
+    }
+    val contentColor = if (isReady) {
+        MaterialTheme.colorScheme.onSecondaryContainer
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    }
+
+    Surface(
+        color = containerColor,
+        contentColor = contentColor,
+        shape = RoundedCornerShape(999.dp),
+        tonalElevation = 0.dp,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.55f)),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Spacer(
+                modifier = Modifier
+                    .size(6.dp)
+                    .clip(RoundedCornerShape(999.dp))
+                    .background(if (isReady) MaterialTheme.colorScheme.secondary else MaterialTheme.colorScheme.outline),
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
     }
 }
 

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
@@ -91,6 +91,9 @@ class HomeProcessHolder @Inject constructor(
             is Session.LoggedIn -> {
                 emit(if (isRefresh) HomeResult.RefreshLoading else HomeResult.Loading)
                 val preferences = fetchUserPreferencesUseCase()
+                val locationTrackingAvailability = locationCaptureService.locationTrackingAvailability(
+                    preferences.locationTrackingEnabled
+                )
                 val smokeCounts = fetchSmokeCountListUseCase.invoke(
                     dayStartHour = preferences.dayStartHour,
                     manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
@@ -129,6 +132,7 @@ class HomeProcessHolder @Inject constructor(
                             dayStartHour = preferences.dayStartHour,
                             manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
                         ),
+                        locationTrackingAvailability = locationTrackingAvailability,
                     )
                 )
                 widgetRefreshService.refreshHomeSnapshot(smokeCounts.toWidgetSnapshot(preferences, goalProgress))
@@ -202,7 +206,10 @@ class HomeProcessHolder @Inject constructor(
             is Session.LoggedIn -> {
                 emit(HomeResult.Loading)
                 val preferences = fetchUserPreferencesUseCase()
-                val location = if (preferences.locationTrackingEnabled) {
+                val locationAvailability = locationCaptureService.locationTrackingAvailability(
+                    preferences.locationTrackingEnabled
+                )
+                val location = if (locationAvailability.isReady) {
                     locationCaptureService.captureCurrentLocation()?.let {
                         GeoPoint(latitude = it.latitude, longitude = it.longitude)
                     }

--- a/features/home/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolderTest.kt
+++ b/features/home/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolderTest.kt
@@ -5,23 +5,27 @@ import com.feragusper.smokeanalytics.features.home.domain.FetchSmokeCountListUse
 import com.feragusper.smokeanalytics.features.home.domain.SmokeCountListResult
 import com.feragusper.smokeanalytics.features.home.presentation.mvi.HomeIntent
 import com.feragusper.smokeanalytics.features.home.presentation.mvi.HomeResult
+import com.feragusper.smokeanalytics.libraries.architecture.domain.Coordinate
 import com.feragusper.smokeanalytics.libraries.architecture.domain.LocationCaptureService
+import com.feragusper.smokeanalytics.libraries.architecture.domain.LocationTrackingAvailability
 import com.feragusper.smokeanalytics.libraries.architecture.domain.WidgetRefreshService
 import com.feragusper.smokeanalytics.libraries.authentication.domain.FetchSessionUseCase
 import com.feragusper.smokeanalytics.libraries.authentication.domain.Session
 import com.feragusper.smokeanalytics.libraries.preferences.domain.FetchUserPreferencesUseCase
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UpdateUserPreferencesUseCase
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.AddSmokeUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.DeleteSmokeUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.EditSmokeUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.FetchSmokesUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.SyncWithWearUseCase
 import io.mockk.Runs
-import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coEvery
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.slot
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -77,6 +81,14 @@ class HomeProcessHolderTest {
         coEvery { syncWithWearUseCase.invoke() } just Runs
         coEvery { fetchUserPreferencesUseCase() } returns UserPreferences()
         coEvery { updateUserPreferencesUseCase.invoke(any()) } just Runs
+        coEvery { locationCaptureService.locationTrackingAvailability(any()) } answers {
+            val preferenceEnabled = firstArg<Boolean>()
+            LocationTrackingAvailability(
+                preferenceEnabled = preferenceEnabled,
+                permissionGranted = preferenceEnabled,
+                providerEnabled = preferenceEnabled,
+            )
+        }
         coEvery { locationCaptureService.captureCurrentLocation() } returns null
         coEvery { fetchSmokeCountListUseCase.invoke(any(), any()) } returns SmokeCountListResult(emptyList(), 0, 0, null)
         coEvery { fetchSmokesUseCase.invoke(any(), any()) } returns emptyList()
@@ -108,6 +120,45 @@ class HomeProcessHolderTest {
                 awaitComplete()
             }
         }
+
+        @Test
+        fun `WHEN location preference is enabled and ready THEN add smoke captures location`() = runTest {
+            val locationSlot = slot<GeoPoint>()
+            coEvery { fetchUserPreferencesUseCase() } returns UserPreferences(locationTrackingEnabled = true)
+            coEvery { locationCaptureService.captureCurrentLocation() } returns Coordinate(12.3, 45.6)
+            coEvery { addSmokeUseCase.invoke(any(), any()) } just Runs
+
+            processHolder.processIntent(HomeIntent.AddSmoke).test {
+                awaitItem() shouldBeEqualTo HomeResult.Loading
+                awaitItem() shouldBeEqualTo HomeResult.AddSmokeSuccess
+                coVerify(exactly = 1) {
+                    addSmokeUseCase.invoke(any(), capture(locationSlot))
+                }
+                locationSlot.captured.latitude shouldBeEqualTo 12.3
+                locationSlot.captured.longitude shouldBeEqualTo 45.6
+                awaitComplete()
+            }
+        }
+
+        @Test
+        fun `WHEN location preference is enabled but permission is missing THEN add smoke skips location capture`() =
+            runTest {
+                coEvery { fetchUserPreferencesUseCase() } returns UserPreferences(locationTrackingEnabled = true)
+                coEvery { locationCaptureService.locationTrackingAvailability(true) } returns LocationTrackingAvailability(
+                    preferenceEnabled = true,
+                    permissionGranted = false,
+                    providerEnabled = true,
+                )
+                coEvery { addSmokeUseCase.invoke(any(), null) } just Runs
+
+                processHolder.processIntent(HomeIntent.AddSmoke).test {
+                    awaitItem() shouldBeEqualTo HomeResult.Loading
+                    awaitItem() shouldBeEqualTo HomeResult.AddSmokeSuccess
+                    coVerify(exactly = 0) { locationCaptureService.captureCurrentLocation() }
+                    coVerify(exactly = 1) { addSmokeUseCase.invoke(any(), null) }
+                    awaitComplete()
+                }
+            }
 
         @Test
         fun `WHEN editing smoke THEN it returns success and syncs with Wear`() = runTest {

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeViewState.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeViewState.kt
@@ -5,6 +5,7 @@ import com.feragusper.smokeanalytics.features.home.domain.FinancialSummary
 import com.feragusper.smokeanalytics.features.home.domain.GamificationSummary
 import com.feragusper.smokeanalytics.features.home.domain.RateSummary
 import com.feragusper.smokeanalytics.features.goals.domain.GoalProgress
+import com.feragusper.smokeanalytics.libraries.architecture.domain.LocationTrackingAvailability
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
 
 /**
@@ -41,6 +42,11 @@ data class HomeViewState(
     val currencySymbol: String = "€",
     val canStartNewDay: Boolean = false,
     val elapsedTone: ElapsedTone = ElapsedTone.Urgent,
+    val locationTrackingAvailability: LocationTrackingAvailability = LocationTrackingAvailability(
+        preferenceEnabled = false,
+        permissionGranted = false,
+        providerEnabled = false,
+    ),
     val error: HomeError? = null,
 ) {
 

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeResult.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeResult.kt
@@ -6,6 +6,7 @@ import com.feragusper.smokeanalytics.features.home.domain.GamificationSummary
 import com.feragusper.smokeanalytics.features.home.domain.GreetingState
 import com.feragusper.smokeanalytics.features.home.domain.RateSummary
 import com.feragusper.smokeanalytics.features.goals.domain.GoalProgress
+import com.feragusper.smokeanalytics.libraries.architecture.domain.LocationTrackingAvailability
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
 
@@ -45,6 +46,7 @@ sealed interface HomeResult {
         val gamificationSummary: GamificationSummary,
         val goalProgress: GoalProgress?,
         val canStartNewDay: Boolean,
+        val locationTrackingAvailability: LocationTrackingAvailability,
     ) : HomeResult
 
     data object FetchSmokesError : HomeResult

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeWebStore.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeWebStore.kt
@@ -105,6 +105,7 @@ class HomeWebStore(
                 bedtimeHour = result.preferences.bedtimeHour,
                 currencySymbol = result.preferences.currencySymbol,
                 canStartNewDay = result.canStartNewDay,
+                locationTrackingAvailability = result.locationTrackingAvailability,
                 elapsedTone = elapsedToneFrom(
                     result.smokeCountListResult.timeSinceLastCigarette.first,
                     result.smokeCountListResult.timeSinceLastCigarette.second,

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/process/HomeProcessHolder.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/process/HomeProcessHolder.kt
@@ -92,6 +92,9 @@ class HomeProcessHolder(
                 is Session.LoggedIn -> {
                     emit(if (isRefresh) HomeResult.RefreshLoading else HomeResult.Loading)
                     val preferences = fetchUserPreferencesUseCase()
+                    val locationTrackingAvailability = locationCaptureService.locationTrackingAvailability(
+                        preferences.locationTrackingEnabled
+                    )
                     val smokeCounts = fetchSmokeCountListUseCase(
                         dayStartHour = preferences.dayStartHour,
                         manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
@@ -129,6 +132,7 @@ class HomeProcessHolder(
                                 dayStartHour = preferences.dayStartHour,
                                 manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
                             ),
+                            locationTrackingAvailability = locationTrackingAvailability,
                         )
                     )
                     return@flow
@@ -153,7 +157,10 @@ class HomeProcessHolder(
                 AppLogger.i { "User logged in, adding smoke..." }
                 emit(HomeResult.Loading)
                 val preferences = fetchUserPreferencesUseCase()
-                val location = if (preferences.locationTrackingEnabled) {
+                val locationAvailability = locationCaptureService.locationTrackingAvailability(
+                    preferences.locationTrackingEnabled
+                )
+                val location = if (locationAvailability.isReady) {
                     locationCaptureService.captureCurrentLocation()?.let {
                         GeoPoint(latitude = it.latitude, longitude = it.longitude)
                     }

--- a/libraries/architecture/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/architecture/domain/PlatformServices.kt
+++ b/libraries/architecture/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/architecture/domain/PlatformServices.kt
@@ -5,7 +5,23 @@ data class Coordinate(
     val longitude: Double,
 )
 
+data class LocationTrackingAvailability(
+    val preferenceEnabled: Boolean,
+    val permissionGranted: Boolean,
+    val providerEnabled: Boolean,
+) {
+    val isReady: Boolean
+        get() = preferenceEnabled && permissionGranted && providerEnabled
+}
+
 interface LocationCaptureService {
+    suspend fun locationTrackingAvailability(preferenceEnabled: Boolean): LocationTrackingAvailability =
+        LocationTrackingAvailability(
+            preferenceEnabled = preferenceEnabled,
+            permissionGranted = preferenceEnabled,
+            providerEnabled = preferenceEnabled,
+        )
+
     suspend fun captureCurrentLocation(): Coordinate?
 }
 


### PR DESCRIPTION
## Summary
- add a shared location tracking availability contract that checks preference, permission, and provider/browser support
- make Home and History only attempt location capture when tracking is actually ready
- show a small mobile Home chip for Location On/Off, including permission/system-off cases

## Validation
- ./gradlew :features:home:presentation:mobile:testDebugUnitTest --tests '*HomeProcessHolderTest'
- ./gradlew :features:history:presentation:mobile:testDebugUnitTest --tests '*HistoryProcessHolderTest'
- ./gradlew :apps:web:jsBrowserDevelopmentWebpack
- ./gradlew :apps:mobile:assembleStagingDebug