### PR TITLE
Fix Sonar: include Android sources at root + add workflow_dispatch

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,6 +3,7 @@
 name: Integration
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/buildSrc/src/main/kotlin/sonarqube.gradle.kts
+++ b/buildSrc/src/main/kotlin/sonarqube.gradle.kts
@@ -24,6 +24,20 @@ sonar {
         if (coverageFiles.isNotEmpty()) {
             property("sonar.coverage.jacoco.xmlReportPaths", coverageFiles.joinToString(","))
         }
+
+        // Include sources from AGP 9 Android modules that are skipped from per-module analysis.
+        // This allows SonarCloud to index their source code and map coverage data.
+        val androidSources = rootProject.subprojects
+            .filter { it.plugins.hasPlugin("com.android.library") || it.plugins.hasPlugin("com.android.application") }
+            .flatMap { sub ->
+                listOf(
+                    "${sub.projectDir}/src/main/java",
+                    "${sub.projectDir}/src/main/kotlin",
+                ).filter { File(it).exists() }
+            }
+        if (androidSources.isNotEmpty()) {
+            property("sonar.sources", androidSources.joinToString(","))
+        }
     }
 }
 


### PR DESCRIPTION
## Problem
SonarCloud shows 'No data available' for coverage because:
1. Android modules are skipped entirely from Sonar (AGP 9 incompatibility) — so their **source files are never indexed**.
2. Even with coverage XMLs aggregated at root level, Sonar can't map coverage to unindexed sources.
3. The Integration workflow has no `workflow_dispatch` trigger, preventing manual analysis runs.
## Fix
- Add Android module source directories to root-level `sonar.sources` property so SonarCloud indexes them.
- Add `workflow_dispatch` trigger to integration workflow.
## Verification
- `./gradlew :buildSrc:build` ✅
- `./gradlew sonar --dry-run` ✅
- Once merged, trigger manual Integration run to verify coverage appears in SonarCloud.