### PR TITLE
Improve Wear smoke actions

### DIFF
--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/MainTileService.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/MainTileService.kt
@@ -77,6 +77,9 @@ class MainTileService : SuspendingTileService() {
             Timber.d("Add Smoke clicked! Updating ViewModel...")
             state = state.withOptimisticAddSmoke(now)
             viewModel.intents().trySend(TileIntent.AddSmoke(now))
+        } else if (requestParams.currentState.lastClickableId == SYNC_SMOKES_ACTION_ID) {
+            Timber.d("Sync clicked! Requesting fresh data...")
+            viewModel.intents().trySend(TileIntent.RefreshSmokes)
         } else {
             viewModel.intents().trySend(TileIntent.RefreshSmokes)
         }
@@ -97,6 +100,15 @@ class MainTileService : SuspendingTileService() {
                     .setAndroidResourceByResId(
                         ResourceBuilders.AndroidImageResourceByResId.Builder()
                             .setResourceId(com.feragusper.smokeanalytics.libraries.design.mobile.R.drawable.ic_cigarette)
+                            .build()
+                    ).build()
+            )
+            .addIdToImageMapping(
+                "sync_icon",
+                ResourceBuilders.ImageResource.Builder()
+                    .setAndroidResourceByResId(
+                        ResourceBuilders.AndroidImageResourceByResId.Builder()
+                            .setResourceId(R.drawable.ic_sync)
                             .build()
                     ).build()
             )
@@ -135,19 +147,30 @@ class MainTileService : SuspendingTileService() {
             .setColor(ColorBuilders.argb(WEAR_PRIMARY))
             .build()
 
-        val content = Text.Builder(
-            this,
-            buildString {
-                append(getString(R.string.next_pace_short, nextSmokeText))
-                append('\n')
-                append(getString(R.string.last_smoke_short, lastSmokeText))
-            }
-        )
+        val nextSmokeLabel = Text.Builder(this, getString(R.string.next_pace_short, nextSmokeText))
             .setTypography(Typography.TYPOGRAPHY_BODY2)
             .setColor(ColorBuilders.argb(WEAR_ON_SURFACE))
             .build()
-
-        val addSmokeChip = addSmokeChip(deviceParameters)
+        val lastSmokeLabel = Text.Builder(this, getString(R.string.last_smoke_short, lastSmokeText))
+            .setTypography(Typography.TYPOGRAPHY_CAPTION1)
+            .setColor(ColorBuilders.argb(WEAR_MUTED))
+            .build()
+        val content = LayoutElementBuilders.Column.Builder()
+            .setHorizontalAlignment(LayoutElementBuilders.HORIZONTAL_ALIGN_CENTER)
+            .addContent(nextSmokeLabel)
+            .addContent(
+                LayoutElementBuilders.Spacer.Builder()
+                    .setHeight(DimensionBuilders.dp(6f))
+                    .build()
+            )
+            .addContent(lastSmokeLabel)
+            .addContent(
+                LayoutElementBuilders.Spacer.Builder()
+                    .setHeight(DimensionBuilders.dp(18f))
+                    .build()
+            )
+            .addContent(actionChips(deviceParameters))
+            .build()
 
         // Build the layout using the created elements
         return LayoutElementBuilders.Layout.Builder()
@@ -168,7 +191,6 @@ class MainTileService : SuspendingTileService() {
                         PrimaryLayout.Builder(deviceParameters)
                             .setPrimaryLabelTextContent(statsText)
                             .setContent(content)
-                            .setPrimaryChipContent(addSmokeChip)
                             .setResponsiveContentInsetEnabled(true)
                             .build()
                     )
@@ -176,6 +198,35 @@ class MainTileService : SuspendingTileService() {
             )
             .build()
     }
