### PR TITLE
feat: add shared microinteraction animations for mobile and web

### DIFF
--- a/apps/mobile/src/main/java/com/feragusper/smokeanalytics/MainActivity.kt
+++ b/apps/mobile/src/main/java/com/feragusper/smokeanalytics/MainActivity.kt
@@ -59,6 +59,7 @@ import com.exyte.animatednavbar.items.dropletbutton.DropletButton
 import com.feragusper.smokeanalytics.features.authentication.presentation.AuthenticationActivity
 import com.feragusper.smokeanalytics.features.home.domain.ElapsedTone
 import com.feragusper.smokeanalytics.features.home.presentation.mvi.compose.HomeViewState.TestTags.Companion.BUTTON_ADD_SMOKE
+import com.feragusper.smokeanalytics.libraries.design.compose.pressScaleMicroInteraction
 import com.feragusper.smokeanalytics.libraries.design.compose.theme.SmokeAnalyticsTheme
 import com.google.android.play.core.appupdate.AppUpdateInfo
 import com.google.android.play.core.appupdate.AppUpdateManager
@@ -317,7 +318,9 @@ private fun MainContainerScreen(
                 exit = slideOutVertically(targetOffsetY = { it * 2 }),
             ) {
                 ExtendedFloatingActionButton(
-                    modifier = Modifier.testTag(BUTTON_ADD_SMOKE),
+                    modifier = Modifier
+                        .testTag(BUTTON_ADD_SMOKE)
+                        .pressScaleMicroInteraction(pressedScale = 0.95f),
                     onClick = { runHomeTrackAction() },
                     containerColor = fabTone.buttonContainerColor(),
                     contentColor = fabTone.contentColor(),
@@ -457,7 +460,8 @@ private fun BottomNavigation(
             DropletButton(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.surface),
+                    .background(MaterialTheme.colorScheme.surface)
+                    .pressScaleMicroInteraction(pressedScale = 0.94f),
                 isSelected = selectedIndex == index,
                 icon = screen.iconId,
                 iconColor = MaterialTheme.colorScheme.onSurface,

--- a/libraries/design/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/design/compose/MicroInteractions.kt
+++ b/libraries/design/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/design/compose/MicroInteractions.kt
@@ -1,0 +1,46 @@
+package com.feragusper.smokeanalytics.libraries.design.compose
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.input.pointer.pointerInput
+
+/**
+ * Adds a lightweight press-scale microinteraction suitable for tap targets.
+ */
+fun Modifier.pressScaleMicroInteraction(
+    enabled: Boolean = true,
+    pressedScale: Float = 0.96f,
+    durationMillis: Int = 120,
+): Modifier = composed {
+    if (!enabled) return@composed this
+
+    var isPressed by remember { mutableStateOf(false) }
+    val scale = animateFloatAsState(
+        targetValue = if (isPressed) pressedScale else 1f,
+        animationSpec = tween(durationMillis = durationMillis),
+        label = "press-scale"
+    ).value
+
+    this
+        .pointerInput(enabled) {
+            if (!enabled) return@pointerInput
+            awaitEachGesture {
+                awaitFirstDown(requireUnconsumed = false)
+                isPressed = true
+                waitForUpOrCancellation()
+                isPressed = false
+            }
+        }
+        .scale(scale)
+}
+

--- a/libraries/design/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/libraries/design/SmokeWebStyles.kt
+++ b/libraries/design/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/libraries/design/SmokeWebStyles.kt
@@ -540,6 +540,11 @@ object SmokeWebStyles : StyleSheet() {
         }
     }
 
+    val statCardPressed by style {
+        property("transform", "scale(0.985)")
+        property("box-shadow", "var(--sa-shadow-1)")
+    }
+
     val statTitle by style {
         fontSize(12.px)
         fontWeight(700)
@@ -645,6 +650,11 @@ object SmokeWebStyles : StyleSheet() {
             property("box-shadow", "var(--sa-shadow-1)")
             property("border-color", "var(--sa-color-outline-strong)")
         }
+    }
+
+    val buttonPressed by style {
+        property("transform", "scale(0.97)")
+        property("box-shadow", "none")
     }
 
     val buttonPrimary by style {

--- a/libraries/design/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/libraries/design/SurfaceCard.kt
+++ b/libraries/design/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/libraries/design/SurfaceCard.kt
@@ -1,6 +1,10 @@
 package com.feragusper.smokeanalytics.libraries.design
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import org.jetbrains.compose.web.dom.Button
 import org.jetbrains.compose.web.dom.Div
 import org.jetbrains.compose.web.dom.Span
@@ -29,9 +33,20 @@ fun StatCard(
     value: String,
     onClick: (() -> Unit)? = null,
 ) {
-    SurfaceCard(SmokeWebStyles.statCard) {
+    var pressed by remember { mutableStateOf(false) }
+    val extraClasses = listOfNotNull(
+        SmokeWebStyles.statCard,
+        SmokeWebStyles.statCardPressed.takeIf { pressed },
+    )
+
+    SurfaceCard(*extraClasses.toTypedArray()) {
         Div(
             attrs = {
+                if (onClick != null) {
+                    onMouseDown { pressed = true }
+                    onMouseUp { pressed = false }
+                    onMouseLeave { pressed = false }
+                }
                 if (onClick != null) {
                     onClick { onClick() }
                 }
@@ -116,14 +131,22 @@ private fun ActionButton(
     enabled: Boolean,
     extraClass: String? = null,
 ) {
+    var pressed by remember { mutableStateOf(false) }
+
     Button(
         attrs = {
             classes(SmokeWebStyles.button)
             extraClass?.split(" ")?.filter { it.isNotBlank() }?.let { classes(*it.toTypedArray()) }
+            if (pressed && enabled) {
+                classes(SmokeWebStyles.buttonPressed)
+            }
             if (!enabled) {
                 attr("disabled", "true")
                 classes(SmokeWebStyles.buttonDisabled)
             }
+            onMouseDown { if (enabled) pressed = true }
+            onMouseUp { pressed = false }
+            onMouseLeave { pressed = false }
             onClick { if (enabled) onClick() }
         }
     ) { Text(text) }


### PR DESCRIPTION
Adds reusable mobile/web microinteractions in shared design primitives and main shell surfaces. Validated with :apps:web:jsBrowserDevelopmentWebpack and :apps:mobile:assembleStagingDebug.