### PR TITLE
Hotfix: provide FetchSmokeStatsUseCase without injecting TimeZone

### DIFF
--- a/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/di/SmokesDomainModule.kt
+++ b/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/di/SmokesDomainModule.kt
@@ -14,5 +14,7 @@ val smokesDomainModule = module {
     factoryOf(::EditSmokeUseCase)
     factoryOf(::DeleteSmokeUseCase)
     factoryOf(::FetchSmokesUseCase)
-    factoryOf(::FetchSmokeStatsUseCase)
+    // Explicit factory (not factoryOf): the constructor DSL would try to resolve
+    // the defaulted TimeZone parameter from the graph, which isn't provided.
+    factory { FetchSmokeStatsUseCase(smokeRepository = get()) }
 }


### PR DESCRIPTION
Runtime Koin crash on the Stats screen (web + latent on mobile): factoryOf tried to inject the defaulted TimeZone of FetchSmokeStatsUseCase. Use an explicit factory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)