### PR TITLE
Fix web goals nav icon contrast

### DIFF
--- a/apps/web/src/jsMain/resources/icons/nav-goals.svg
+++ b/apps/web/src/jsMain/resources/icons/nav-goals.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-  <circle cx="12" cy="12" r="8" stroke="#F5FAF8" stroke-width="2"/>
-  <circle cx="12" cy="12" r="4" stroke="#F5FAF8" stroke-width="2"/>
-  <circle cx="12" cy="12" r="1.5" fill="#F5FAF8"/>
+  <circle cx="12" cy="12" r="8" stroke="#191C1C" stroke-width="2"/>
+  <circle cx="12" cy="12" r="4" stroke="#191C1C" stroke-width="2"/>
+  <circle cx="12" cy="12" r="1.5" fill="#191C1C"/>
 </svg>


### PR DESCRIPTION
## Summary
- Confirms the Home web Daily Cap readout is already aligned with mobile via the shared HomeGoalNarrative contract: only Every and Pace render for Daily Cap.
- Confirms web Consistency already includes the streak milestone chips.
- Fixes the Goals sidebar SVG so it uses the same dark icon color as the other inactive nav icons and remains visible on the light sidebar.

## Validation
- ./gradlew :apps:web:jsBrowserDevelopmentWebpack --stacktrace