### PR TITLE
Fix Sonar coverage aggregation for KMP and AGP 9 modules

### DIFF
--- a/buildSrc/src/main/kotlin/kmp-lib.gradle.kts
+++ b/buildSrc/src/main/kotlin/kmp-lib.gradle.kts
@@ -1,8 +1,13 @@
+import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
+
 plugins {
     kotlin("multiplatform")
     id("org.jetbrains.kotlinx.kover")
     id("org.sonarqube")
 }
+
+// Configure Kover code coverage reports using the centralized KoverConfig.
+extensions.configure<KoverProjectExtension>("kover", KoverConfig(layout).configure)
 
 kotlin {
     jvm()

--- a/buildSrc/src/main/kotlin/sonarqube.gradle.kts
+++ b/buildSrc/src/main/kotlin/sonarqube.gradle.kts
@@ -13,6 +13,17 @@ sonar {
         property("sonar.host.url", "https://sonarcloud.io")
         property("sonar.projectName", "SmokeAnalytics")
         property("sonar.projectKey", "feragusper_SmokeAnalytics")
+
+        // Aggregate coverage from ALL subprojects (including AGP 9 modules skipped from per-module analysis).
+        val coverageFiles = rootProject.subprojects.flatMap { sub ->
+            listOf(
+                "${sub.layout.buildDirectory.get()}/${KoverConfig.KOVER_REPORT_DIR}/${KoverConfig.KOVER_REPORT_XML_FILE}",
+                "${sub.layout.buildDirectory.get()}/reports/kover/report.xml",
+            )
+        }.filter { File(it).exists() }
+        if (coverageFiles.isNotEmpty()) {
+            property("sonar.coverage.jacoco.xmlReportPaths", coverageFiles.joinToString(","))
+        }
     }
 }
 


### PR DESCRIPTION
## Problem
SonarCloud quality gate was failing because:
1. **KMP modules** (domain layers) didn't configure Kover reports in the path Sonar expects (`smoke-analytics-report/result.xml`).
2. **Android modules** are skipped from per-module Sonar analysis (AGP 9 incompatibility) so their coverage XML was never reported to SonarCloud.
## Fix
- Add `KoverConfig(layout).configure` to `kmp-lib.gradle.kts` convention plugin.
- Aggregate all subproject coverage XMLs at root sonar properties level so SonarCloud sees them even from skipped modules.
## Verification
- `./gradlew check` passes ✅
- 21 coverage reports generated (up from 16) including all KMP domain modules.
- `./gradlew :buildSrc:build` ✅