+
+    private fun actionChips(
+        deviceParameters: DeviceParametersBuilders.DeviceParameters,
+    ): LayoutElementBuilders.Row =
+        LayoutElementBuilders.Row.Builder()
+            .addContent(syncSmokeChip(deviceParameters))
+            .addContent(
+                LayoutElementBuilders.Spacer.Builder()
+                    .setWidth(DimensionBuilders.dp(8f))
+                    .build()
+            )
+            .addContent(addSmokeChip(deviceParameters))
+            .build()
+
+    private fun syncSmokeChip(
+        deviceParameters: DeviceParametersBuilders.DeviceParameters,
+    ): CompactChip =
+        CompactChip.Builder(
+            this,
+            androidx.wear.protolayout.ModifiersBuilders.Clickable.Builder()
+                .setId(SYNC_SMOKES_ACTION_ID)
+                .setOnClick(ActionBuilders.LoadAction.Builder().build())
+                .build(),
+            deviceParameters
+        )
+            .setIconContent("sync_icon")
+            .setContentDescription(getString(R.string.sync_smokes))
+            .setChipColors(ChipDefaults.SECONDARY_COLORS)
+            .build()
 
     private fun addSmokeChip(
         deviceParameters: DeviceParametersBuilders.DeviceParameters,
@@ -188,8 +239,8 @@ class MainTileService : SuspendingTileService() {
                 .build(),
             deviceParameters
         )
-            .setTextContent(getString(R.string.add_smoke_track))
             .setIconContent("smoke_icon")
+            .setContentDescription(getString(R.string.add_smoke_track))
             .setChipColors(ChipDefaults.PRIMARY_COLORS)
             .build()
 
@@ -236,10 +287,12 @@ class MainTileService : SuspendingTileService() {
 
     companion object {
         private const val ADD_SMOKE_ACTION_ID = "add_smoke_action"
+        private const val SYNC_SMOKES_ACTION_ID = "sync_smokes_action"
         private const val RESOURCES_VERSION = "1"
         private const val WEAR_BLACK = 0xFF000000.toInt()
         private const val WEAR_PRIMARY = 0xFF80F2D7.toInt()
         private const val WEAR_ON_SURFACE = 0xFFF5FAF8.toInt()
+        private const val WEAR_MUTED = 0xFF9FB6AF.toInt()
     }
 
 }

--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/wear/MainActivity.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/wear/MainActivity.kt
@@ -3,6 +3,13 @@ package com.feragusper.smokeanalytics.wear
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -27,11 +34,18 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -45,6 +59,7 @@ import com.feragusper.smokeanalytics.libraries.architecture.presentation.BuildCo
 import com.feragusper.smokeanalytics.tile.TileIntent
 import com.feragusper.smokeanalytics.tile.TileViewModel
 import com.feragusper.smokeanalytics.tile.TileViewState
+import kotlinx.coroutines.delay
 import timber.log.Timber
 import java.util.concurrent.TimeUnit
 
@@ -101,6 +116,7 @@ private fun WearHomeContent(
     val listState = rememberScalingLazyListState()
     val configuration = LocalConfiguration.current
     val horizontalInset = if (configuration.isScreenRound) 30.dp else 18.dp
+    var trackFeedbackNonce by remember { mutableIntStateOf(0) }
 
     Scaffold(
         modifier = Modifier
@@ -125,7 +141,10 @@ private fun WearHomeContent(
             verticalArrangement = Arrangement.spacedBy(6.dp, Alignment.CenterVertically),
         ) {
             item {
-                SmokeCount(state.todayCount)
+                SmokeCount(
+                    todayCount = state.todayCount,
+                    trackFeedbackNonce = trackFeedbackNonce,
+                )
             }
             item {
                 Text(
@@ -152,7 +171,10 @@ private fun WearHomeContent(
                 WearActionButtons(
                     state = state,
                     onRefresh = onRefresh,
-                    onAddSmoke = onAddSmoke,
+                    onAddSmoke = {
+                        trackFeedbackNonce += 1
+                        onAddSmoke()
+                    },
                 )
             }
         }
@@ -165,6 +187,8 @@ private fun WearActionButtons(
     onRefresh: () -> Unit,
     onAddSmoke: () -> Unit,
 ) {
+    val hapticFeedback = LocalHapticFeedback.current
+
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -196,7 +220,10 @@ private fun WearActionButtons(
             )
         }
         Button(
-            onClick = onAddSmoke,
+            onClick = {
+                hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                onAddSmoke()
+            },
             modifier = Modifier
                 .fillMaxWidth()
                 .heightIn(min = 40.dp),
@@ -215,15 +242,46 @@ private fun WearActionButtons(
 }
 
 @Composable
-private fun SmokeCount(todayCount: Int?) {
+private fun SmokeCount(
+    todayCount: Int?,
+    trackFeedbackNonce: Int,
+) {
+    val countScale = remember { Animatable(1f) }
+    var showTrackFeedback by remember { mutableStateOf(false) }
+
+    LaunchedEffect(trackFeedbackNonce) {
+        if (trackFeedbackNonce > 0) {
+            showTrackFeedback = true
+            countScale.snapTo(1f)
+            countScale.animateTo(1.14f, animationSpec = tween(durationMillis = 140))
+            countScale.animateTo(1f, animationSpec = tween(durationMillis = 260))
+            delay(320)
+            showTrackFeedback = false
+        }
+    }
+
     Box(
         modifier = Modifier
             .sizeIn(minWidth = 58.dp, minHeight = 58.dp)
+            .scale(countScale.value)
             .clip(CircleShape)
             .background(WearSurface)
             .padding(horizontal = 14.dp, vertical = 8.dp),
         contentAlignment = Alignment.Center,
     ) {
+        AnimatedVisibility(
+            visible = showTrackFeedback,
+            enter = fadeIn(animationSpec = tween(120)) + scaleIn(initialScale = 0.72f),
+            exit = fadeOut(animationSpec = tween(220)) + scaleOut(targetScale = 1.18f),
+            modifier = Modifier.align(Alignment.TopEnd),
+        ) {
+            Text(
+                text = "+1",
+                color = WearPrimary,
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.ExtraBold,
+            )
+        }
         if (todayCount == null) {
             CircularProgressIndicator(
                 modifier = Modifier.size(24.dp),

--- a/apps/wear/src/main/res/drawable/ic_sync.xml
+++ b/apps/wear/src/main/res/drawable/ic_sync.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,4C9.79,4 7.8,4.9 6.36,6.36L4,4V10H10L7.78,7.78C8.86,6.68 10.35,6 12,6C14.62,6 16.84,7.68 17.66,10H19.75C18.82,6.55 15.68,4 12,4ZM4.25,14C5.18,17.45 8.32,20 12,20C14.21,20 16.2,19.1 17.64,17.64L20,20V14H14L16.22,16.22C15.14,17.32 13.65,18 12,18C9.38,18 7.16,16.32 6.34,14H4.25Z" />
+</vector>


### PR DESCRIPTION
## Summary
- Restores the Wear Tile last-smoke readout below the next-pace line.
- Adds manual Sync and Track actions to the Wear Tile using icon-only compact chips with content descriptions.
- Moves the Tile action chips into the central content column instead of the bottom primary-chip slot, avoiding clipping on small round screens.
- Adds Track feedback in the Wear app with a short pulse, transient +1 badge, and haptic feedback.

## Layout safety
The Tile no longer uses PrimaryLayout's bottom chip slot, which was clipping the action row at the bottom of round devices. The action row is now centered inside the content area with fixed spacing, and the chips are icon-only fixed-size compact chips.

## Validation
- ./gradlew :apps:wear:compileStagingDebugKotlin --stacktrace
- ./gradlew :apps:wear:assembleStagingDebug --stacktrace

Closes #322