### PR TITLE
Fix release version print tasks (configuration cache)

### DIFF
--- a/apps/mobile/build.gradle.kts
+++ b/apps/mobile/build.gradle.kts
@@ -212,17 +212,21 @@ dependencies {
 }
 
 tasks.register("printProductVersion") {
-    doLast { println(productVersionName) }
+    val value = productVersionName
+    doLast { println(value) }
 }
 
 tasks.register("printVersionName") {
-    doLast { println(androidVersionName) }
+    val value = androidVersionName
+    doLast { println(value) }
 }
 
 tasks.register("printAndroidVersionName") {
-    doLast { println(androidVersionName) }
+    val value = androidVersionName
+    doLast { println(value) }
 }
 
 tasks.register("printAndroidReleaseTag") {
-    doLast { println(androidReleaseTag) }
+    val value = androidReleaseTag
+    doLast { println(value) }
 }

--- a/apps/wear/build.gradle.kts
+++ b/apps/wear/build.gradle.kts
@@ -138,9 +138,11 @@ dependencies {
 }
 
 tasks.register("printWearVersionCode") {
-    doLast { println(wearVersionCode) }
+    val value = wearVersionCode
+    doLast { println(value) }
 }
 
 tasks.register("printWearVersionName") {
-    doLast { println(wearVersionName) }
+    val value = wearVersionName
+    doLast { println(value) }
 }

--- a/apps/web/build.gradle.kts
+++ b/apps/web/build.gradle.kts
@@ -113,13 +113,16 @@ val prepareFirebaseHosting by tasks.registering(Sync::class) {
 }
 
 tasks.register("printProductVersion") {
-    doLast { println(productVersionName) }
+    val value = productVersionName
+    doLast { println(value) }
 }
 
 tasks.register("printWebVersionName") {
-    doLast { println(webVersionName) }
+    val value = webVersionName
+    doLast { println(value) }
 }
 
 tasks.register("printWebReleaseTag") {
-    doLast { println(webReleaseTag) }
+    val value = webReleaseTag
+    doLast { println(value) }
 }


### PR DESCRIPTION
The deploy workflows for 0.18 failed at the Push Git Tag step because the
`print*Version*`/`print*ReleaseTag` Gradle tasks crash under the configuration
cache ("Cannot invoke ... because this.this\$0 is null"), producing an empty
tag name. The Play upload and web hosting deploy themselves succeeded.

Fix: capture the version values into locals at configuration time so the
`doLast` closures no longer capture the build script receiver.

After merging, re-dispatch "Deploy to Play Store" and "Deploy Web (Firebase
Hosting)" to create the 0.18 tags/releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)