### PR TITLE
chore: bump develop version to 0.17.3

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-product.version=0.17.2
+product.version=0.17.3


### PR DESCRIPTION
## Context
- `release: 0.17.2` was promoted to `master`.
- Per branch/release policy, `develop` moves to the next unreleased patch version.

## Change
- Update `version.properties` from `0.17.2` to `0.17.3`.

## Validation
- `./gradlew :apps:mobile:printAndroidVersionName :apps:mobile:printAndroidReleaseTag :apps:wear:printWearVersionName :apps:wear:printWearVersionCode :apps:web:printWebVersionName :apps:web:printWebReleaseTag`