### PR TITLE
[codex] Add manual Wear sync action

### DIFF
--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileProcessHolder.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileProcessHolder.kt
@@ -38,9 +38,11 @@ class TileProcessHolder @Inject constructor(
                 }
 
         TileIntent.RefreshSmokes -> callbackFlow {
+            trySend(TileResult.RefreshStarted)
             launch {
                 try {
                     wearSyncManager.sendRequestToMobile(WearPaths.REQUEST_SMOKES)
+                    trySend(TileResult.RefreshRequestSent)
                 } catch (e: Exception) {
                     Timber.e(e, "Error requesting smoke count from mobile.")
                     trySend(TileResult.Error)

--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileResult.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileResult.kt
@@ -5,6 +5,8 @@ import com.feragusper.smokeanalytics.libraries.architecture.presentation.mvi.MVI
 sealed class TileResult : MVIResult {
     data class AddSmokeStarted(val requestedAtMillis: Long) : TileResult()
 
+    data object RefreshStarted : TileResult()
+
     data class FetchSmokesSuccess(
         val todayCount: Int,
         val targetGapMinutes: Int,
@@ -13,6 +15,8 @@ sealed class TileResult : MVIResult {
     ) : TileResult()
 
     data object AddSmokeRequestSent : TileResult()
+
+    data object RefreshRequestSent : TileResult()
 
     data object Error : TileResult()
 }

--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileViewModel.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileViewModel.kt
@@ -54,9 +54,16 @@ object TileViewModel : MVIViewModel<TileIntent, TileViewState, TileResult, MVINa
     ): TileViewState = when (result) {
         is TileResult.AddSmokeStarted -> previous.withOptimisticAddSmoke(result.requestedAtMillis)
 
+        TileResult.RefreshStarted -> previous.copy(
+            refreshRequestInFlight = true,
+            error = null,
+        )
+
         is TileResult.FetchSmokesSuccess -> previous.updatedWithSmokeSnapshot(result)
 
         is TileResult.AddSmokeRequestSent -> previous.copy()
+
+        TileResult.RefreshRequestSent -> previous.copy(refreshRequestInFlight = false)
 
         is TileResult.Error -> previous.withPendingAddSmokeRolledBack()
     }
@@ -70,6 +77,7 @@ object TileViewModel : MVIViewModel<TileIntent, TileViewState, TileResult, MVINa
             targetGapMinutes = result.targetGapMinutes,
             averageSmokesPerDayWeek = result.averageSmokesPerDayWeek,
             lastSmokeTimestamp = result.lastSmokeTimestamp,
+            refreshRequestInFlight = false,
             addSmokePendingCount = 0,
             addSmokePendingBaseline = null,
             error = null,

--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileViewState.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileViewState.kt
@@ -8,6 +8,7 @@ data class TileViewState(
     val targetGapMinutes: Int? = null,
     val averageSmokesPerDayWeek: Double? = null,
     val lastSmokeTimestamp: Long? = null,
+    val refreshRequestInFlight: Boolean = false,
     val addSmokePendingCount: Int = 0,
     val addSmokePendingBaseline: TileSmokeSnapshot? = null,
     val error: TileResult? = null,
@@ -43,6 +44,7 @@ fun TileViewState.withOptimisticAddSmoke(requestedAtMillis: Long): TileViewState
 
 fun TileViewState.withPendingAddSmokeRolledBack(): TileViewState {
     val baseline = addSmokePendingBaseline ?: return copy(
+        refreshRequestInFlight = false,
         addSmokePendingCount = 0,
         error = TileResult.Error,
     )
@@ -52,6 +54,7 @@ fun TileViewState.withPendingAddSmokeRolledBack(): TileViewState {
         targetGapMinutes = baseline.targetGapMinutes,
         averageSmokesPerDayWeek = baseline.averageSmokesPerDayWeek,
         lastSmokeTimestamp = baseline.lastSmokeTimestamp,
+        refreshRequestInFlight = false,
         addSmokePendingCount = 0,
         addSmokePendingBaseline = null,
         error = TileResult.Error,

--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/wear/MainActivity.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/wear/MainActivity.kt
@@ -77,6 +77,7 @@ private fun WearApp(
         ) {
             WearHomeContent(
                 state = state,
+                onRefresh = onRefresh,
                 onAddSmoke = onAddSmoke,
             )
         }
@@ -86,6 +87,7 @@ private fun WearApp(
 @Composable
 private fun WearHomeContent(
     state: TileViewState,
+    onRefresh: () -> Unit,
     onAddSmoke: () -> Unit,
 ) {
     Box(
@@ -117,18 +119,48 @@ private fun WearHomeContent(
                 maxLines = 1,
             )
             Spacer(modifier = Modifier.height(12.dp))
-            Button(
-                onClick = onAddSmoke,
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = WearPrimary,
-                    contentColor = WearPrimaryContent,
-                ),
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(
-                    text = stringResourceCompat(R.string.add_smoke_track),
-                    fontWeight = FontWeight.SemiBold,
-                    maxLines = 1,
-                )
+                Button(
+                    onClick = onRefresh,
+                    modifier = Modifier.weight(1f),
+                    enabled = !state.refreshRequestInFlight,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = WearSurface,
+                        contentColor = WearOnSurface,
+                        disabledContainerColor = WearSurface,
+                        disabledContentColor = WearMuted,
+                    ),
+                ) {
+                    Text(
+                        text = stringResourceCompat(
+                            if (state.refreshRequestInFlight) {
+                                R.string.sync_smokes_syncing
+                            } else {
+                                R.string.sync_smokes
+                            },
+                        ),
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1,
+                    )
+                }
+                Button(
+                    onClick = onAddSmoke,
+                    modifier = Modifier.weight(1f),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = WearPrimary,
+                        contentColor = WearPrimaryContent,
+                    ),
+                ) {
+                    Text(
+                        text = stringResourceCompat(R.string.add_smoke_track),
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1,
+                    )
+                }
             }
         }
     }

--- a/apps/wear/src/main/res/values/strings.xml
+++ b/apps/wear/src/main/res/values/strings.xml
@@ -9,5 +9,7 @@
     <string name="pace_ready_now">now</string>
     <string name="pace_time_na">--</string>
     <string name="stats_today_short">Today %1$d</string>
+    <string name="sync_smokes">Sync</string>
+    <string name="sync_smokes_syncing">Syncing</string>
     <string name="add_smoke_track">Track</string>
 </resources>

--- a/libraries/wear/data/src/main/java/com/feragusper/smokeanalytics/libraries/wear/data/WearPaths.kt
+++ b/libraries/wear/data/src/main/java/com/feragusper/smokeanalytics/libraries/wear/data/WearPaths.kt
@@ -15,4 +15,5 @@ object WearPaths {
     const val AVERAGE_SMOKES_PER_DAY_WEEK = "average_smokes_per_day_week"
     const val TARGET_GAP_MINUTES = "target_gap_minutes"
     const val LAST_SMOKE_TIMESTAMP = "last_smoke_timestamp"
+    const val SYNC_SENT_AT = "sync_sent_at"
 }

--- a/libraries/wear/data/src/main/java/com/feragusper/smokeanalytics/libraries/wear/data/WearSyncManagerImpl.kt
+++ b/libraries/wear/data/src/main/java/com/feragusper/smokeanalytics/libraries/wear/data/WearSyncManagerImpl.kt
@@ -88,6 +88,7 @@ class WearSyncManagerImpl(
                 dataMap.putInt(WearPaths.SMOKE_COUNT_TODAY, smokeCount.today.size)
                 dataMap.putInt(WearPaths.TARGET_GAP_MINUTES, targetGapMinutes)
                 dataMap.putDouble(WearPaths.AVERAGE_SMOKES_PER_DAY_WEEK, averageSmokesPerDayWeek)
+                dataMap.putLong(WearPaths.SYNC_SENT_AT, Clock.System.now().toEpochMilliseconds())
                 smokeCount.lastSmoke?.date?.utcMillis()?.let {
                     dataMap.putLong(WearPaths.LAST_SMOKE_TIMESTAMP, it)
                 }


### PR DESCRIPTION
Closes #298

## Summary
- Adds a compact Sync action to the Wear home screen next to Track.
- Reuses the existing REQUEST_SMOKES Wear path and shows a short in-flight state to avoid repeat taps.
- Adds a sync_sent_at field to mobile DataLayer responses so forced syncs produce a changed DataItem even when visible values are unchanged.

## Validation
- ./gradlew :apps:wear:compileStagingDebugKotlin
- git diff --check