### PR TITLE
Fix Wear Play policy issues for 0.17.0

### DIFF
--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/MainTileService.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/MainTileService.kt
@@ -2,8 +2,11 @@ package com.feragusper.smokeanalytics.tile
 
 import androidx.lifecycle.lifecycleScope
 import androidx.wear.protolayout.ActionBuilders
+import androidx.wear.protolayout.ColorBuilders
 import androidx.wear.protolayout.DeviceParametersBuilders
+import androidx.wear.protolayout.DimensionBuilders
 import androidx.wear.protolayout.LayoutElementBuilders
+import androidx.wear.protolayout.ModifiersBuilders
 import androidx.wear.protolayout.ResourceBuilders
 import androidx.wear.protolayout.TimelineBuilders
 import androidx.wear.protolayout.material.ChipDefaults
@@ -129,8 +132,7 @@ class MainTileService : SuspendingTileService() {
         )
         val statsText = Text.Builder(this, getString(R.string.stats_today_short, state.todayCount ?: 0))
             .setTypography(Typography.TYPOGRAPHY_TITLE3)
-            .setColor(androidx.wear.protolayout.ColorBuilders.argb(WEAR_PRIMARY))
-            .setMaxLines(1)
+            .setColor(ColorBuilders.argb(WEAR_PRIMARY))
             .build()
 
         val content = Text.Builder(
@@ -142,8 +144,7 @@ class MainTileService : SuspendingTileService() {
             }
         )
             .setTypography(Typography.TYPOGRAPHY_BODY2)
-            .setColor(androidx.wear.protolayout.ColorBuilders.argb(WEAR_ON_SURFACE))
-            .setMaxLines(2)
+            .setColor(ColorBuilders.argb(WEAR_ON_SURFACE))
             .build()
 
         val addSmokeChip = addSmokeChip(deviceParameters)
@@ -151,11 +152,26 @@ class MainTileService : SuspendingTileService() {
         // Build the layout using the created elements
         return LayoutElementBuilders.Layout.Builder()
             .setRoot(
-                PrimaryLayout.Builder(deviceParameters)
-                    .setPrimaryLabelTextContent(statsText)
-                    .setContent(content)
-                    .setPrimaryChipContent(addSmokeChip)
-                    .setResponsiveContentInsetEnabled(true)
+                LayoutElementBuilders.Box.Builder()
+                    .setWidth(DimensionBuilders.expand())
+                    .setHeight(DimensionBuilders.expand())
+                    .setModifiers(
+                        ModifiersBuilders.Modifiers.Builder()
+                            .setBackground(
+                                ModifiersBuilders.Background.Builder()
+                                    .setColor(ColorBuilders.argb(WEAR_BLACK))
+                                    .build()
+                            )
+                            .build()
+                    )
+                    .addContent(
+                        PrimaryLayout.Builder(deviceParameters)
+                            .setPrimaryLabelTextContent(statsText)
+                            .setContent(content)
+                            .setPrimaryChipContent(addSmokeChip)
+                            .setResponsiveContentInsetEnabled(true)
+                            .build()
+                    )
                     .build()
             )
             .build()
@@ -221,6 +237,7 @@ class MainTileService : SuspendingTileService() {
     companion object {
         private const val ADD_SMOKE_ACTION_ID = "add_smoke_action"
         private const val RESOURCES_VERSION = "1"
+        private const val WEAR_BLACK = 0xFF000000.toInt()
         private const val WEAR_PRIMARY = 0xFF80F2D7.toInt()
         private const val WEAR_ON_SURFACE = 0xFFF5FAF8.toInt()
     }

--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/wear/MainActivity.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/wear/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,9 +13,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -98,7 +102,9 @@ private fun WearHomeContent(
         contentAlignment = Alignment.Center,
     ) {
         Column(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
         ) {
@@ -109,24 +115,24 @@ private fun WearHomeContent(
                 color = WearOnSurface,
                 style = MaterialTheme.typography.bodyMedium,
                 textAlign = TextAlign.Center,
-                maxLines = 1,
             )
             Text(
                 text = state.lastSmokeLabel(),
                 color = WearMuted,
                 style = MaterialTheme.typography.bodySmall,
                 textAlign = TextAlign.Center,
-                maxLines = 1,
             )
             Spacer(modifier = Modifier.height(12.dp))
-            Row(
+            Column(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Button(
                     onClick = onRefresh,
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = 40.dp),
                     enabled = !state.refreshRequestInFlight,
                     colors = ButtonDefaults.buttonColors(
                         containerColor = WearSurface,
@@ -144,12 +150,14 @@ private fun WearHomeContent(
                             },
                         ),
                         fontWeight = FontWeight.SemiBold,
-                        maxLines = 1,
+                        textAlign = TextAlign.Center,
                     )
                 }
                 Button(
                     onClick = onAddSmoke,
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = 40.dp),
                     colors = ButtonDefaults.buttonColors(
                         containerColor = WearPrimary,
                         contentColor = WearPrimaryContent,
@@ -158,7 +166,7 @@ private fun WearHomeContent(
                     Text(
                         text = stringResourceCompat(R.string.add_smoke_track),
                         fontWeight = FontWeight.SemiBold,
-                        maxLines = 1,
+                        textAlign = TextAlign.Center,
                     )
                 }
             }
@@ -170,9 +178,10 @@ private fun WearHomeContent(
 private fun SmokeCount(todayCount: Int?) {
     Box(
         modifier = Modifier
-            .size(58.dp)
+            .sizeIn(minWidth = 58.dp, minHeight = 58.dp)
             .clip(CircleShape)
-            .background(WearSurface),
+            .background(WearSurface)
+            .padding(horizontal = 14.dp, vertical = 8.dp),
         contentAlignment = Alignment.Center,
     ) {
         if (todayCount == null) {
@@ -191,7 +200,7 @@ private fun SmokeCount(todayCount: Int?) {
                     color = WearPrimary,
                     style = MaterialTheme.typography.headlineLarge,
                     fontWeight = FontWeight.Bold,
-                    maxLines = 1,
+                    textAlign = TextAlign.Center,
                 )
             }
         }
@@ -257,7 +266,7 @@ private fun Long.toDurationLabel(): String {
     }
 }
 
-private val WearBackground = Color(0xFF071311)
+private val WearBackground = Color.Black
 private val WearSurface = Color(0xFF10241F)
 private val WearPrimary = Color(0xFF80F2D7)
 private val WearPrimaryContent = Color(0xFF05201A)

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-product.version=0.16.1
+product.version=0.17.0


### PR DESCRIPTION
## Summary
- use true black for the Wear in-app background and tile root background
- make Wear in-app content scrollable and remove rigid single-line clipping for large font sizes
- bump product version to 0.17.0 for the develop-to-master release train

## Verification
- ./gradlew :apps:wear:compileProductionReleaseKotlin
- ./gradlew :apps:wear:printWearVersionCode :apps:wear:printWearVersionName :apps:web:printWebVersionName :apps:web:printWebReleaseTag -Psmoke.env=production
- ./gradlew :apps:web:jsBrowserDevelopmentWebpack :apps:web:prepareFirebaseHosting :apps:mobile:bundleProductionRelease :apps:wear:bundleProductionRelease -Psmoke.env=production (failed only because dev/prod web tasks conflict in one Gradle invocation)
- ./gradlew :apps:mobile:bundleProductionRelease :apps:wear:bundleProductionRelease -Psmoke.env=production
- ./gradlew :apps:web:prepareFirebaseHosting -Psmoke.env=production