### PR TITLE
Release: 1.0 — first production release

### DIFF
--- a/apps/mobile/build.gradle.kts
+++ b/apps/mobile/build.gradle.kts
@@ -178,7 +178,8 @@ dependencies {
     implementation(project(":libraries:authentication:data:mobile"))
     implementation(project(":libraries:wear:data"))
     implementation(project(":libraries:wear:domain"))
-    implementation(project(":features:devtools:presentation"))
+    // DevTools is a debug-only feature (see debugImplementation below); it must not
+    // ship in release builds. The Koin module is wired via variant-specific source sets.
     implementation(project(":features:authentication:presentation:mobile"))
     implementation(project(":features:goals:domain"))
     implementation(project(":features:goals:presentation:mobile"))

--- a/apps/mobile/src/debug/java/com/feragusper/smokeanalytics/DevToolsKoinModules.kt
+++ b/apps/mobile/src/debug/java/com/feragusper/smokeanalytics/DevToolsKoinModules.kt
@@ -1,0 +1,13 @@
+package com.feragusper.smokeanalytics
+
+import com.feragusper.smokeanalytics.features.devtools.presentation.di.devToolsPresentationModule
+import org.koin.core.module.Module
+
+/**
+ * DevTools is a debug-only feature, surfaced through app shortcuts in debug builds.
+ * In debug builds its Koin module is registered so the tooling can resolve its dependencies.
+ *
+ * The release counterpart in `src/release` returns an empty list, keeping DevTools out of
+ * production builds entirely.
+ */
+fun devToolsKoinModules(): List<Module> = listOf(devToolsPresentationModule)

--- a/apps/mobile/src/main/java/com/feragusper/smokeanalytics/MainActivity.kt
+++ b/apps/mobile/src/main/java/com/feragusper/smokeanalytics/MainActivity.kt
@@ -646,15 +646,17 @@ private fun MainScreenNavigationConfigurations(
         composable(route = BottomNavigationScreens.Goals.route) {
             onFabConfigChanged(false, ElapsedTone.Urgent, null)
             GoalsMobileDestination(
-                navigateBack = {
-                    navController.navigate(BottomNavigationScreens.Home.route) {
-                        popUpTo(navController.graph.findStartDestination().id) {
-                            saveState = true
-                        }
+                navigateToConfigure = {
+                    navController.navigate(GOALS_CONFIGURE_ROUTE) {
                         launchSingleTop = true
-                        restoreState = true
                     }
                 },
+            )
+        }
+        composable(route = GOALS_CONFIGURE_ROUTE) {
+            onFabConfigChanged(false, ElapsedTone.Urgent, null)
+            GoalsConfigureMobileDestination(
+                navigateBack = { navController.popBackStack() },
             )
         }
         composable(route = BottomNavigationScreens.You.route) {
@@ -734,6 +736,9 @@ private sealed class BottomNavigationScreens(
      */
     data object You : BottomNavigationScreens(route = "settings", iconId = R.drawable.ic_you)
 }
+
+/** Goal editor route, reached from the Goals tab via "Configure goal" (not a bottom item). */
+private const val GOALS_CONFIGURE_ROUTE = "goals_configure"
 
 @Preview(showBackground = true)
 @Composable

--- a/apps/mobile/src/main/java/com/feragusper/smokeanalytics/MainShellDestinations.kt
+++ b/apps/mobile/src/main/java/com/feragusper/smokeanalytics/MainShellDestinations.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import org.koin.androidx.compose.koinViewModel
 import androidx.navigation.compose.rememberNavController
+import com.feragusper.smokeanalytics.features.goals.presentation.GoalsConfigureView
 import com.feragusper.smokeanalytics.features.goals.presentation.GoalsView
 import com.feragusper.smokeanalytics.features.goals.presentation.GoalsViewModel
 import com.feragusper.smokeanalytics.features.goals.presentation.navigation.GoalsNavigator
@@ -188,11 +189,23 @@ fun SettingsMobileDestination() {
 
 @Composable
 fun GoalsMobileDestination(
+    navigateToConfigure: () -> Unit,
+) {
+    val viewModel = koinViewModel<GoalsViewModel>()
+    viewModel.navigator = remember { GoalsNavigator() }
+    GoalsView(
+        viewModel = viewModel,
+        navigateToConfigure = navigateToConfigure,
+    )
+}
+
+@Composable
+fun GoalsConfigureMobileDestination(
     navigateBack: () -> Unit,
 ) {
     val viewModel = koinViewModel<GoalsViewModel>()
     viewModel.navigator = remember(navigateBack) { GoalsNavigator(navigateBack) }
-    GoalsView(
+    GoalsConfigureView(
         viewModel = viewModel,
         navigateBack = navigateBack,
     )

--- a/apps/mobile/src/main/java/com/feragusper/smokeanalytics/SmokeAnalyticsApplication.kt
+++ b/apps/mobile/src/main/java/com/feragusper/smokeanalytics/SmokeAnalyticsApplication.kt
@@ -2,7 +2,6 @@ package com.feragusper.smokeanalytics
 
 import android.app.Application
 import com.feragusper.smokeanalytics.features.authentication.presentation.di.authenticationPresentationModule
-import com.feragusper.smokeanalytics.features.devtools.presentation.di.devToolsPresentationModule
 import com.feragusper.smokeanalytics.features.goals.domain.di.goalsDomainModule
 import com.feragusper.smokeanalytics.features.goals.presentation.di.goalsPresentationModule
 import com.feragusper.smokeanalytics.features.history.presentation.di.historyPresentationModule
@@ -55,13 +54,14 @@ class SmokeAnalyticsApplication : Application() {
                 homePresentationModule,
                 settingsPresentationModule,
                 goalsPresentationModule,
-                devToolsPresentationModule,
                 historyPresentationModule,
                 authenticationPresentationModule,
                 statsPresentationModule,
                 // app
                 appModule,
             )
+            // DevTools modules are provided only in debug builds (empty in release).
+            modules(devToolsKoinModules())
         }
     }
 }

--- a/apps/mobile/src/main/java/com/feragusper/smokeanalytics/platform/AndroidLocationCaptureService.kt
+++ b/apps/mobile/src/main/java/com/feragusper/smokeanalytics/platform/AndroidLocationCaptureService.kt
@@ -4,11 +4,18 @@ import android.annotation.SuppressLint
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
+import android.location.Location
 import android.location.LocationManager
+import android.os.Build
+import android.os.CancellationSignal
+import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
 import com.feragusper.smokeanalytics.libraries.architecture.domain.Coordinate
 import com.feragusper.smokeanalytics.libraries.architecture.domain.LocationCaptureService
 import com.feragusper.smokeanalytics.libraries.architecture.domain.LocationTrackingAvailability
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.coroutines.resume
 
 class AndroidLocationCaptureService constructor(
     private val context: Context,
@@ -28,21 +35,58 @@ class AndroidLocationCaptureService constructor(
         if (!hasLocationPermission()) return null
 
         val locationManager = locationManager() ?: return null
+        val enabledProviders = providers.filter { provider ->
+            runCatching { locationManager.isProviderEnabled(provider) }.getOrDefault(false)
+        }
+        if (enabledProviders.isEmpty()) return null
 
-        val bestLocation = providers
-            .filter(locationManager::isProviderEnabled)
-            .mapNotNull { provider ->
-                runCatching { locationManager.getLastKnownLocation(provider) }.getOrNull()
+        // Actively request a fresh fix (API 30+). getLastKnownLocation alone is frequently
+        // null or stale — that's why so few smokes ended up geolocated. Fall back to the
+        // last known fix when a fresh one isn't available (older OS, or background where a
+        // live fix is blocked without ACCESS_BACKGROUND_LOCATION).
+        val location = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            requestFreshLocation(locationManager, enabledProviders) ?: bestLastKnown(locationManager, enabledProviders)
+        } else {
+            bestLastKnown(locationManager, enabledProviders)
+        }
+
+        return location?.let { Coordinate(latitude = it.latitude, longitude = it.longitude) }
+    }
+
+    @SuppressLint("MissingPermission")
+    @RequiresApi(Build.VERSION_CODES.R)
+    private suspend fun requestFreshLocation(
+        locationManager: LocationManager,
+        enabledProviders: List<String>,
+    ): Location? {
+        // Prefer GPS, then network, then whatever else is on.
+        val provider = providers.firstOrNull { it in enabledProviders } ?: return null
+        return withTimeoutOrNull(LOCATION_TIMEOUT_MILLIS) {
+            suspendCancellableCoroutine { continuation ->
+                val cancellationSignal = CancellationSignal()
+                continuation.invokeOnCancellation { cancellationSignal.cancel() }
+                runCatching {
+                    locationManager.getCurrentLocation(
+                        provider,
+                        cancellationSignal,
+                        context.mainExecutor,
+                    ) { location ->
+                        if (continuation.isActive) continuation.resume(location)
+                    }
+                }.onFailure {
+                    if (continuation.isActive) continuation.resume(null)
+                }
             }
-            .maxByOrNull { it.time }
-
-        return bestLocation?.let {
-            Coordinate(
-                latitude = it.latitude,
-                longitude = it.longitude,
-            )
         }
     }
+
+    @SuppressLint("MissingPermission")
+    private fun bestLastKnown(
+        locationManager: LocationManager,
+        enabledProviders: List<String>,
+    ): Location? = enabledProviders
+        .mapNotNull { provider -> runCatching { locationManager.getLastKnownLocation(provider) }.getOrNull() }
+        .maxByOrNull { it.time }
 
     private fun hasLocationPermission(): Boolean {
         val fine = ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
@@ -59,6 +103,7 @@ class AndroidLocationCaptureService constructor(
         }
 
     private companion object {
+        const val LOCATION_TIMEOUT_MILLIS = 8_000L
         val providers = listOf(
             LocationManager.GPS_PROVIDER,
             LocationManager.NETWORK_PROVIDER,

--- a/apps/mobile/src/main/java/com/feragusper/smokeanalytics/wear/WearMessageListenerService.kt
+++ b/apps/mobile/src/main/java/com/feragusper/smokeanalytics/wear/WearMessageListenerService.kt
@@ -22,7 +22,7 @@ class WearMessageListenerService : WearableListenerService() {
     override fun onMessageReceived(messageEvent: MessageEvent) {
         super.onMessageReceived(messageEvent)
         CoroutineScope(serviceJob + dispatcherProvider.io()).launch {
-            runCatching { wearSyncManager.handleWearRequest(messageEvent.path) }
+            runCatching { wearSyncManager.handleWearRequest(messageEvent.path, messageEvent.data) }
                 .onFailure { Timber.w(it, "Failed to handle Wear request: ${messageEvent.path}") }
         }
     }

--- a/apps/mobile/src/release/java/com/feragusper/smokeanalytics/DevToolsKoinModules.kt
+++ b/apps/mobile/src/release/java/com/feragusper/smokeanalytics/DevToolsKoinModules.kt
@@ -1,0 +1,10 @@
+package com.feragusper.smokeanalytics
+
+import org.koin.core.module.Module
+
+/**
+ * DevTools ships only in debug builds. Release builds register no DevTools Koin module,
+ * mirroring the absence of the `:features:devtools:presentation` dependency from the
+ * release classpath. See the `src/debug` counterpart for the debug implementation.
+ */
+fun devToolsKoinModules(): List<Module> = emptyList()

--- a/apps/wear/src/main/AndroidManifest.xml
+++ b/apps/wear/src/main/AndroidManifest.xml
@@ -5,6 +5,12 @@
 
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="com.google.android.providers.gsf.permission.READ_GSERVICES" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
+    <uses-feature
+        android:name="android.hardware.location.gps"
+        android:required="false" />
 
     <application
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileProcessHolder.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileProcessHolder.kt
@@ -2,6 +2,7 @@ package com.feragusper.smokeanalytics.tile
 
 import com.feragusper.smokeanalytics.libraries.architecture.presentation.extensions.catchAndLog
 import com.feragusper.smokeanalytics.libraries.architecture.presentation.process.MVIProcessHolder
+import com.feragusper.smokeanalytics.libraries.wear.data.WearLocationCodec
 import com.feragusper.smokeanalytics.libraries.wear.data.WearPaths
 import com.feragusper.smokeanalytics.libraries.wear.data.WearSyncManagerImpl
 import com.feragusper.smokeanalytics.libraries.wear.domain.WearSyncManager
@@ -18,7 +19,8 @@ import timber.log.Timber
  * with the mobile app via the WearSyncManager.
  */
 class TileProcessHolder constructor(
-    private val wearSyncManager: WearSyncManager.Wear
+    private val wearSyncManager: WearSyncManager.Wear,
+    private val locationProvider: WearLocationProvider? = null,
 ) : MVIProcessHolder<TileIntent, TileResult> {
 
     /**
@@ -60,7 +62,11 @@ class TileProcessHolder constructor(
             // Launched within the callbackFlow to ensure it runs as a coroutine
             launch {
                 try {
-                    wearSyncManager.sendRequestToMobile(WearPaths.ADD_SMOKE)
+                    // Capture the watch's location here (the phone can't, in the background)
+                    // and ship it with the add. Best-effort: no fix → no location.
+                    val coordinates = runCatching { locationProvider?.currentLatLng() }.getOrNull()
+                    val payload = coordinates?.let { (lat, lng) -> WearLocationCodec.encode(lat, lng) }
+                    wearSyncManager.sendRequestToMobile(WearPaths.ADD_SMOKE, payload)
                     // Emit success after sending the request
                     trySend(TileResult.AddSmokeRequestSent)
                 } catch (e: Exception) {

--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileProcessHolder.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileProcessHolder.kt
@@ -42,7 +42,7 @@ class TileProcessHolder constructor(
             trySend(TileResult.RefreshStarted)
             launch {
                 try {
-                    wearSyncManager.sendRequestToMobile(WearPaths.REQUEST_SMOKES)
+                    wearSyncManager.sendRequestToMobile(WearPaths.REQUEST_SMOKES, data = null)
                     trySend(TileResult.RefreshRequestSent)
                 } catch (e: Exception) {
                     Timber.e(e, "Error requesting smoke count from mobile.")
@@ -101,7 +101,7 @@ class TileProcessHolder constructor(
 
         launch {
             try {
-                wearSyncManager.sendRequestToMobile(WearPaths.REQUEST_SMOKES)
+                wearSyncManager.sendRequestToMobile(WearPaths.REQUEST_SMOKES, data = null)
             } catch (e: Exception) {
                 Timber.e(e, "Error requesting smoke count from mobile.")
                 trySend(TileResult.Error)

--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileViewModel.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/TileViewModel.kt
@@ -32,7 +32,10 @@ object TileViewModel : MVIViewModel<TileIntent, TileViewState, TileResult, MVINa
             context = context.applicationContext,
             dispatcherProvider = DispatcherProviderImpl()
         ).Wear()
-        processHolder = TileProcessHolder(wearSyncManager)
+        processHolder = TileProcessHolder(
+            wearSyncManager = wearSyncManager,
+            locationProvider = WearLocationProvider(context.applicationContext),
+        )
         if (!isListeningForData) {
             isListeningForData = true
             intents().trySend(TileIntent.FetchSmokes)

--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/WearLocationProvider.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/tile/WearLocationProvider.kt
@@ -1,0 +1,91 @@
+package com.feragusper.smokeanalytics.tile
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.pm.PackageManager
+import android.location.Location
+import android.location.LocationManager
+import android.os.Build
+import android.os.CancellationSignal
+import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.coroutines.resume
+
+/**
+ * Captures the watch's own location for a smoke added from the tile. Smokes added from the
+ * watch reach the phone in the background, where the phone can't get a fix — so the watch
+ * (Pixel Watch 2 and other GPS watches) captures here and ships the coordinates in the message.
+ *
+ * Best-effort: returns null when permission is missing, no provider is on, or no fix arrives.
+ */
+class WearLocationProvider(
+    private val context: Context,
+) {
+
+    @SuppressLint("MissingPermission")
+    suspend fun currentLatLng(): Pair<Double, Double>? {
+        if (!hasLocationPermission()) return null
+        val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as? LocationManager ?: return null
+        val enabledProviders = PROVIDERS.filter { provider ->
+            runCatching { locationManager.isProviderEnabled(provider) }.getOrDefault(false)
+        }
+        if (enabledProviders.isEmpty()) return null
+
+        val location = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            requestFreshLocation(locationManager, enabledProviders) ?: bestLastKnown(locationManager, enabledProviders)
+        } else {
+            bestLastKnown(locationManager, enabledProviders)
+        }
+        return location?.let { it.latitude to it.longitude }
+    }
+
+    @SuppressLint("MissingPermission")
+    @RequiresApi(Build.VERSION_CODES.R)
+    private suspend fun requestFreshLocation(
+        locationManager: LocationManager,
+        enabledProviders: List<String>,
+    ): Location? {
+        val provider = PROVIDERS.firstOrNull { it in enabledProviders } ?: return null
+        return withTimeoutOrNull(LOCATION_TIMEOUT_MILLIS) {
+            suspendCancellableCoroutine { continuation ->
+                val cancellationSignal = CancellationSignal()
+                continuation.invokeOnCancellation { cancellationSignal.cancel() }
+                runCatching {
+                    locationManager.getCurrentLocation(
+                        provider,
+                        cancellationSignal,
+                        context.mainExecutor,
+                    ) { location -> if (continuation.isActive) continuation.resume(location) }
+                }.onFailure {
+                    if (continuation.isActive) continuation.resume(null)
+                }
+            }
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun bestLastKnown(
+        locationManager: LocationManager,
+        enabledProviders: List<String>,
+    ): Location? = enabledProviders
+        .mapNotNull { provider -> runCatching { locationManager.getLastKnownLocation(provider) }.getOrNull() }
+        .maxByOrNull { it.time }
+
+    private fun hasLocationPermission(): Boolean {
+        val fine = ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
+        val coarse = ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION)
+        return fine == PackageManager.PERMISSION_GRANTED || coarse == PackageManager.PERMISSION_GRANTED
+    }
+
+    private companion object {
+        const val LOCATION_TIMEOUT_MILLIS = 5_000L
+        val PROVIDERS = listOf(
+            LocationManager.GPS_PROVIDER,
+            LocationManager.NETWORK_PROVIDER,
+            LocationManager.PASSIVE_PROVIDER,
+        )
+    }
+}

--- a/apps/wear/src/main/java/com/feragusper/smokeanalytics/wear/MainActivity.kt
+++ b/apps/wear/src/main/java/com/feragusper/smokeanalytics/wear/MainActivity.kt
@@ -1,8 +1,12 @@
 package com.feragusper.smokeanalytics.wear
 
+import android.Manifest
+import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
@@ -65,6 +69,9 @@ import java.util.concurrent.TimeUnit
 
 class MainActivity : ComponentActivity() {
 
+    private val locationPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { /* best-effort */ }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         TileViewModel.initialize(this)
@@ -73,12 +80,30 @@ class MainActivity : ComponentActivity() {
             Timber.plant(Timber.DebugTree())
         }
 
+        // Ask once so the tile can geolocate smokes from the watch. Tiles can't request
+        // permissions themselves, so we do it from the app.
+        requestLocationPermissionIfNeeded()
+
         setContent {
             WearApp(
                 onRefresh = { TileViewModel.intents().trySend(TileIntent.RefreshSmokes) },
                 onAddSmoke = { TileViewModel.intents().trySend(TileIntent.AddSmoke(System.currentTimeMillis())) },
             )
         }
+    }
+
+    private fun requestLocationPermissionIfNeeded() {
+        val alreadyGranted = ContextCompat.checkSelfPermission(
+            this,
+            Manifest.permission.ACCESS_FINE_LOCATION,
+        ) == PackageManager.PERMISSION_GRANTED
+        if (alreadyGranted) return
+        locationPermissionLauncher.launch(
+            arrayOf(
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+            ),
+        )
     }
 }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,7 +1,7 @@
 default_platform(:android)
 
 platform :android do
-  desc "Deploy the production release to Google Play Store open testing tracks"
+  desc "Deploy the production release to Google Play Store production tracks"
   lane :deploy_playstore do |options|
     common_upload_options = {
       release_status: "completed",                       # Marks the release as final.
@@ -13,14 +13,14 @@ platform :android do
 
     upload_to_play_store(
       common_upload_options.merge(
-        track: "wear:beta",
+        track: "wear:production",
         aab: "apps/wear/build/outputs/bundle/productionRelease/wear-production-release.aab"
       )
     )
 
     upload_to_play_store(
       common_upload_options.merge(
-        track: "beta",
+        track: "production",
         aab: "apps/mobile/build/outputs/bundle/productionRelease/mobile-production-release.aab"
       )
     )

--- a/features/goals/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/goals/presentation/GoalsProgressScreen.kt
+++ b/features/goals/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/goals/presentation/GoalsProgressScreen.kt
@@ -1,0 +1,295 @@
+package com.feragusper.smokeanalytics.features.goals.presentation
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.feragusper.smokeanalytics.features.goals.domain.GoalProgress
+import com.feragusper.smokeanalytics.features.goals.domain.GoalStatus
+import com.feragusper.smokeanalytics.libraries.authentication.presentation.compose.GoogleSignInComponent
+import com.feragusper.smokeanalytics.libraries.preferences.domain.SmokingGoal
+
+/**
+ * The Goals tab landing screen: focuses on how the active goal is going, not on the
+ * selector. While loading it shows a skeleton (so the sign-in/empty state never flashes),
+ * and a "Configure goal" button leads to [GoalsEditorScreen].
+ */
+@Composable
+fun GoalsProgressScreen(
+    currentEmail: String?,
+    activeGoal: SmokingGoal?,
+    goalProgress: GoalProgress?,
+    displayLoading: Boolean,
+    errorMessage: String? = null,
+    signInErrorMessage: String? = null,
+    onConfigure: () -> Unit,
+    onSignInSuccess: () -> Unit,
+    onSignInError: (String) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 4.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text(
+                text = "Goals",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                text = "Track how your active goal is going.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        // Skeleton during the initial load so the sign-in / empty state never flashes.
+        if (displayLoading && goalProgress == null && currentEmail == null && errorMessage == null) {
+            GoalsSkeleton()
+            return
+        }
+
+        errorMessage?.let { message ->
+            GoalsCard(
+                containerColor = MaterialTheme.colorScheme.errorContainer,
+                contentColor = MaterialTheme.colorScheme.onErrorContainer,
+            ) {
+                Text("Could not load your goal", style = MaterialTheme.typography.titleMedium)
+                Text(message, style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+
+        if (currentEmail == null) {
+            GoalsCard {
+                Text(
+                    text = "Goals need an account",
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Text(
+                    text = "Sign in to save one active goal and keep it aligned across mobile and web.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                signInErrorMessage?.let { message ->
+                    Text(
+                        text = message,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+                GoogleSignInComponent(
+                    modifier = Modifier.fillMaxWidth(),
+                    onSignInSuccess = onSignInSuccess,
+                    onSignInError = onSignInError,
+                )
+            }
+            return
+        }
+
+        if (activeGoal == null) {
+            GoalsCard {
+                Text(
+                    text = "No active goal yet",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                )
+                Text(
+                    text = "Set one target to keep your progress front and center on Home.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Button(
+                    onClick = onConfigure,
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(18.dp),
+                ) {
+                    Text("Set a goal", fontWeight = FontWeight.Bold)
+                }
+            }
+            return
+        }
+
+        GoalProgressCard(goalProgress = goalProgress, onConfigure = onConfigure)
+    }
+}
+
+@Composable
+private fun GoalProgressCard(
+    goalProgress: GoalProgress?,
+    onConfigure: () -> Unit,
+) {
+    GoalsCard {
+        Text(
+            text = "Active goal",
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = goalProgress?.title ?: "Your goal",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.ExtraBold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        goalProgress?.let { progress ->
+            progress.status.pill()?.let { (label, container, content) ->
+                Surface(color = container, shape = RoundedCornerShape(999.dp)) {
+                    Text(
+                        text = label,
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = content,
+                    )
+                }
+            }
+            Text(
+                text = progress.targetLabel,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            progress.progressFraction?.let { fraction ->
+                LinearProgressIndicator(
+                    progress = { fraction.coerceIn(0f, 1f) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(8.dp)
+                        .clip(RoundedCornerShape(999.dp)),
+                )
+            }
+            Text(
+                text = progress.progressLabel,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            progress.supportingText.takeIf { it.isNotBlank() }?.let {
+                Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            progress.baselineLabel?.let {
+                Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            progress.warningLabel?.let {
+                Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+            }
+            progress.celebrationLabel?.let {
+                Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
+            }
+            progress.streakLabel?.let {
+                Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+        Button(
+            onClick = onConfigure,
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(18.dp),
+        ) {
+            Icon(Icons.Filled.Settings, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("Configure goal", fontWeight = FontWeight.Bold)
+        }
+    }
+}
+
+@Composable
+private fun GoalsSkeleton() {
+    repeat(2) {
+        Card(
+            shape = RoundedCornerShape(28.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+            ),
+        ) {
+            Column(modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                SkeletonLine(widthFraction = 0.4f)
+                SkeletonLine(widthFraction = 0.7f, height = 26.dp)
+                SkeletonLine(widthFraction = 1f, height = 8.dp)
+                SkeletonLine(widthFraction = 0.5f)
+            }
+        }
+    }
+}
+
+@Composable
+private fun SkeletonLine(widthFraction: Float, height: androidx.compose.ui.unit.Dp = 14.dp) {
+    Spacer(
+        modifier = Modifier
+            .fillMaxWidth(widthFraction)
+            .height(height)
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.18f)),
+    )
+}
+
+@Composable
+private fun GoalsCard(
+    containerColor: Color = MaterialTheme.colorScheme.surfaceContainerLowest,
+    contentColor: Color = MaterialTheme.colorScheme.onSurface,
+    content: @Composable () -> Unit,
+) {
+    Card(
+        shape = RoundedCornerShape(28.dp),
+        colors = CardDefaults.cardColors(containerColor = containerColor, contentColor = contentColor),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            content()
+        }
+    }
+}
+
+@Composable
+private fun GoalStatus.pill(): Triple<String, Color, Color>? = when (this) {
+    GoalStatus.OnTrack -> Triple(
+        "On track",
+        MaterialTheme.colorScheme.primaryContainer,
+        MaterialTheme.colorScheme.onPrimaryContainer,
+    )
+    GoalStatus.OffTrack -> Triple(
+        "Off track",
+        MaterialTheme.colorScheme.errorContainer,
+        MaterialTheme.colorScheme.onErrorContainer,
+    )
+    GoalStatus.Completed -> Triple(
+        "Completed",
+        MaterialTheme.colorScheme.tertiaryContainer,
+        MaterialTheme.colorScheme.onTertiaryContainer,
+    )
+    GoalStatus.NotEnoughData -> null
+}

--- a/features/goals/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/goals/presentation/GoalsView.kt
+++ b/features/goals/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/goals/presentation/GoalsView.kt
@@ -5,14 +5,29 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 
+/** Goals tab landing screen: shows how the active goal is going. */
 @Composable
 fun GoalsView(
+    viewModel: GoalsViewModel,
+    navigateToConfigure: () -> Unit,
+) {
+    val viewState by remember(viewModel) { viewModel.states() }.collectAsState()
+
+    viewState.Compose(
+        intent = { intent -> viewModel.intents().trySend(intent) },
+        navigateToConfigure = navigateToConfigure,
+    )
+}
+
+/** Goal editor (selector + setup), reached from [GoalsView] via "Configure goal". */
+@Composable
+fun GoalsConfigureView(
     viewModel: GoalsViewModel,
     navigateBack: () -> Unit,
 ) {
     val viewState by remember(viewModel) { viewModel.states() }.collectAsState()
 
-    viewState.Compose(
+    viewState.ComposeEditor(
         intent = { intent -> viewModel.intents().trySend(intent) },
         navigateBack = navigateBack,
     )

--- a/features/goals/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/goals/presentation/mvi/compose/GoalsViewState.kt
+++ b/features/goals/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/goals/presentation/mvi/compose/GoalsViewState.kt
@@ -3,6 +3,7 @@ package com.feragusper.smokeanalytics.features.goals.presentation.mvi.compose
 import androidx.compose.runtime.Composable
 import com.feragusper.smokeanalytics.features.goals.domain.GoalProgress
 import com.feragusper.smokeanalytics.features.goals.presentation.GoalsEditorScreen
+import com.feragusper.smokeanalytics.features.goals.presentation.GoalsProgressScreen
 import com.feragusper.smokeanalytics.features.goals.presentation.mvi.GoalsIntent
 import com.feragusper.smokeanalytics.libraries.architecture.presentation.mvi.MVIViewState
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
@@ -17,8 +18,28 @@ data class GoalsViewState(
     internal val signInErrorMessage: String? = null,
 ) : MVIViewState<GoalsIntent> {
 
+    /** The Goals tab landing screen: progress-first, with a button into the editor. */
     @Composable
     fun Compose(
+        intent: (GoalsIntent) -> Unit,
+        navigateToConfigure: () -> Unit,
+    ) {
+        GoalsProgressScreen(
+            currentEmail = currentEmail,
+            activeGoal = preferences.activeGoal,
+            goalProgress = goalProgress,
+            displayLoading = displayLoading,
+            errorMessage = errorMessage,
+            signInErrorMessage = signInErrorMessage,
+            onConfigure = navigateToConfigure,
+            onSignInSuccess = { intent(GoalsIntent.FetchGoals) },
+            onSignInError = { intent(GoalsIntent.FetchGoals) },
+        )
+    }
+
+    /** The goal editor (selector + setup), reached from the progress screen. */
+    @Composable
+    fun ComposeEditor(
         intent: (GoalsIntent) -> Unit,
         navigateBack: () -> Unit,
     ) {

--- a/features/goals/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/goals/presentation/web/GoalsWebScreen.kt
+++ b/features/goals/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/goals/presentation/web/GoalsWebScreen.kt
@@ -4,14 +4,21 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.feragusper.smokeanalytics.features.goals.domain.GoalProgress
+import com.feragusper.smokeanalytics.features.goals.domain.GoalStatus
 import com.feragusper.smokeanalytics.features.goals.presentation.web.mvi.GoalsIntent
 import com.feragusper.smokeanalytics.features.goals.presentation.web.mvi.GoalsWebStore
 import com.feragusper.smokeanalytics.libraries.design.EmptyStateCard
+import com.feragusper.smokeanalytics.libraries.design.GhostButton
 import com.feragusper.smokeanalytics.libraries.design.LoadingSkeletonCard
 import com.feragusper.smokeanalytics.libraries.design.PageSectionHeader
+import com.feragusper.smokeanalytics.libraries.design.PrimaryButton
 import com.feragusper.smokeanalytics.libraries.design.SmokeWebStyles
 import com.feragusper.smokeanalytics.libraries.design.StatusTone
+import com.feragusper.smokeanalytics.libraries.design.SurfaceCard
 import org.jetbrains.compose.web.dom.Div
 import org.jetbrains.compose.web.dom.Text
 
@@ -26,11 +33,18 @@ fun GoalsWebScreen(
 
     val state by store.state.collectAsState()
 
+    // Whether the goal editor (selector + setup) is shown instead of the progress view.
+    var configuring by remember { mutableStateOf(false) }
+
     Div(attrs = { classes(SmokeWebStyles.panelStack) }) {
         PageSectionHeader(
             title = "Goals",
             eyebrow = "Goals",
-            subtitle = "Choose one active target and keep its progress visible from Home.",
+            subtitle = if (configuring) {
+                "Choose one active target and keep its progress visible from Home."
+            } else {
+                "Track how your active goal is going."
+            },
             badgeText = when {
                 state.displayLoading -> "Loading"
                 state.errorMessage != null -> "Needs attention"
@@ -44,22 +58,59 @@ fun GoalsWebScreen(
             },
         )
 
+        // Skeleton during the initial load so the sign-in / empty state never flashes.
         if (state.displayLoading && state.currentEmail == null && state.errorMessage == null) {
             LoadingSkeletonCard(heightPx = 176, lineWidths = listOf("30%", "68%", "44%"))
             LoadingSkeletonCard(heightPx = 180, lineWidths = listOf("22%", "58%", "46%"))
             return@Div
         }
 
-        GoalsWebEditorPanel(
-            currentEmail = state.currentEmail,
-            preferences = state.preferences,
-            goalProgress = state.goalProgress,
-            displayLoading = state.displayLoading,
-            onSaveGoal = { goal -> store.send(GoalsIntent.SaveGoal(goal)) },
-            onClearGoal = { store.send(GoalsIntent.ClearGoal) },
-            onSignInSuccess = { store.send(GoalsIntent.FetchGoals) },
-            onSignInError = { store.send(GoalsIntent.FetchGoals) },
-        )
+        when {
+            // Logged out: the editor panel hosts the sign-in card.
+            state.currentEmail == null -> {
+                GoalsWebEditorPanel(
+                    currentEmail = state.currentEmail,
+                    preferences = state.preferences,
+                    goalProgress = state.goalProgress,
+                    displayLoading = state.displayLoading,
+                    onSaveGoal = { goal -> store.send(GoalsIntent.SaveGoal(goal)) },
+                    onClearGoal = { store.send(GoalsIntent.ClearGoal) },
+                    onSignInSuccess = { store.send(GoalsIntent.FetchGoals) },
+                    onSignInError = { store.send(GoalsIntent.FetchGoals) },
+                )
+            }
+
+            configuring -> {
+                GhostButton(text = "← Back to progress", onClick = { configuring = false })
+                GoalsWebEditorPanel(
+                    currentEmail = state.currentEmail,
+                    preferences = state.preferences,
+                    goalProgress = state.goalProgress,
+                    displayLoading = state.displayLoading,
+                    onSaveGoal = { goal -> store.send(GoalsIntent.SaveGoal(goal)) },
+                    onClearGoal = { store.send(GoalsIntent.ClearGoal) },
+                    onSignInSuccess = { store.send(GoalsIntent.FetchGoals) },
+                    onSignInError = { store.send(GoalsIntent.FetchGoals) },
+                )
+            }
+
+            state.preferences.activeGoal == null -> {
+                SurfaceCard {
+                    Div(attrs = { attr("style", "display:flex;flex-direction:column;gap:12px;") }) {
+                        Div(attrs = { classes(SmokeWebStyles.sectionTitle) }) { Text("No active goal yet") }
+                        Div(attrs = { classes(SmokeWebStyles.sectionBody) }) {
+                            Text("Set one target to keep your progress front and center on Home.")
+                        }
+                        PrimaryButton(text = "Set a goal", onClick = { configuring = true })
+                    }
+                }
+            }
+
+            else -> GoalProgressPanel(
+                goalProgress = state.goalProgress,
+                onConfigure = { configuring = true },
+            )
+        }
 
         state.errorMessage?.let { msg ->
             EmptyStateCard(
@@ -74,4 +125,42 @@ fun GoalsWebScreen(
             Div(attrs = { classes(SmokeWebStyles.helperText) }) { Text(msg) }
         }
     }
+}
+
+@Composable
+private fun GoalProgressPanel(
+    goalProgress: GoalProgress?,
+    onConfigure: () -> Unit,
+) {
+    SurfaceCard {
+        Div(attrs = { attr("style", "display:flex;flex-direction:column;gap:10px;") }) {
+            Div(attrs = { classes(SmokeWebStyles.helperText) }) { Text("Active goal") }
+            Div(attrs = { classes(SmokeWebStyles.sectionTitle) }) {
+                Text(goalProgress?.title ?: "Your goal")
+            }
+            goalProgress?.let { progress ->
+                progress.status.label()?.let { status ->
+                    Div(attrs = { classes(SmokeWebStyles.helperText) }) { Text(status) }
+                }
+                Div(attrs = { classes(SmokeWebStyles.sectionBody) }) { Text(progress.progressLabel) }
+                progress.supportingText.takeIf { it.isNotBlank() }?.let {
+                    Div(attrs = { classes(SmokeWebStyles.helperText) }) { Text(it) }
+                }
+                progress.baselineLabel?.let {
+                    Div(attrs = { classes(SmokeWebStyles.helperText) }) { Text(it) }
+                }
+                progress.streakLabel?.let {
+                    Div(attrs = { classes(SmokeWebStyles.helperText) }) { Text(it) }
+                }
+            }
+            PrimaryButton(text = "Configure goal", onClick = onConfigure)
+        }
+    }
+}
+
+private fun GoalStatus.label(): String? = when (this) {
+    GoalStatus.OnTrack -> "On track"
+    GoalStatus.OffTrack -> "Off track"
+    GoalStatus.Completed -> "Completed"
+    GoalStatus.NotEnoughData -> null
 }

--- a/features/history/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/history/presentation/process/HistoryProcessHolderTest.kt
+++ b/features/history/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/history/presentation/process/HistoryProcessHolderTest.kt
@@ -111,7 +111,7 @@ class HistoryProcessHolderTest {
         @Test
         fun `WHEN adding smoke THEN returns Loading, Success and syncs with Wear`() = runTest {
             val date: Instant = Clock.System.now()
-            coEvery { addSmokeUseCase(any()) } just Runs
+            coEvery { addSmokeUseCase(any()) } returns "smoke-id"
 
             results = processHolder.processIntent(HistoryIntent.AddSmoke(date))
 
@@ -130,6 +130,7 @@ class HistoryProcessHolderTest {
             var addedAt: Instant? = null
             coEvery { addSmokeUseCase(any()) } answers {
                 addedAt = firstArg()
+                "smoke-id"
             }
 
             results = processHolder.processIntent(HistoryIntent.AddSmoke(selectedDate))
@@ -161,7 +162,7 @@ class HistoryProcessHolderTest {
         @Test
         fun `WHEN widget refresh fails after add for date THEN tracking still succeeds`() = runTest {
             val date: Instant = Clock.System.now()
-            coEvery { addSmokeUseCase(any()) } just Runs
+            coEvery { addSmokeUseCase(any()) } returns "smoke-id"
             coEvery { fetchSmokeCountListUseCase.invoke(any()) } throws IllegalStateException("Quota exceeded")
 
             results = processHolder.processIntent(HistoryIntent.AddSmoke(date))

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/HomeViewModel.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/HomeViewModel.kt
@@ -156,6 +156,9 @@ class HomeViewModel constructor(
                     monthTrend = if (result.previousMonthCount > 0) {
                         (((result.previousMonthCount - result.smokeCountListResult.countByMonth).toDouble() / result.previousMonthCount) * 100).toInt()
                     } else null,
+                    monthTrendDelta = if (result.previousMonthCount > 0) {
+                        result.smokeCountListResult.countByMonth - result.previousMonthCount
+                    } else null,
                     activeCraving = result.activeCraving,
                     cravingStats = result.cravingStats,
                 )

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/HomeViewModel.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/HomeViewModel.kt
@@ -162,6 +162,7 @@ class HomeViewModel constructor(
                     activeCraving = result.activeCraving,
                     cravingStats = result.cravingStats,
                     pendingRelationshipSmokes = result.pendingRelationshipSmokes,
+                    availableTriggers = result.availableTriggers,
                 )
             }
 

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/HomeViewModel.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/HomeViewModel.kt
@@ -161,6 +161,7 @@ class HomeViewModel constructor(
                     } else null,
                     activeCraving = result.activeCraving,
                     cravingStats = result.cravingStats,
+                    pendingRelationshipSmokes = result.pendingRelationshipSmokes,
                 )
             }
 
@@ -203,8 +204,8 @@ class HomeViewModel constructor(
                 )
             }
 
-            DeleteSmokeSuccess, EditSmokeSuccess, AddSmokeSuccess, StartNewDaySuccess -> {
-                // Re-fetch smokes when adding, editing, or deleting a smoke.
+            DeleteSmokeSuccess, EditSmokeSuccess, StartNewDaySuccess -> {
+                // Re-fetch smokes when editing, deleting, or starting a new day.
                 intents().trySend(HomeIntent.FetchSmokes)
                 previous.copy(
                     displayLoading = false,
@@ -212,6 +213,25 @@ class HomeViewModel constructor(
                     error = null,
                 )
             }
+
+            is AddSmokeSuccess -> {
+                // Re-fetch so the new smoke shows up, and open the relationship prompt for it.
+                intents().trySend(HomeIntent.FetchSmokes)
+                previous.copy(
+                    displayLoading = false,
+                    displayRefreshLoading = false,
+                    error = null,
+                    relationshipPromptSmokeId = result.smokeId,
+                )
+            }
+
+            HomeResult.RelationshipUpdated -> {
+                // Relationship saved/skipped: refresh the pending list and close the prompt.
+                intents().trySend(HomeIntent.FetchSmokes)
+                previous.copy(relationshipPromptSmokeId = null)
+            }
+
+            HomeResult.RelationshipPromptDismissed -> previous.copy(relationshipPromptSmokeId = null)
 
             is Error -> previous.copy(
                 displayLoading = false,

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/HomeIntent.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/HomeIntent.kt
@@ -3,6 +3,7 @@ package com.feragusper.smokeanalytics.features.home.presentation.mvi
 import com.feragusper.smokeanalytics.libraries.architecture.presentation.mvi.MVIIntent
 import com.feragusper.smokeanalytics.libraries.cravings.domain.model.Craving
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeTrigger
 import kotlinx.datetime.Instant
 
 /**
@@ -85,4 +86,29 @@ sealed class HomeIntent : MVIIntent {
      * Dismisses the craving celebration shown after a resolved wait.
      */
     data object DismissCravingCelebration : HomeIntent()
+
+    /**
+     * Opens the "what was it related to?" prompt for a given smoke (e.g. from the
+     * reminder card, for a smoke that is still untracked).
+     */
+    data class OpenRelationshipPrompt(val smokeId: String) : HomeIntent()
+
+    /**
+     * Saves the triggers the user attached to a smoke. [note] holds the free-text "Other".
+     */
+    data class SaveSmokeRelationship(
+        val smokeId: String,
+        val triggers: Set<SmokeTrigger>,
+        val note: String?,
+    ) : HomeIntent()
+
+    /**
+     * Marks a smoke as having no particular trigger so it stops appearing in the reminder.
+     */
+    data class SkipSmokeRelationship(val smokeId: String) : HomeIntent()
+
+    /**
+     * Closes the relationship prompt without answering; the smoke stays untracked.
+     */
+    data object DismissRelationshipPrompt : HomeIntent()
 }

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/HomeIntent.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/HomeIntent.kt
@@ -3,7 +3,6 @@ package com.feragusper.smokeanalytics.features.home.presentation.mvi
 import com.feragusper.smokeanalytics.libraries.architecture.presentation.mvi.MVIIntent
 import com.feragusper.smokeanalytics.libraries.cravings.domain.model.Craving
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
-import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeTrigger
 import kotlinx.datetime.Instant
 
 /**
@@ -94,12 +93,11 @@ sealed class HomeIntent : MVIIntent {
     data class OpenRelationshipPrompt(val smokeId: String) : HomeIntent()
 
     /**
-     * Saves the triggers the user attached to a smoke. [note] holds the free-text "Other".
+     * Saves the tags the user attached to a smoke (built-in keys and/or custom strings).
      */
     data class SaveSmokeRelationship(
         val smokeId: String,
-        val triggers: Set<SmokeTrigger>,
-        val note: String?,
+        val tags: Set<String>,
     ) : HomeIntent()
 
     /**

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/HomeResult.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/HomeResult.kt
@@ -52,8 +52,20 @@ sealed interface HomeResult : MVIResult {
 
     /**
      * Indicates that a smoke event was successfully added.
+     *
+     * @property smokeId The id of the new smoke, used to open the relationship prompt.
      */
-    data object AddSmokeSuccess : HomeResult
+    data class AddSmokeSuccess(val smokeId: String) : HomeResult
+
+    /**
+     * A smoke's relationship was saved or skipped; the home should refetch and close the prompt.
+     */
+    data object RelationshipUpdated : HomeResult
+
+    /**
+     * The relationship prompt was dismissed without answering.
+     */
+    data object RelationshipPromptDismissed : HomeResult
 
     /**
      * Indicates that the current day was manually restarted.
@@ -105,6 +117,7 @@ sealed interface HomeResult : MVIResult {
         val previousMonthCount: Int = 0,
         val activeCraving: Craving? = null,
         val cravingStats: CravingStats = CravingStats(),
+        val pendingRelationshipSmokes: List<Smoke> = emptyList(),
     ) : HomeResult
 
     /**

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/HomeResult.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/HomeResult.kt
@@ -13,6 +13,7 @@ import com.feragusper.smokeanalytics.libraries.cravings.domain.model.CravingOutc
 import com.feragusper.smokeanalytics.libraries.cravings.domain.model.CravingStats
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.TriggerOption
 
 /**
  * Represents the possible outcomes of processing [HomeIntent] actions.
@@ -118,6 +119,7 @@ sealed interface HomeResult : MVIResult {
         val activeCraving: Craving? = null,
         val cravingStats: CravingStats = CravingStats(),
         val pendingRelationshipSmokes: List<Smoke> = emptyList(),
+        val availableTriggers: List<TriggerOption> = emptyList(),
     ) : HomeResult
 
     /**

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
@@ -121,6 +121,7 @@ data class HomeViewState(
     ),
     internal val error: HomeResult.Error? = null,
     internal val monthTrend: Int? = null,
+    internal val monthTrendDelta: Int? = null,
     internal val activeCraving: Craving? = null,
     internal val cravingStats: CravingStats? = null,
     internal val showCravingHint: Boolean = false,
@@ -207,6 +208,7 @@ data class HomeViewState(
                 isLoading = displayLoading,
                 error = error,
                 monthTrend = monthTrend,
+                monthTrendDelta = monthTrendDelta,
                 activeCraving = activeCraving,
                 cravingStats = cravingStats,
                 showCravingHint = showCravingHint,
@@ -243,6 +245,7 @@ private fun HomeContent(
     isLoading: Boolean,
     error: HomeResult.Error?,
     monthTrend: Int?,
+    monthTrendDelta: Int?,
     activeCraving: Craving?,
     cravingStats: CravingStats?,
     showCravingHint: Boolean,
@@ -367,7 +370,7 @@ private fun HomeContent(
         }
         monthTrend?.let { trend ->
             item {
-                HomeTrendCard(trendValue = trend)
+                HomeTrendCard(trendValue = trend, delta = monthTrendDelta)
             }
         }
         item { Spacer(modifier = Modifier.height(24.dp)) }
@@ -375,12 +378,38 @@ private fun HomeContent(
 }
 
 @Composable
-private fun HomeTrendCard(trendValue: Int) {
+private fun HomeTrendCard(trendValue: Int, delta: Int?) {
+    // trendValue is the reduction vs last month: positive = smoking less (good),
+    // negative = smoking more (bad). Colour and copy follow that, not a fixed green.
+    val improving = trendValue > 0
+    val worsening = trendValue < 0
+    val containerColor = when {
+        improving -> MaterialTheme.colorScheme.primary
+        worsening -> MaterialTheme.colorScheme.error
+        else -> MaterialTheme.colorScheme.surfaceVariant
+    }
+    val contentColor = when {
+        improving -> MaterialTheme.colorScheme.onPrimary
+        worsening -> MaterialTheme.colorScheme.onError
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    val headline = when {
+        improving -> "Smoking less than last month"
+        worsening -> "Smoking more than last month"
+        else -> "Same pace as last month"
+    }
+    // delta = current - previous (same elapsed window). Negative = fewer so far.
+    val deltaLabel = delta?.let {
+        when {
+            it < 0 -> "${-it} fewer ${pluralCigarettes(-it)} so far"
+            it > 0 -> "$it more ${pluralCigarettes(it)} so far"
+            else -> "Same count so far"
+        }
+    }
+
     androidx.compose.material3.Card(
         shape = RoundedCornerShape(24.dp),
-        colors = androidx.compose.material3.CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.primary,
-        ),
+        colors = androidx.compose.material3.CardDefaults.cardColors(containerColor = containerColor),
     ) {
         Row(
             modifier = Modifier
@@ -389,37 +418,52 @@ private fun HomeTrendCard(trendValue: Int) {
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.weight(1f)) {
                 Text(
-                    text = "Trend",
+                    text = "Vs last month",
                     style = MaterialTheme.typography.labelLarge,
-                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.72f),
+                    color = contentColor.copy(alpha = 0.72f),
                 )
                 Text(
-                    text = "${if (trendValue > 0) "+" else ""}$trendValue%",
-                    style = MaterialTheme.typography.displaySmall,
-                    color = MaterialTheme.colorScheme.onPrimary,
+                    text = headline,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.ExtraBold,
+                    color = contentColor,
                 )
-                Text(
-                    text = "Reduction vs last month",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.78f),
-                )
+                deltaLabel?.let {
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = contentColor.copy(alpha = 0.82f),
+                    )
+                }
             }
             Surface(
-                color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.12f),
+                color = contentColor.copy(alpha = 0.12f),
                 shape = RoundedCornerShape(999.dp),
             ) {
-                Text(
-                    text = if (trendValue > 0) "↘" else if (trendValue < 0) "↗" else "→",
-                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 18.dp),
-                    style = MaterialTheme.typography.headlineMedium,
-                    color = MaterialTheme.colorScheme.onPrimary,
-                )
+                Column(
+                    modifier = Modifier.padding(horizontal = 18.dp, vertical = 14.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(
+                        text = if (improving) "↘" else if (worsening) "↗" else "→",
+                        style = MaterialTheme.typography.titleLarge,
+                        color = contentColor,
+                    )
+                    Text(
+                        text = "${if (trendValue > 0) "+" else ""}$trendValue%",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = contentColor,
+                    )
+                }
             }
         }
     }
 }
+
+private fun pluralCigarettes(count: Int): String = if (count == 1) "cigarette" else "cigarettes"
 
 @Composable
 private fun CravingPromptCard(onTrack: () -> Unit) {

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
@@ -82,6 +82,7 @@ import com.feragusper.smokeanalytics.libraries.cravings.domain.model.CravingStat
 import com.feragusper.smokeanalytics.libraries.design.compose.CombinedPreviews
 import com.feragusper.smokeanalytics.libraries.design.compose.theme.SmokeAnalyticsTheme
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.TriggerOption
 import com.valentinilk.shimmer.shimmer
 import kotlinx.coroutines.delay
 import kotlin.time.Clock
@@ -128,6 +129,7 @@ data class HomeViewState(
     internal val cravingCelebration: CravingCelebration? = null,
     internal val pendingRelationshipSmokes: List<Smoke> = emptyList(),
     internal val relationshipPromptSmokeId: String? = null,
+    internal val availableTriggers: List<TriggerOption> = emptyList(),
 ) : MVIViewState<HomeIntent> {
 
     internal val lastSmokeTimeLabel: String?
@@ -234,9 +236,8 @@ data class HomeViewState(
         val promptSmokeId = relationshipPromptSmokeId
         if (promptSmokeId != null) {
             RelationshipPromptSheet(
-                onSave = { triggers, note ->
-                    intent(HomeIntent.SaveSmokeRelationship(promptSmokeId, triggers, note))
-                },
+                availableTriggers = availableTriggers,
+                onSave = { tags -> intent(HomeIntent.SaveSmokeRelationship(promptSmokeId, tags)) },
                 onSkip = { intent(HomeIntent.SkipSmokeRelationship(promptSmokeId)) },
                 onDismiss = { intent(HomeIntent.DismissRelationshipPrompt) },
             )

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
@@ -126,6 +126,8 @@ data class HomeViewState(
     internal val cravingStats: CravingStats? = null,
     internal val showCravingHint: Boolean = false,
     internal val cravingCelebration: CravingCelebration? = null,
+    internal val pendingRelationshipSmokes: List<Smoke> = emptyList(),
+    internal val relationshipPromptSmokeId: String? = null,
 ) : MVIViewState<HomeIntent> {
 
     internal val lastSmokeTimeLabel: String?
@@ -212,6 +214,12 @@ data class HomeViewState(
                 activeCraving = activeCraving,
                 cravingStats = cravingStats,
                 showCravingHint = showCravingHint,
+                pendingRelationshipCount = pendingRelationshipSmokes.size,
+                onAddRelationship = {
+                    pendingRelationshipSmokes.firstOrNull()?.let {
+                        intent(HomeIntent.OpenRelationshipPrompt(it.id))
+                    }
+                },
                 intent = intent,
             )
         }
@@ -220,6 +228,17 @@ data class HomeViewState(
             CravingCelebrationDialog(
                 celebration = celebration,
                 onDismiss = { intent(HomeIntent.DismissCravingCelebration) },
+            )
+        }
+
+        val promptSmokeId = relationshipPromptSmokeId
+        if (promptSmokeId != null) {
+            RelationshipPromptSheet(
+                onSave = { triggers, note ->
+                    intent(HomeIntent.SaveSmokeRelationship(promptSmokeId, triggers, note))
+                },
+                onSkip = { intent(HomeIntent.SkipSmokeRelationship(promptSmokeId)) },
+                onDismiss = { intent(HomeIntent.DismissRelationshipPrompt) },
             )
         }
     }
@@ -249,6 +268,8 @@ private fun HomeContent(
     activeCraving: Craving?,
     cravingStats: CravingStats?,
     showCravingHint: Boolean,
+    pendingRelationshipCount: Int,
+    onAddRelationship: () -> Unit,
     intent: (HomeIntent) -> Unit,
 ) {
     val hasLoadedContent = smokesPerDay != null || timeSinceLastCigarette != null || goalProgress != null
@@ -325,6 +346,14 @@ private fun HomeContent(
             )
         }
         if (!isLoading && hasLoadedContent) {
+            if (pendingRelationshipCount > 0) {
+                item {
+                    RelationshipReminderCard(
+                        pendingCount = pendingRelationshipCount,
+                        onAdd = onAddRelationship,
+                    )
+                }
+            }
             if (showCravingHint) {
                 item { CravingHintBanner(onDismiss = { intent(HomeIntent.DismissCravingHint) }) }
             }

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/RelationshipComponents.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/RelationshipComponents.kt
@@ -1,0 +1,194 @@
+package com.feragusper.smokeanalytics.features.home.presentation.mvi.compose
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.feragusper.smokeanalytics.libraries.design.compose.CombinedPreviews
+import com.feragusper.smokeanalytics.libraries.design.compose.theme.SmokeAnalyticsTheme
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeTrigger
+
+/** Human-readable label for a trigger chip. */
+internal fun SmokeTrigger.label(): String = when (this) {
+    SmokeTrigger.COFFEE -> "Coffee"
+    SmokeTrigger.ALCOHOL -> "Alcohol"
+    SmokeTrigger.BOREDOM -> "Boredom"
+    SmokeTrigger.ANXIETY -> "Anxiety"
+    SmokeTrigger.STRESS -> "Stress"
+    SmokeTrigger.AFTER_MEAL -> "After a meal"
+    SmokeTrigger.SOCIAL -> "Social"
+    SmokeTrigger.BREAK -> "Break"
+    SmokeTrigger.DRIVING -> "Driving"
+    SmokeTrigger.PHONE -> "Phone"
+}
+
+/**
+ * Home card reminding the user that some smokes (logged from the watch, or whose prompt
+ * was dismissed) still have no trigger. Tapping the CTA opens the prompt for the next one.
+ */
+@Composable
+internal fun RelationshipReminderCard(
+    pendingCount: Int,
+    onAdd: () -> Unit,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.4f),
+        shape = RoundedCornerShape(24.dp),
+        tonalElevation = 1.dp,
+    ) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = "What were these about?",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                text = if (pendingCount == 1) {
+                    "1 cigarette still needs a trigger"
+                } else {
+                    "$pendingCount cigarettes still need a trigger"
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Button(
+                onClick = onAdd,
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(18.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Edit,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("Add trigger", fontWeight = FontWeight.Bold)
+            }
+        }
+    }
+}
+
+/**
+ * Bottom sheet asking what a smoke was related to. Multi-select chips plus an "Other"
+ * free-text field; the user can save, declare "no relation", or dismiss (stays untracked).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun RelationshipPromptSheet(
+    onSave: (triggers: Set<SmokeTrigger>, note: String?) -> Unit,
+    onSkip: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var selected by remember { mutableStateOf(emptySet<SmokeTrigger>()) }
+    var note by remember { mutableStateOf("") }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = "What was it related to?",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                text = "Tag what triggered this cigarette, or skip if it was nothing in particular.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                SmokeTrigger.entries.forEach { trigger ->
+                    FilterChip(
+                        selected = trigger in selected,
+                        onClick = {
+                            selected = if (trigger in selected) selected - trigger else selected + trigger
+                        },
+                        label = { Text(trigger.label()) },
+                    )
+                }
+            }
+            OutlinedTextField(
+                value = note,
+                onValueChange = { note = it },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text("Other") },
+                placeholder = { Text("Add your own…") },
+                singleLine = true,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                OutlinedButton(
+                    onClick = onSkip,
+                    modifier = Modifier.weight(1f),
+                    shape = RoundedCornerShape(16.dp),
+                ) {
+                    Text("No relation")
+                }
+                Button(
+                    onClick = { onSave(selected, note.trim().takeIf { it.isNotEmpty() }) },
+                    modifier = Modifier.weight(1f),
+                    shape = RoundedCornerShape(16.dp),
+                    enabled = selected.isNotEmpty() || note.isNotBlank(),
+                ) {
+                    Text("Save", fontWeight = FontWeight.Bold)
+                }
+            }
+        }
+    }
+}
+
+@CombinedPreviews
+@Composable
+private fun RelationshipReminderCardPreview() {
+    SmokeAnalyticsTheme {
+        RelationshipReminderCard(pendingCount = 3, onAdd = {})
+    }
+}

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/RelationshipComponents.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/RelationshipComponents.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -36,20 +37,8 @@ import androidx.compose.ui.unit.dp
 import com.feragusper.smokeanalytics.libraries.design.compose.CombinedPreviews
 import com.feragusper.smokeanalytics.libraries.design.compose.theme.SmokeAnalyticsTheme
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeTrigger
-
-/** Human-readable label for a trigger chip. */
-internal fun SmokeTrigger.label(): String = when (this) {
-    SmokeTrigger.COFFEE -> "Coffee"
-    SmokeTrigger.ALCOHOL -> "Alcohol"
-    SmokeTrigger.BOREDOM -> "Boredom"
-    SmokeTrigger.ANXIETY -> "Anxiety"
-    SmokeTrigger.STRESS -> "Stress"
-    SmokeTrigger.AFTER_MEAL -> "After a meal"
-    SmokeTrigger.SOCIAL -> "Social"
-    SmokeTrigger.BREAK -> "Break"
-    SmokeTrigger.DRIVING -> "Driving"
-    SmokeTrigger.PHONE -> "Phone"
-}
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.TriggerOption
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.normalizedTag
 
 /**
  * Home card reminding the user that some smokes (logged from the watch, or whose prompt
@@ -108,13 +97,22 @@ internal fun RelationshipReminderCard(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun RelationshipPromptSheet(
-    onSave: (triggers: Set<SmokeTrigger>, note: String?) -> Unit,
+    availableTriggers: List<TriggerOption>,
+    onSave: (tags: Set<String>) -> Unit,
     onSkip: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    var selected by remember { mutableStateOf(emptySet<SmokeTrigger>()) }
-    var note by remember { mutableStateOf("") }
+    // Chips come from the catalog (defaults + custom). The user can also type an ad-hoc
+    // tag, which is added to the chip row for this smoke.
+    val catalog = remember(availableTriggers) {
+        if (availableTriggers.isEmpty()) SmokeTrigger.defaultOptions() else availableTriggers
+    }
+    var adHoc by remember { mutableStateOf(listOf<TriggerOption>()) }
+    var selectedKeys by remember { mutableStateOf(emptySet<String>()) }
+    var draft by remember { mutableStateOf("") }
+
+    val options = catalog + adHoc.filter { extra -> catalog.none { it.key == extra.key } }
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -143,23 +141,37 @@ internal fun RelationshipPromptSheet(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                SmokeTrigger.entries.forEach { trigger ->
+                options.forEach { option ->
                     FilterChip(
-                        selected = trigger in selected,
+                        selected = option.key in selectedKeys,
                         onClick = {
-                            selected = if (trigger in selected) selected - trigger else selected + trigger
+                            selectedKeys = if (option.key in selectedKeys) {
+                                selectedKeys - option.key
+                            } else {
+                                selectedKeys + option.key
+                            }
                         },
-                        label = { Text(trigger.label()) },
+                        label = { Text(option.label) },
                     )
                 }
             }
             OutlinedTextField(
-                value = note,
-                onValueChange = { note = it },
+                value = draft,
+                onValueChange = { draft = it },
                 modifier = Modifier.fillMaxWidth(),
-                label = { Text("Other") },
-                placeholder = { Text("Add your own…") },
+                label = { Text("Add a tag") },
+                placeholder = { Text("Type and press Add…") },
                 singleLine = true,
+                trailingIcon = {
+                    val key = draft.normalizedTag()
+                    if (key != null) {
+                        TextButton(onClick = {
+                            adHoc = adHoc + TriggerOption(key = key, label = key, isCustom = true)
+                            selectedKeys = selectedKeys + key
+                            draft = ""
+                        }) { Text("Add") }
+                    }
+                },
             )
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -173,10 +185,13 @@ internal fun RelationshipPromptSheet(
                     Text("No relation")
                 }
                 Button(
-                    onClick = { onSave(selected, note.trim().takeIf { it.isNotEmpty() }) },
+                    onClick = {
+                        val tags = selectedKeys + listOfNotNull(draft.normalizedTag())
+                        onSave(tags)
+                    },
                     modifier = Modifier.weight(1f),
                     shape = RoundedCornerShape(16.dp),
-                    enabled = selected.isNotEmpty() || note.isNotBlank(),
+                    enabled = selectedKeys.isNotEmpty() || draft.normalizedTag() != null,
                 ) {
                     Text("Save", fontWeight = FontWeight.Bold)
                 }

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
@@ -291,26 +291,46 @@ class HomeProcessHolder constructor(
 
             is Session.LoggedIn -> {
                 emit(HomeResult.Loading)
-                val preferences = fetchUserPreferencesUseCase()
-                val locationAvailability = locationCaptureService.locationTrackingAvailability(
-                    preferences.locationTrackingEnabled
-                )
-                val location = if (locationAvailability.isReady) {
-                    locationCaptureService.captureCurrentLocation()?.let {
-                        GeoPoint(latitude = it.latitude, longitude = it.longitude)
-                    }
-                } else {
-                    null
-                }
-                val smokeId = addSmokeUseCase.invoke(location = location)
+                // Log the smoke immediately so the tap stays instant, then attach the
+                // location asynchronously — an active GPS fix can take a few seconds and
+                // shouldn't block tracking.
+                val now = Clock.System.now()
+                val smokeId = addSmokeUseCase.invoke(timestamp = now)
                 emit(HomeResult.AddSmokeSuccess(smokeId))
                 refreshWidgetSnapshotBestEffort()
                 syncWithWearBestEffort()
+                attachLocationBestEffort(smokeId, now)
             }
         }
     }.catchAndLog { e ->
         Timber.e(e, "Track smoke failed")
         emit(HomeResult.Error.Generic(e.debugSummary()))
+    }
+
+    /**
+     * Captures the current location after the smoke is logged and attaches it via edit.
+     * Best-effort: failures (no permission, no fix) leave the smoke without a location and
+     * never surface an error, since tracking already succeeded.
+     */
+    private suspend fun kotlinx.coroutines.flow.FlowCollector<HomeResult>.attachLocationBestEffort(
+        smokeId: String,
+        date: kotlin.time.Instant,
+    ) {
+        runCatching {
+            val preferences = fetchUserPreferencesUseCase()
+            val available = locationCaptureService.locationTrackingAvailability(
+                preferences.locationTrackingEnabled
+            ).isReady
+            if (!available) return
+            val coordinate = locationCaptureService.captureCurrentLocation() ?: return
+            editSmokeUseCase.invoke(
+                smokeId,
+                date,
+                GeoPoint(latitude = coordinate.latitude, longitude = coordinate.longitude),
+            )
+            emit(HomeResult.EditSmokeSuccess)
+            refreshWidgetSnapshotBestEffort()
+        }.onFailure { Timber.w(it, "Async location attach failed") }
     }
 
     /**

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
@@ -29,10 +29,12 @@ import com.feragusper.smokeanalytics.libraries.authentication.domain.Session
 import com.feragusper.smokeanalytics.libraries.preferences.domain.FetchUserPreferencesUseCase
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UpdateUserPreferencesUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeRelationship
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.AddSmokeUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.DeleteSmokeUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.EditSmokeUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.FetchSmokesUseCase
+import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.SetSmokeRelationshipUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.SyncWithWearUseCase
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -44,6 +46,7 @@ import kotlinx.datetime.minus
 import kotlinx.datetime.toLocalDateTime
 import timber.log.Timber
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
 
 /**
  * Processes intents from the Home feature, invoking the appropriate use cases and updating the result.
@@ -61,6 +64,7 @@ class HomeProcessHolder constructor(
     private val addSmokeUseCase: AddSmokeUseCase,
     private val editSmokeUseCase: EditSmokeUseCase,
     private val deleteSmokeUseCase: DeleteSmokeUseCase,
+    private val setSmokeRelationshipUseCase: SetSmokeRelationshipUseCase,
     private val fetchSmokeCountListUseCase: FetchSmokeCountListUseCase,
     private val fetchSmokesUseCase: FetchSmokesUseCase,
     private val fetchSessionUseCase: FetchSessionUseCase,
@@ -96,6 +100,33 @@ class HomeProcessHolder constructor(
         is HomeIntent.ResolveCraving -> processResolveCraving(intent)
         HomeIntent.DismissCravingHint -> flow { emit(HomeResult.CravingHintDismissed) }
         HomeIntent.DismissCravingCelebration -> flow { emit(HomeResult.CravingCelebrationDismissed) }
+        is HomeIntent.OpenRelationshipPrompt -> flow { emit(HomeResult.AddSmokeSuccess(intent.smokeId)) }
+        is HomeIntent.SaveSmokeRelationship -> processSaveRelationship(intent)
+        is HomeIntent.SkipSmokeRelationship -> processSkipRelationship(intent)
+        HomeIntent.DismissRelationshipPrompt -> flow { emit(HomeResult.RelationshipPromptDismissed) }
+    }
+
+    /**
+     * Persists the triggers the user attached to a smoke, then refreshes the home.
+     */
+    private fun processSaveRelationship(intent: HomeIntent.SaveSmokeRelationship): Flow<HomeResult> = flow<HomeResult> {
+        setSmokeRelationshipUseCase(
+            id = intent.smokeId,
+            relationship = SmokeRelationship.Tagged(triggers = intent.triggers, note = intent.note),
+        )
+        emit(HomeResult.RelationshipUpdated)
+    }.catchAndLog { e ->
+        emit(HomeResult.Error.Generic(e.debugSummary()))
+    }
+
+    /**
+     * Marks a smoke as having no particular trigger so it stops appearing in the reminder.
+     */
+    private fun processSkipRelationship(intent: HomeIntent.SkipSmokeRelationship): Flow<HomeResult> = flow<HomeResult> {
+        setSmokeRelationshipUseCase(id = intent.smokeId, relationship = SmokeRelationship.Skipped)
+        emit(HomeResult.RelationshipUpdated)
+    }.catchAndLog { e ->
+        emit(HomeResult.Error.Generic(e.debugSummary()))
     }
 
     /**
@@ -138,6 +169,12 @@ class HomeProcessHolder constructor(
                     fetchSmokesUseCase(start = previousMonthStart, end = previousMonthWindowEnd).size
                 val goalSmokes = fetchSmokesUseCase(start = goalDataFetchStart(preferences))
                 val goalProgress = evaluateGoalProgressUseCase(preferences.activeGoal, goalSmokes, preferences)
+                // Smokes still missing a relationship within the lookback window (e.g. logged
+                // from the watch, or whose prompt was dismissed) drive the home reminder card.
+                val pendingRelationshipSmokes = fetchSmokesUseCase(
+                    start = now.minus(RELATIONSHIP_LOOKBACK_DAYS.days),
+                    end = now,
+                ).filter { it.relationship.isPending }
                 val activeCraving = fetchActiveCravingUseCase()
                 val cravingStats = fetchCravingsUseCase(start = goalDataFetchStart(preferences)).toCravingStats()
                 val greetingState = greetingStateFor(
@@ -176,6 +213,7 @@ class HomeProcessHolder constructor(
                         previousMonthCount = previousMonthCount,
                         activeCraving = activeCraving,
                         cravingStats = cravingStats,
+                        pendingRelationshipSmokes = pendingRelationshipSmokes,
                     )
                 )
                 widgetRefreshService.refreshHomeSnapshot(smokeCounts.toWidgetSnapshot(preferences, goalProgress))
@@ -259,8 +297,8 @@ class HomeProcessHolder constructor(
                 } else {
                     null
                 }
-                addSmokeUseCase.invoke(location = location)
-                emit(HomeResult.AddSmokeSuccess)
+                val smokeId = addSmokeUseCase.invoke(location = location)
+                emit(HomeResult.AddSmokeSuccess(smokeId))
                 refreshWidgetSnapshotBestEffort()
                 syncWithWearBestEffort()
             }
@@ -365,6 +403,12 @@ class HomeProcessHolder constructor(
     private suspend fun syncWithWearBestEffort() {
         runCatching { syncWithWearUseCase.invoke() }
             .onFailure { Timber.w(it, "Home mutation succeeded but Wear sync failed: ${it.debugSummary()}") }
+    }
+
+    private companion object {
+        // How far back to look for smokes still missing a relationship. Firestore can't
+        // query "field absent", so the pending list is computed in memory over this window.
+        const val RELATIONSHIP_LOOKBACK_DAYS = 30
     }
 }
 

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
@@ -30,6 +30,7 @@ import com.feragusper.smokeanalytics.libraries.preferences.domain.FetchUserPrefe
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UpdateUserPreferencesUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeRelationship
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeTrigger
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.AddSmokeUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.DeleteSmokeUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.EditSmokeUseCase
@@ -112,7 +113,7 @@ class HomeProcessHolder constructor(
     private fun processSaveRelationship(intent: HomeIntent.SaveSmokeRelationship): Flow<HomeResult> = flow<HomeResult> {
         setSmokeRelationshipUseCase(
             id = intent.smokeId,
-            relationship = SmokeRelationship.Tagged(triggers = intent.triggers, note = intent.note),
+            relationship = SmokeRelationship.Tagged(tags = intent.tags),
         )
         emit(HomeResult.RelationshipUpdated)
     }.catchAndLog { e ->
@@ -214,6 +215,10 @@ class HomeProcessHolder constructor(
                         activeCraving = activeCraving,
                         cravingStats = cravingStats,
                         pendingRelationshipSmokes = pendingRelationshipSmokes,
+                        availableTriggers = SmokeTrigger.catalog(
+                            customTriggers = preferences.customTriggers,
+                            hiddenDefaultKeys = preferences.hiddenDefaultTriggers,
+                        ),
                     )
                 )
                 widgetRefreshService.refreshHomeSnapshot(smokeCounts.toWidgetSnapshot(preferences, goalProgress))

--- a/features/home/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/home/presentation/HomeViewModelTest.kt
+++ b/features/home/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/home/presentation/HomeViewModelTest.kt
@@ -87,7 +87,7 @@ class HomeViewModelTest {
             every { processHolder.processIntent(HomeIntent.AddSmoke) } returns intentResults
 
             viewModel.intents().trySend(HomeIntent.AddSmoke)
-            intentResults.emit(HomeResult.AddSmokeSuccess)
+            intentResults.emit(HomeResult.AddSmokeSuccess("smoke-id"))
 
             viewModel.states().test {
                 awaitItem().displayLoading shouldBeEqualTo false

--- a/features/home/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolderTest.kt
+++ b/features/home/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolderTest.kt
@@ -210,17 +210,21 @@ class HomeProcessHolderTest {
         }
 
         @Test
-        fun `WHEN location preference is enabled and ready THEN add smoke captures location`() = runTest {
+        fun `WHEN location preference is enabled and ready THEN smoke is logged first then location attached`() = runTest {
             val locationSlot = slot<GeoPoint>()
             coEvery { fetchUserPreferencesUseCase() } returns UserPreferences(locationTrackingEnabled = true)
             coEvery { locationCaptureService.captureCurrentLocation() } returns Coordinate(12.3, 45.6)
-            coEvery { addSmokeUseCase.invoke(any(), any()) } returns "smoke-id"
+            coEvery { addSmokeUseCase.invoke(any()) } returns "smoke-id"
+            coEvery { editSmokeUseCase.invoke(any(), any(), any()) } just Runs
 
             processHolder.processIntent(HomeIntent.AddSmoke).test {
                 awaitItem() shouldBeEqualTo HomeResult.Loading
+                // Logged immediately, before the (potentially slow) location fix.
                 awaitItem() shouldBeEqualTo HomeResult.AddSmokeSuccess("smoke-id")
+                // Location attached asynchronously via edit.
+                awaitItem() shouldBeEqualTo HomeResult.EditSmokeSuccess
                 coVerify(exactly = 1) {
-                    addSmokeUseCase.invoke(any(), capture(locationSlot))
+                    editSmokeUseCase.invoke("smoke-id", any(), capture(locationSlot))
                 }
                 locationSlot.captured.latitude shouldBeEqualTo 12.3
                 locationSlot.captured.longitude shouldBeEqualTo 45.6

--- a/features/home/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolderTest.kt
+++ b/features/home/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolderTest.kt
@@ -19,6 +19,7 @@ import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.AddSmokeUse
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.DeleteSmokeUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.EditSmokeUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.FetchSmokesUseCase
+import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.SetSmokeRelationshipUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.SyncWithWearUseCase
 import com.feragusper.smokeanalytics.libraries.cravings.domain.model.Craving
 import com.feragusper.smokeanalytics.libraries.cravings.domain.model.CravingOutcome
@@ -61,6 +62,7 @@ class HomeProcessHolderTest {
     private val addSmokeUseCase: AddSmokeUseCase = mockk()
     private val editSmokeUseCase: EditSmokeUseCase = mockk()
     private val deleteSmokeUseCase: DeleteSmokeUseCase = mockk()
+    private val setSmokeRelationshipUseCase: SetSmokeRelationshipUseCase = mockk()
     private val fetchSmokeCountListUseCase: FetchSmokeCountListUseCase = mockk()
     private val fetchSmokesUseCase: FetchSmokesUseCase = mockk()
     private val fetchSessionUseCase: FetchSessionUseCase = mockk()
@@ -82,6 +84,7 @@ class HomeProcessHolderTest {
             addSmokeUseCase = addSmokeUseCase,
             editSmokeUseCase = editSmokeUseCase,
             deleteSmokeUseCase = deleteSmokeUseCase,
+            setSmokeRelationshipUseCase = setSmokeRelationshipUseCase,
             fetchSmokeCountListUseCase = fetchSmokeCountListUseCase,
             fetchSmokesUseCase = fetchSmokesUseCase,
             fetchSessionUseCase = fetchSessionUseCase,
@@ -132,11 +135,11 @@ class HomeProcessHolderTest {
 
         @Test
         fun `WHEN adding smoke THEN it returns success and syncs with Wear`() = runTest {
-            coEvery { addSmokeUseCase.invoke(any()) } just Runs
+            coEvery { addSmokeUseCase.invoke(any()) } returns "smoke-id"
 
             processHolder.processIntent(HomeIntent.AddSmoke).test {
                 awaitItem() shouldBeEqualTo HomeResult.Loading
-                awaitItem() shouldBeEqualTo HomeResult.AddSmokeSuccess
+                awaitItem() shouldBeEqualTo HomeResult.AddSmokeSuccess("smoke-id")
                 coVerify(exactly = 1) { syncWithWearUseCase.invoke() }
                 awaitComplete()
             }
@@ -193,7 +196,7 @@ class HomeProcessHolderTest {
                 createdAt = Clock.System.now() - 60.minutes,
                 targetAt = Clock.System.now() - 1.minutes,
             )
-            coEvery { addSmokeUseCase.invoke(any(), any()) } just Runs
+            coEvery { addSmokeUseCase.invoke(any(), any()) } returns "smoke-id"
             coEvery { resolveCravingUseCase.invoke(craving, CravingOutcome.POSTPONED, any()) } returns 12
 
             processHolder.processIntent(
@@ -211,11 +214,11 @@ class HomeProcessHolderTest {
             val locationSlot = slot<GeoPoint>()
             coEvery { fetchUserPreferencesUseCase() } returns UserPreferences(locationTrackingEnabled = true)
             coEvery { locationCaptureService.captureCurrentLocation() } returns Coordinate(12.3, 45.6)
-            coEvery { addSmokeUseCase.invoke(any(), any()) } just Runs
+            coEvery { addSmokeUseCase.invoke(any(), any()) } returns "smoke-id"
 
             processHolder.processIntent(HomeIntent.AddSmoke).test {
                 awaitItem() shouldBeEqualTo HomeResult.Loading
-                awaitItem() shouldBeEqualTo HomeResult.AddSmokeSuccess
+                awaitItem() shouldBeEqualTo HomeResult.AddSmokeSuccess("smoke-id")
                 coVerify(exactly = 1) {
                     addSmokeUseCase.invoke(any(), capture(locationSlot))
                 }
@@ -234,11 +237,11 @@ class HomeProcessHolderTest {
                     permissionGranted = false,
                     providerEnabled = true,
                 )
-                coEvery { addSmokeUseCase.invoke(any(), null) } just Runs
+                coEvery { addSmokeUseCase.invoke(any(), null) } returns "smoke-id"
 
                 processHolder.processIntent(HomeIntent.AddSmoke).test {
                     awaitItem() shouldBeEqualTo HomeResult.Loading
-                    awaitItem() shouldBeEqualTo HomeResult.AddSmokeSuccess
+                    awaitItem() shouldBeEqualTo HomeResult.AddSmokeSuccess("smoke-id")
                     coVerify(exactly = 0) { locationCaptureService.captureCurrentLocation() }
                     coVerify(exactly = 1) { addSmokeUseCase.invoke(any(), null) }
                     awaitComplete()
@@ -286,12 +289,12 @@ class HomeProcessHolderTest {
 
         @Test
         fun `WHEN widget refresh fails after adding smoke THEN tracking still succeeds`() = runTest {
-            coEvery { addSmokeUseCase.invoke(any()) } just Runs
+            coEvery { addSmokeUseCase.invoke(any()) } returns "smoke-id"
             coEvery { fetchSmokeCountListUseCase.invoke(any(), any()) } throws IllegalStateException("Quota exceeded")
 
             processHolder.processIntent(HomeIntent.AddSmoke).test {
                 awaitItem() shouldBeEqualTo HomeResult.Loading
-                awaitItem() shouldBeEqualTo HomeResult.AddSmokeSuccess
+                awaitItem() shouldBeEqualTo HomeResult.AddSmokeSuccess("smoke-id")
                 coVerify(exactly = 1) { syncWithWearUseCase.invoke() }
                 awaitComplete()
             }

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeViewState.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeViewState.kt
@@ -45,6 +45,7 @@ data class HomeViewState(
     val currencySymbol: String = "€",
     val canStartNewDay: Boolean = false,
     val monthTrend: Int? = null,
+    val monthTrendDelta: Int? = null,
     val elapsedTone: ElapsedTone = ElapsedTone.Urgent,
     val locationTrackingAvailability: LocationTrackingAvailability = LocationTrackingAvailability(
         preferenceEnabled = false,

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeViewState.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeViewState.kt
@@ -10,6 +10,7 @@ import com.feragusper.smokeanalytics.libraries.cravings.domain.model.Craving
 import com.feragusper.smokeanalytics.libraries.cravings.domain.model.CravingOutcome
 import com.feragusper.smokeanalytics.libraries.cravings.domain.model.CravingStats
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.TriggerOption
 
 /**
  * Represents the state of the Home screen.
@@ -59,6 +60,7 @@ data class HomeViewState(
     val cravingCelebration: CravingCelebration? = null,
     val pendingRelationshipSmokes: List<Smoke> = emptyList(),
     val relationshipPromptSmokeId: String? = null,
+    val availableTriggers: List<TriggerOption> = emptyList(),
 ) {
 
     /**

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeViewState.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeViewState.kt
@@ -57,6 +57,8 @@ data class HomeViewState(
     val cravingStats: CravingStats? = null,
     val showCravingHint: Boolean = false,
     val cravingCelebration: CravingCelebration? = null,
+    val pendingRelationshipSmokes: List<Smoke> = emptyList(),
+    val relationshipPromptSmokeId: String? = null,
 ) {
 
     /**

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeWebScreen.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeWebScreen.kt
@@ -223,9 +223,8 @@ fun HomeViewState.Render(
     val promptSmokeId = relationshipPromptSmokeId
     if (promptSmokeId != null) {
         RelationshipPromptDialogWeb(
-            onSave = { triggers, note ->
-                onIntent(HomeIntent.SaveSmokeRelationship(promptSmokeId, triggers, note))
-            },
+            availableTriggers = availableTriggers,
+            onSave = { tags -> onIntent(HomeIntent.SaveSmokeRelationship(promptSmokeId, tags)) },
             onSkip = { onIntent(HomeIntent.SkipSmokeRelationship(promptSmokeId)) },
             onDismiss = { onIntent(HomeIntent.DismissRelationshipPrompt) },
         )

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeWebScreen.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeWebScreen.kt
@@ -184,6 +184,17 @@ fun HomeViewState.Render(
                 }
             }
 
+            if (pendingRelationshipSmokes.isNotEmpty()) {
+                RelationshipReminderCardWeb(
+                    pendingCount = pendingRelationshipSmokes.size,
+                    onAdd = {
+                        pendingRelationshipSmokes.firstOrNull()?.let {
+                            onIntent(HomeIntent.OpenRelationshipPrompt(it.id))
+                        }
+                    },
+                )
+            }
+
             HomeInsightGrid(
                 lastSmokeTimeLabel = lastSmoke?.date?.toHomeClockLabel(),
                 timeSinceLastCigarette = timeSinceLastCigarette,
@@ -207,6 +218,17 @@ fun HomeViewState.Render(
                 )
             }
         }
+    }
+
+    val promptSmokeId = relationshipPromptSmokeId
+    if (promptSmokeId != null) {
+        RelationshipPromptDialogWeb(
+            onSave = { triggers, note ->
+                onIntent(HomeIntent.SaveSmokeRelationship(promptSmokeId, triggers, note))
+            },
+            onSkip = { onIntent(HomeIntent.SkipSmokeRelationship(promptSmokeId)) },
+            onDismiss = { onIntent(HomeIntent.DismissRelationshipPrompt) },
+        )
     }
 }
 

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeWebScreen.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeWebScreen.kt
@@ -198,7 +198,7 @@ fun HomeViewState.Render(
             }
 
             monthTrend?.let { trendValue ->
-                HomeTrendCard(trendValue = trendValue)
+                HomeTrendCard(trendValue = trendValue, delta = monthTrendDelta)
             }
 
             if (canStartNewDay) {
@@ -648,36 +648,67 @@ private fun Long.toWaitedLabel(): String {
 @Composable
 private fun HomeTrendCard(
     trendValue: Int,
+    delta: Int?,
 ) {
+    // trendValue is the reduction vs last month: positive = smoking less (good),
+    // negative = smoking more (bad). Colour and copy follow that, not a fixed green.
+    val improving = trendValue > 0
+    val worsening = trendValue < 0
+    val gradient = when {
+        improving -> "linear-gradient(135deg,var(--sa-color-primary) 0%, #2D5D63 100%)"
+        worsening -> "linear-gradient(135deg,#C0413B 0%, #8E2B27 100%)"
+        else -> "linear-gradient(135deg,#5A6568 0%, #3E484B 100%)"
+    }
+    val headline = when {
+        improving -> "Smoking less than last month"
+        worsening -> "Smoking more than last month"
+        else -> "Same pace as last month"
+    }
+    val deltaLabel = delta?.let {
+        when {
+            it < 0 -> "${-it} fewer ${pluralCigarettes(-it)} so far"
+            it > 0 -> "$it more ${pluralCigarettes(it)} so far"
+            else -> "Same count so far"
+        }
+    }
+    val glyph = if (improving) "↘" else if (worsening) "↗" else "→"
+
     SurfaceCard {
         Div(attrs = {
             attr(
                 "style",
-                "display:flex;justify-content:space-between;align-items:center;gap:18px;background:linear-gradient(135deg,var(--sa-color-primary) 0%, #2D5D63 100%);border-radius:24px;padding:24px;color:var(--sa-color-onPrimary);"
+                "display:flex;justify-content:space-between;align-items:center;gap:18px;background:$gradient;border-radius:24px;padding:24px;color:#FFFFFF;"
             )
         }) {
             Div {
                 Div(attrs = { attr("style", "font-size:11px;font-weight:700;letter-spacing:0.18em;text-transform:uppercase;opacity:0.76;") }) {
-                    Text("Trend")
+                    Text("Vs last month")
                 }
-                Div(attrs = { attr("style", "font-size:56px;font-weight:800;line-height:1;margin-top:10px;") }) {
-                    Text("${if (trendValue > 0) "+" else ""}$trendValue%")
+                Div(attrs = { attr("style", "font-size:26px;font-weight:800;line-height:1.1;margin-top:10px;max-width:320px;") }) {
+                    Text(headline)
                 }
-                Div(attrs = { attr("style", "font-size:14px;opacity:0.78;max-width:240px;") }) {
-                    Text("Reduction vs last month")
+                deltaLabel?.let {
+                    Div(attrs = { attr("style", "font-size:14px;opacity:0.82;margin-top:8px;") }) {
+                        Text(it)
+                    }
                 }
             }
             Div(attrs = {
                 attr(
                     "style",
-                    "width:84px;height:84px;border-radius:999px;border:8px solid rgba(255,255,255,0.22);display:flex;align-items:center;justify-content:center;font-size:30px;font-weight:800;"
+                    "width:84px;height:84px;border-radius:999px;border:8px solid rgba(255,255,255,0.22);display:flex;flex-direction:column;align-items:center;justify-content:center;flex-shrink:0;"
                 )
             }) {
-                Text(if (trendValue >= 0) "↘" else "↗")
+                Div(attrs = { attr("style", "font-size:26px;font-weight:800;line-height:1;") }) { Text(glyph) }
+                Div(attrs = { attr("style", "font-size:14px;font-weight:700;") }) {
+                    Text("${if (trendValue > 0) "+" else ""}$trendValue%")
+                }
             }
         }
     }
 }
+
+private fun pluralCigarettes(count: Int): String = if (count == 1) "cigarette" else "cigarettes"
 
 @Composable
 private fun EveningResetCard(

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/RelationshipComponentsWeb.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/RelationshipComponentsWeb.kt
@@ -7,28 +7,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import com.feragusper.smokeanalytics.libraries.design.SmokeWebStyles
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeTrigger
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.TriggerOption
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.normalizedTag
 import org.jetbrains.compose.web.attributes.InputType
-import org.jetbrains.compose.web.attributes.disabled
 import org.jetbrains.compose.web.dom.Button
 import org.jetbrains.compose.web.dom.Div
 import org.jetbrains.compose.web.dom.H3
 import org.jetbrains.compose.web.dom.Input
 import org.jetbrains.compose.web.dom.P
 import org.jetbrains.compose.web.dom.Text
-
-/** Human-readable label for a trigger chip. */
-internal fun SmokeTrigger.label(): String = when (this) {
-    SmokeTrigger.COFFEE -> "Coffee"
-    SmokeTrigger.ALCOHOL -> "Alcohol"
-    SmokeTrigger.BOREDOM -> "Boredom"
-    SmokeTrigger.ANXIETY -> "Anxiety"
-    SmokeTrigger.STRESS -> "Stress"
-    SmokeTrigger.AFTER_MEAL -> "After a meal"
-    SmokeTrigger.SOCIAL -> "Social"
-    SmokeTrigger.BREAK -> "Break"
-    SmokeTrigger.DRIVING -> "Driving"
-    SmokeTrigger.PHONE -> "Phone"
-}
 
 /**
  * Home card reminding the user that some smokes (logged from the watch, or whose prompt
@@ -60,12 +47,16 @@ internal fun RelationshipReminderCardWeb(
  */
 @Composable
 internal fun RelationshipPromptDialogWeb(
-    onSave: (triggers: Set<SmokeTrigger>, note: String?) -> Unit,
+    availableTriggers: List<TriggerOption>,
+    onSave: (tags: Set<String>) -> Unit,
     onSkip: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    var selected by remember { mutableStateOf(emptySet<SmokeTrigger>()) }
-    var note by remember { mutableStateOf("") }
+    val options = remember(availableTriggers) {
+        if (availableTriggers.isEmpty()) SmokeTrigger.defaultOptions() else availableTriggers
+    }
+    var selectedKeys by remember { mutableStateOf(emptySet<String>()) }
+    var draft by remember { mutableStateOf("") }
 
     Div(
         attrs = {
@@ -106,12 +97,12 @@ internal fun RelationshipPromptDialogWeb(
                     }
                 }
             ) {
-                SmokeTrigger.entries.forEach { trigger ->
-                    val isSelected = trigger in selected
+                options.forEach { option ->
+                    val isSelected = option.key in selectedKeys
                     Button(
                         attrs = {
                             onClick {
-                                selected = if (isSelected) selected - trigger else selected + trigger
+                                selectedKeys = if (isSelected) selectedKeys - option.key else selectedKeys + option.key
                             }
                             style {
                                 property("border-radius", "999px")
@@ -127,16 +118,16 @@ internal fun RelationshipPromptDialogWeb(
                                 }
                             }
                         }
-                    ) { Text(trigger.label()) }
+                    ) { Text(option.label) }
                 }
             }
 
             Input(
                 type = InputType.Text,
                 attrs = {
-                    value(note)
-                    onInput { note = it.value }
-                    attr("placeholder", "Other (add your own…)")
+                    value(draft)
+                    onInput { draft = it.value }
+                    attr("placeholder", "Add a tag…")
                     style {
                         property("width", "100%")
                         property("box-sizing", "border-box")
@@ -158,10 +149,9 @@ internal fun RelationshipPromptDialogWeb(
                 Button(attrs = { onClick { onSkip() } }) { Text("No relation") }
                 Button(
                     attrs = {
-                        val enabled = selected.isNotEmpty() || note.isNotBlank()
-                        if (!enabled) disabled()
                         onClick {
-                            onSave(selected, note.trim().takeIf { it.isNotEmpty() })
+                            val tags = selectedKeys + listOfNotNull(draft.normalizedTag())
+                            if (tags.isNotEmpty()) onSave(tags)
                         }
                     }
                 ) { Text("Save") }

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/RelationshipComponentsWeb.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/RelationshipComponentsWeb.kt
@@ -1,0 +1,171 @@
+package com.feragusper.smokeanalytics.features.home.presentation.web
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.feragusper.smokeanalytics.libraries.design.SmokeWebStyles
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeTrigger
+import org.jetbrains.compose.web.attributes.InputType
+import org.jetbrains.compose.web.attributes.disabled
+import org.jetbrains.compose.web.dom.Button
+import org.jetbrains.compose.web.dom.Div
+import org.jetbrains.compose.web.dom.H3
+import org.jetbrains.compose.web.dom.Input
+import org.jetbrains.compose.web.dom.P
+import org.jetbrains.compose.web.dom.Text
+
+/** Human-readable label for a trigger chip. */
+internal fun SmokeTrigger.label(): String = when (this) {
+    SmokeTrigger.COFFEE -> "Coffee"
+    SmokeTrigger.ALCOHOL -> "Alcohol"
+    SmokeTrigger.BOREDOM -> "Boredom"
+    SmokeTrigger.ANXIETY -> "Anxiety"
+    SmokeTrigger.STRESS -> "Stress"
+    SmokeTrigger.AFTER_MEAL -> "After a meal"
+    SmokeTrigger.SOCIAL -> "Social"
+    SmokeTrigger.BREAK -> "Break"
+    SmokeTrigger.DRIVING -> "Driving"
+    SmokeTrigger.PHONE -> "Phone"
+}
+
+/**
+ * Home card reminding the user that some smokes (logged from the watch, or whose prompt
+ * was dismissed) still have no trigger. Tapping the CTA opens the prompt for the next one.
+ */
+@Composable
+internal fun RelationshipReminderCardWeb(
+    pendingCount: Int,
+    onAdd: () -> Unit,
+) {
+    Div(attrs = { classes(SmokeWebStyles.card) }) {
+        H3 { Text("What were these about?") }
+        P {
+            Text(
+                if (pendingCount == 1) {
+                    "1 cigarette still needs a trigger"
+                } else {
+                    "$pendingCount cigarettes still need a trigger"
+                }
+            )
+        }
+        Button(attrs = { onClick { onAdd() } }) { Text("Add trigger") }
+    }
+}
+
+/**
+ * Modal asking what a smoke was related to: multi-select chips plus an "Other" free-text
+ * field. The user can save, declare "no relation", or dismiss (the smoke stays untracked).
+ */
+@Composable
+internal fun RelationshipPromptDialogWeb(
+    onSave: (triggers: Set<SmokeTrigger>, note: String?) -> Unit,
+    onSkip: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var selected by remember { mutableStateOf(emptySet<SmokeTrigger>()) }
+    var note by remember { mutableStateOf("") }
+
+    Div(
+        attrs = {
+            style {
+                property("position", "fixed")
+                property("inset", "0")
+                property("background", "rgba(0,0,0,0.4)")
+                property("display", "flex")
+                property("align-items", "center")
+                property("justify-content", "center")
+                property("z-index", "9999")
+            }
+            onClick { onDismiss() }
+        }
+    ) {
+        Div(
+            attrs = {
+                style {
+                    property("background", "white")
+                    property("padding", "20px")
+                    property("border-radius", "12px")
+                    property("min-width", "320px")
+                    property("max-width", "90vw")
+                }
+                onClick { it.stopPropagation() }
+            }
+        ) {
+            H3 { Text("What was it related to?") }
+            P { Text("Tag what triggered this cigarette, or skip if it was nothing in particular.") }
+
+            Div(
+                attrs = {
+                    style {
+                        property("display", "flex")
+                        property("flex-wrap", "wrap")
+                        property("gap", "8px")
+                        property("margin", "12px 0")
+                    }
+                }
+            ) {
+                SmokeTrigger.entries.forEach { trigger ->
+                    val isSelected = trigger in selected
+                    Button(
+                        attrs = {
+                            onClick {
+                                selected = if (isSelected) selected - trigger else selected + trigger
+                            }
+                            style {
+                                property("border-radius", "999px")
+                                property("padding", "6px 14px")
+                                property("cursor", "pointer")
+                                property("border", "1px solid #006A6A")
+                                if (isSelected) {
+                                    property("background", "#006A6A")
+                                    property("color", "white")
+                                } else {
+                                    property("background", "transparent")
+                                    property("color", "#006A6A")
+                                }
+                            }
+                        }
+                    ) { Text(trigger.label()) }
+                }
+            }
+
+            Input(
+                type = InputType.Text,
+                attrs = {
+                    value(note)
+                    onInput { note = it.value }
+                    attr("placeholder", "Other (add your own…)")
+                    style {
+                        property("width", "100%")
+                        property("box-sizing", "border-box")
+                        property("padding", "8px")
+                    }
+                }
+            )
+
+            Div(
+                attrs = {
+                    style {
+                        property("display", "flex")
+                        property("gap", "8px")
+                        property("margin-top", "16px")
+                        property("justify-content", "flex-end")
+                    }
+                }
+            ) {
+                Button(attrs = { onClick { onSkip() } }) { Text("No relation") }
+                Button(
+                    attrs = {
+                        val enabled = selected.isNotEmpty() || note.isNotBlank()
+                        if (!enabled) disabled()
+                        onClick {
+                            onSave(selected, note.trim().takeIf { it.isNotEmpty() })
+                        }
+                    }
+                ) { Text("Save") }
+            }
+        }
+    }
+}

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeIntent.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeIntent.kt
@@ -2,7 +2,6 @@ package com.feragusper.smokeanalytics.features.home.presentation.web.mvi
 
 import com.feragusper.smokeanalytics.libraries.cravings.domain.model.Craving
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
-import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeTrigger
 import kotlinx.datetime.Instant
 
 /**
@@ -92,8 +91,7 @@ sealed interface HomeIntent {
      */
     data class SaveSmokeRelationship(
         val smokeId: String,
-        val triggers: Set<SmokeTrigger>,
-        val note: String?,
+        val tags: Set<String>,
     ) : HomeIntent
 
     /**

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeIntent.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeIntent.kt
@@ -2,6 +2,7 @@ package com.feragusper.smokeanalytics.features.home.presentation.web.mvi
 
 import com.feragusper.smokeanalytics.libraries.cravings.domain.model.Craving
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeTrigger
 import kotlinx.datetime.Instant
 
 /**
@@ -80,4 +81,28 @@ sealed interface HomeIntent {
      * Dismisses the craving celebration.
      */
     data object DismissCravingCelebration : HomeIntent
+
+    /**
+     * Opens the "what was it related to?" prompt for an untracked smoke.
+     */
+    data class OpenRelationshipPrompt(val smokeId: String) : HomeIntent
+
+    /**
+     * Saves the triggers attached to a smoke. [note] holds the free-text "Other".
+     */
+    data class SaveSmokeRelationship(
+        val smokeId: String,
+        val triggers: Set<SmokeTrigger>,
+        val note: String?,
+    ) : HomeIntent
+
+    /**
+     * Marks a smoke as having no particular trigger so it stops appearing in the reminder.
+     */
+    data class SkipSmokeRelationship(val smokeId: String) : HomeIntent
+
+    /**
+     * Closes the relationship prompt without answering; the smoke stays untracked.
+     */
+    data object DismissRelationshipPrompt : HomeIntent
 }

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeResult.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeResult.kt
@@ -27,7 +27,11 @@ sealed interface HomeResult {
 
     data object GoToGoals : HomeResult
 
-    data object AddSmokeSuccess : HomeResult
+    data class AddSmokeSuccess(val smokeId: String) : HomeResult
+
+    data object RelationshipUpdated : HomeResult
+
+    data object RelationshipPromptDismissed : HomeResult
 
     data object StartNewDaySuccess : HomeResult
 
@@ -53,6 +57,7 @@ sealed interface HomeResult {
         val previousMonthCount: Int = 0,
         val activeCraving: Craving? = null,
         val cravingStats: CravingStats = CravingStats(),
+        val pendingRelationshipSmokes: List<Smoke> = emptyList(),
     ) : HomeResult
 
     data object FetchSmokesError : HomeResult

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeResult.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeResult.kt
@@ -12,6 +12,7 @@ import com.feragusper.smokeanalytics.libraries.cravings.domain.model.CravingOutc
 import com.feragusper.smokeanalytics.libraries.cravings.domain.model.CravingStats
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.TriggerOption
 
 sealed interface HomeResult {
 
@@ -58,6 +59,7 @@ sealed interface HomeResult {
         val activeCraving: Craving? = null,
         val cravingStats: CravingStats = CravingStats(),
         val pendingRelationshipSmokes: List<Smoke> = emptyList(),
+        val availableTriggers: List<TriggerOption> = emptyList(),
     ) : HomeResult
 
     data object FetchSmokesError : HomeResult

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeWebStore.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeWebStore.kt
@@ -123,6 +123,7 @@ class HomeWebStore(
                 activeCraving = result.activeCraving,
                 cravingStats = result.cravingStats,
                 pendingRelationshipSmokes = result.pendingRelationshipSmokes,
+                availableTriggers = result.availableTriggers,
             )
 
             is HomeResult.CravingTracked -> previous.copy(

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeWebStore.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeWebStore.kt
@@ -110,6 +110,11 @@ class HomeWebStore(
                 } else {
                     null
                 },
+                monthTrendDelta = if (result.previousMonthCount > 0) {
+                    result.smokeCountListResult.countByMonth - result.previousMonthCount
+                } else {
+                    null
+                },
                 locationTrackingAvailability = result.locationTrackingAvailability,
                 elapsedTone = elapsedToneFrom(
                     result.smokeCountListResult.timeSinceLastCigarette.first,

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeWebStore.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeWebStore.kt
@@ -122,6 +122,7 @@ class HomeWebStore(
                 ),
                 activeCraving = result.activeCraving,
                 cravingStats = result.cravingStats,
+                pendingRelationshipSmokes = result.pendingRelationshipSmokes,
             )
 
             is HomeResult.CravingTracked -> previous.copy(
@@ -161,13 +162,24 @@ class HomeWebStore(
                 ),
             )
 
-            HomeResult.AddSmokeSuccess,
             HomeResult.StartNewDaySuccess,
             HomeResult.EditSmokeSuccess,
             HomeResult.DeleteSmokeSuccess -> {
                 send(HomeIntent.FetchSmokes)
                 previous
             }
+
+            is HomeResult.AddSmokeSuccess -> {
+                send(HomeIntent.FetchSmokes)
+                previous.copy(relationshipPromptSmokeId = result.smokeId)
+            }
+
+            HomeResult.RelationshipUpdated -> {
+                send(HomeIntent.FetchSmokes)
+                previous.copy(relationshipPromptSmokeId = null)
+            }
+
+            HomeResult.RelationshipPromptDismissed -> previous.copy(relationshipPromptSmokeId = null)
 
             is HomeResult.Error -> previous.copy(
                 displayLoading = false,

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/process/HomeProcessHolder.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/process/HomeProcessHolder.kt
@@ -25,10 +25,12 @@ import com.feragusper.smokeanalytics.libraries.preferences.domain.FetchUserPrefe
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UpdateUserPreferencesUseCase
 import com.feragusper.smokeanalytics.libraries.logging.AppLogger
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeRelationship
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.AddSmokeUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.DeleteSmokeUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.EditSmokeUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.FetchSmokesUseCase
+import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.SetSmokeRelationshipUseCase
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -40,6 +42,7 @@ import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.minus
 import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
 
 /**
  * Represents the process holder for the Home screen.
@@ -54,6 +57,7 @@ class HomeProcessHolder(
     private val addSmokeUseCase: AddSmokeUseCase,
     private val editSmokeUseCase: EditSmokeUseCase,
     private val deleteSmokeUseCase: DeleteSmokeUseCase,
+    private val setSmokeRelationshipUseCase: SetSmokeRelationshipUseCase,
     private val fetchSmokeCountListUseCase: FetchSmokeCountListUseCase,
     private val fetchSmokesUseCase: FetchSmokesUseCase,
     private val fetchSessionUseCase: FetchSessionUseCase,
@@ -95,7 +99,24 @@ class HomeProcessHolder(
         is HomeIntent.ResolveCraving -> processResolveCraving(intent)
         HomeIntent.DismissCravingHint -> flow { emit(HomeResult.CravingHintDismissed) }
         HomeIntent.DismissCravingCelebration -> flow { emit(HomeResult.CravingCelebrationDismissed) }
+        is HomeIntent.OpenRelationshipPrompt -> flow { emit(HomeResult.AddSmokeSuccess(intent.smokeId)) }
+        is HomeIntent.SaveSmokeRelationship -> processSaveRelationship(intent)
+        is HomeIntent.SkipSmokeRelationship -> processSkipRelationship(intent)
+        HomeIntent.DismissRelationshipPrompt -> flow { emit(HomeResult.RelationshipPromptDismissed) }
     }
+
+    private fun processSaveRelationship(intent: HomeIntent.SaveSmokeRelationship): Flow<HomeResult> = flow<HomeResult> {
+        setSmokeRelationshipUseCase(
+            id = intent.smokeId,
+            relationship = SmokeRelationship.Tagged(triggers = intent.triggers, note = intent.note),
+        )
+        emit(HomeResult.RelationshipUpdated)
+    }.catch { emit(HomeResult.Error.Generic) }
+
+    private fun processSkipRelationship(intent: HomeIntent.SkipSmokeRelationship): Flow<HomeResult> = flow<HomeResult> {
+        setSmokeRelationshipUseCase(id = intent.smokeId, relationship = SmokeRelationship.Skipped)
+        emit(HomeResult.RelationshipUpdated)
+    }.catch { emit(HomeResult.Error.Generic) }
 
     private fun processFetchSmokes(isRefresh: Boolean): Flow<HomeResult> = flow {
         repeat(5) { attempt ->
@@ -122,6 +143,10 @@ class HomeProcessHolder(
                         manualDayStartEpochMillis = preferences.manualDayStartEpochMillis,
                     )
                     val goalSmokes = fetchSmokesUseCase(start = goalDataFetchStart(preferences))
+                    val pendingRelationshipSmokes = fetchSmokesUseCase(
+                        start = Clock.System.now().minus(RELATIONSHIP_LOOKBACK_DAYS.days),
+                        end = Clock.System.now(),
+                    ).filter { it.relationship.isPending }
                     val activeCraving = fetchActiveCravingUseCase()
                     val cravingStats = fetchCravingsUseCase(start = goalDataFetchStart(preferences)).toCravingStats()
                     val timeZone = TimeZone.currentSystemDefault()
@@ -180,6 +205,7 @@ class HomeProcessHolder(
                             previousMonthCount = previousMonthCount,
                             activeCraving = activeCraving,
                             cravingStats = cravingStats,
+                            pendingRelationshipSmokes = pendingRelationshipSmokes,
                         )
                     )
                     return@flow
@@ -214,9 +240,9 @@ class HomeProcessHolder(
                 } else {
                     null
                 }
-                addSmokeUseCase(location = location)
+                val smokeId = addSmokeUseCase(location = location)
                 AppLogger.i { "Smoke added successfully" }
-                emit(HomeResult.AddSmokeSuccess)
+                emit(HomeResult.AddSmokeSuccess(smokeId))
             }
         }
     }.catch { e ->
@@ -300,6 +326,12 @@ class HomeProcessHolder(
         emit(HomeResult.DeleteSmokeSuccess)
     }.catch {
         emit(HomeResult.Error.Generic)
+    }
+
+    private companion object {
+        // Firestore can't query "field absent", so the pending list is computed in memory
+        // over this lookback window.
+        const val RELATIONSHIP_LOOKBACK_DAYS = 30
     }
 }
 

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/process/HomeProcessHolder.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/process/HomeProcessHolder.kt
@@ -26,6 +26,7 @@ import com.feragusper.smokeanalytics.libraries.preferences.domain.UpdateUserPref
 import com.feragusper.smokeanalytics.libraries.logging.AppLogger
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeRelationship
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeTrigger
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.AddSmokeUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.DeleteSmokeUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.EditSmokeUseCase
@@ -108,7 +109,7 @@ class HomeProcessHolder(
     private fun processSaveRelationship(intent: HomeIntent.SaveSmokeRelationship): Flow<HomeResult> = flow<HomeResult> {
         setSmokeRelationshipUseCase(
             id = intent.smokeId,
-            relationship = SmokeRelationship.Tagged(triggers = intent.triggers, note = intent.note),
+            relationship = SmokeRelationship.Tagged(tags = intent.tags),
         )
         emit(HomeResult.RelationshipUpdated)
     }.catch { emit(HomeResult.Error.Generic) }
@@ -206,6 +207,10 @@ class HomeProcessHolder(
                             activeCraving = activeCraving,
                             cravingStats = cravingStats,
                             pendingRelationshipSmokes = pendingRelationshipSmokes,
+                            availableTriggers = SmokeTrigger.catalog(
+                                customTriggers = preferences.customTriggers,
+                                hiddenDefaultKeys = preferences.hiddenDefaultTriggers,
+                            ),
                         )
                     )
                     return@flow

--- a/features/settings/presentation/mobile/build.gradle.kts
+++ b/features/settings/presentation/mobile/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation(project(":libraries:authentication:data:mobile"))
     implementation(project(":libraries:architecture:domain"))
     implementation(project(":libraries:preferences:domain"))
+    implementation(project(":libraries:smokes:domain"))
 
     // Core AndroidX libraries and Compose dependencies
     implementation(libs.bundles.androidx.base)

--- a/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/mvi/compose/SettingsViewState.kt
+++ b/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/mvi/compose/SettingsViewState.kt
@@ -65,6 +65,8 @@ import com.feragusper.smokeanalytics.libraries.design.compose.CombinedPreviews
 import com.feragusper.smokeanalytics.libraries.design.compose.theme.SmokeAnalyticsTheme
 import com.feragusper.smokeanalytics.libraries.preferences.domain.AccountTier
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeTrigger
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.normalizedTag
 import com.valentinilk.shimmer.shimmer
 
 data class SettingsViewState(
@@ -149,6 +151,24 @@ data class SettingsViewState(
                 onSave = { updated -> intent(SettingsIntent.UpdatePreferences(updated)) },
                 onReset = { draftPreferences = preferences },
             )
+
+            if (currentEmail != null) {
+                SettingsSectionHeader(title = "Triggers")
+
+                SettingsCard(
+                    title = "Manage triggers",
+                    subtitle = "Choose which built-in triggers appear when you tag a cigarette, and add your own.",
+                ) {
+                    ManageTriggersSection(
+                        preferences = draftPreferences,
+                        enabled = !displayLoading,
+                        onChange = { updated ->
+                            draftPreferences = updated
+                            intent(SettingsIntent.UpdatePreferences(updated))
+                        },
+                    )
+                }
+            }
 
             SettingsSectionHeader(title = "App")
 
@@ -1113,6 +1133,85 @@ private fun SettingsPreview() {
             currentDisplayName = "Fernando Perez",
         ).Compose(
             intent = {},
+        )
+    }
+}
+
+@Composable
+private fun ManageTriggersSection(
+    preferences: UserPreferences,
+    enabled: Boolean,
+    onChange: (UserPreferences) -> Unit,
+) {
+    var draft by remember { mutableStateOf("") }
+
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        Text(
+            text = "Built-in",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        SmokeTrigger.defaultOptions().forEach { option ->
+            val visible = option.key !in preferences.hiddenDefaultTriggers
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(text = option.label, modifier = Modifier.weight(1f))
+                Switch(
+                    checked = visible,
+                    enabled = enabled,
+                    onCheckedChange = { checked ->
+                        val hidden = if (checked) {
+                            preferences.hiddenDefaultTriggers - option.key
+                        } else {
+                            preferences.hiddenDefaultTriggers + option.key
+                        }
+                        onChange(preferences.copy(hiddenDefaultTriggers = hidden))
+                    },
+                )
+            }
+        }
+
+        if (preferences.customTriggers.isNotEmpty()) {
+            Text(
+                text = "Your tags",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            preferences.customTriggers.forEach { tag ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(text = tag, modifier = Modifier.weight(1f))
+                    TextButton(
+                        onClick = { onChange(preferences.copy(customTriggers = preferences.customTriggers - tag)) },
+                        enabled = enabled,
+                    ) { Text("Remove") }
+                }
+            }
+        }
+
+        OutlinedTextField(
+            value = draft,
+            onValueChange = { draft = it },
+            modifier = Modifier.fillMaxWidth(),
+            label = { Text("Add a tag") },
+            singleLine = true,
+            enabled = enabled,
+            trailingIcon = {
+                draft.normalizedTag()?.let { key ->
+                    TextButton(onClick = {
+                        if (preferences.customTriggers.none { it.equals(key, ignoreCase = true) }) {
+                            onChange(preferences.copy(customTriggers = preferences.customTriggers + key))
+                        }
+                        draft = ""
+                    }) { Text("Add") }
+                }
+            },
         )
     }
 }

--- a/features/settings/presentation/web/build.gradle.kts
+++ b/features/settings/presentation/web/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
                 implementation(project(":libraries:authentication:domain"))
                 implementation(project(":libraries:authentication:presentation:web"))
                 implementation(project(":libraries:preferences:domain"))
+                implementation(project(":libraries:smokes:domain"))
 
                 implementation(compose.runtime)
                 implementation(compose.html.core)

--- a/features/settings/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/settings/presentation/web/SettingsWebScreen.kt
+++ b/features/settings/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/settings/presentation/web/SettingsWebScreen.kt
@@ -18,6 +18,8 @@ import com.feragusper.smokeanalytics.libraries.design.PrimaryButton
 import com.feragusper.smokeanalytics.libraries.design.SmokeWebStyles
 import com.feragusper.smokeanalytics.libraries.design.SurfaceCard
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeTrigger
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.normalizedTag
 import kotlinx.coroutines.launch
 import kotlin.math.abs
 import kotlin.math.roundToInt
@@ -140,6 +142,21 @@ private fun SettingsViewState.Render(
                     }
                 }
             }
+        }
+
+        if (currentEmail != null) {
+            SectionHeader(
+                title = "Triggers",
+                subtitle = "Choose which built-in triggers appear when tagging a cigarette, and add your own.",
+            )
+            ManageTriggersPanelWeb(
+                preferences = draftPreferences,
+                displayLoading = displayLoading,
+                onChange = { updated ->
+                    draftPreferences = updated
+                    onIntent(SettingsIntent.UpdatePreferences(preferences = updated))
+                },
+            )
         }
 
         SectionHeader(
@@ -621,4 +638,78 @@ private fun Double.asDecimalString(): String {
     val integerPart = scaled / 100
     val decimalPart = abs(scaled % 100).toString().padStart(2, '0')
     return "$integerPart.$decimalPart"
+}
+
+@Composable
+private fun ManageTriggersPanelWeb(
+    preferences: UserPreferences,
+    displayLoading: Boolean,
+    onChange: (UserPreferences) -> Unit,
+) {
+    var draft by remember { mutableStateOf("") }
+
+    SurfaceCard {
+        Div(attrs = { attr("style", "display:flex;flex-direction:column;gap:12px;") }) {
+            Div(attrs = { classes(SmokeWebStyles.helperText) }) { Text("Built-in") }
+            SmokeTrigger.defaultOptions().forEach { option ->
+                val visible = option.key !in preferences.hiddenDefaultTriggers
+                Div(attrs = { attr("style", "display:flex;align-items:center;justify-content:space-between;gap:8px;") }) {
+                    Span { Text(option.label) }
+                    GhostButton(
+                        text = if (visible) "Hide" else "Show",
+                        enabled = !displayLoading,
+                        onClick = {
+                            val hidden = if (visible) {
+                                preferences.hiddenDefaultTriggers + option.key
+                            } else {
+                                preferences.hiddenDefaultTriggers - option.key
+                            }
+                            onChange(preferences.copy(hiddenDefaultTriggers = hidden))
+                        },
+                    )
+                }
+            }
+
+            if (preferences.customTriggers.isNotEmpty()) {
+                Div(attrs = { classes(SmokeWebStyles.helperText) }) { Text("Your tags") }
+                preferences.customTriggers.forEach { tag ->
+                    Div(attrs = { attr("style", "display:flex;align-items:center;justify-content:space-between;gap:8px;") }) {
+                        Span { Text(tag) }
+                        GhostButton(
+                            text = "Remove",
+                            enabled = !displayLoading,
+                            onClick = { onChange(preferences.copy(customTriggers = preferences.customTriggers - tag)) },
+                        )
+                    }
+                }
+            }
+
+            Div(attrs = { attr("style", "display:flex;gap:8px;align-items:center;") }) {
+                Input(
+                    type = InputType.Text,
+                    attrs = {
+                        value(draft)
+                        onInput { draft = it.value }
+                        attr("placeholder", "Add a tag…")
+                        style {
+                            property("flex", "1")
+                            property("box-sizing", "border-box")
+                            property("padding", "8px")
+                        }
+                    },
+                )
+                PrimaryButton(
+                    text = "Add",
+                    enabled = !displayLoading && draft.normalizedTag() != null,
+                    onClick = {
+                        val key = draft.normalizedTag() ?: return@PrimaryButton
+                        if (preferences.customTriggers.none { it.equals(key, ignoreCase = true) }) {
+                            onChange(preferences.copy(customTriggers = preferences.customTriggers + key))
+                        }
+                        draft = ""
+                    },
+                )
+            }
+        }
+    }
 }

--- a/features/stats/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/stats/presentation/mvi/compose/StatsViewState.kt
+++ b/features/stats/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/stats/presentation/mvi/compose/StatsViewState.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.ui.draw.clip
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -300,6 +302,60 @@ data class StatsViewState(
                                 StatsPeriod.YEAR -> BarChart(stats.yearly)
                             }
                         }
+                    }
+
+                    TriggerBreakdownCard(stats = stats)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TriggerBreakdownCard(stats: SmokeStats) {
+    val breakdown = stats.triggerBreakdown
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(28.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = "By trigger",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            if (breakdown.isEmpty()) {
+                Text(
+                    text = "No tagged cigarettes in this period yet. Tag what each one was related to and the breakdown shows up here.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                val max = breakdown.first().count.coerceAtLeast(1)
+                breakdown.forEach { entry ->
+                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                        ) {
+                            Text(text = entry.label, style = MaterialTheme.typography.bodyMedium)
+                            Text(
+                                text = entry.count.toString(),
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.Bold,
+                            )
+                        }
+                        LinearProgressIndicator(
+                            progress = { entry.count.toFloat() / max },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(6.dp)
+                                .clip(RoundedCornerShape(999.dp)),
+                        )
                     }
                 }
             }

--- a/features/stats/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/stats/presentation/mvi/compose/StatsViewState.kt
+++ b/features/stats/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/stats/presentation/mvi/compose/StatsViewState.kt
@@ -371,6 +371,9 @@ private fun SummaryCards(
 ) {
     val averageSummary = averageSummaryFor(currentPeriod, stats, selectedDate)
     val locale = LocalLocale.current.platformLocale
+    // Only a single day shows a raw total; for week/month/year a big cumulative number
+    // (e.g. "1,000 cigarettes") is discouraging, so lead with the daily average instead.
+    val isDay = currentPeriod == StatsViewState.StatsPeriod.DAY
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -381,14 +384,13 @@ private fun SummaryCards(
         ) {
             SummaryCard(
                 modifier = Modifier.weight(1.6f),
-                title = "Total Frequency",
-                headline = when (currentPeriod) {
-                    StatsViewState.StatsPeriod.DAY -> stats.totalDay.toString()
-                    StatsViewState.StatsPeriod.WEEK -> stats.totalWeek.toString()
-                    StatsViewState.StatsPeriod.MONTH -> stats.totalMonth.toString()
-                    StatsViewState.StatsPeriod.YEAR -> stats.yearly.values.sum().toString()
+                title = if (isDay) "Total Frequency" else averageSummary.title,
+                headline = if (isDay) {
+                    stats.totalDay.toString()
+                } else {
+                    String.format(locale, "%.1f", averageSummary.value)
                 },
-                supporting = "Cigarettes",
+                supporting = if (isDay) "Cigarettes" else averageSummary.supporting,
                 meta = selectedDate.summaryMeta(currentPeriod),
                 prominent = true,
             )
@@ -396,14 +398,18 @@ private fun SummaryCards(
                 modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                SummaryCard(
-                    modifier = Modifier.fillMaxWidth(),
-                    title = averageSummary.title,
-                    headline = String.format(locale, "%.1f", averageSummary.value),
-                    supporting = averageSummary.supporting,
-                    highlighted = true,
-                    compact = true,
-                )
+                // On a single day, the daily average is its own metric; on longer ranges the
+                // average is already the headline above, so this slot only shows the peak.
+                if (isDay) {
+                    SummaryCard(
+                        modifier = Modifier.fillMaxWidth(),
+                        title = averageSummary.title,
+                        headline = String.format(locale, "%.1f", averageSummary.value),
+                        supporting = averageSummary.supporting,
+                        highlighted = true,
+                        compact = true,
+                    )
+                }
                 SummaryCard(
                     modifier = Modifier.fillMaxWidth(),
                     title = "Peak Window",

--- a/features/stats/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/stats/presentation/web/StatsWebScreen.kt
+++ b/features/stats/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/stats/presentation/web/StatsWebScreen.kt
@@ -27,6 +27,7 @@ import org.jetbrains.compose.web.attributes.InputType
 import org.jetbrains.compose.web.attributes.disabled
 import org.jetbrains.compose.web.dom.Canvas
 import org.jetbrains.compose.web.dom.Div
+import org.jetbrains.compose.web.dom.Span
 import org.jetbrains.compose.web.dom.Input
 import org.jetbrains.compose.web.dom.Text
 
@@ -289,6 +290,41 @@ private fun StatsWebContent(
                             title = "Year",
                             data = stats.yearly
                         )
+                    }
+                }
+
+                TriggerBreakdownCardWeb(stats = stats)
+            }
+        }
+    }
+}
+
+@Composable
+private fun TriggerBreakdownCardWeb(
+    stats: com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeStats,
+) {
+    SurfaceCard {
+        Div(attrs = { attr("style", "display:flex;flex-direction:column;gap:12px;") }) {
+            Div(attrs = { classes(SmokeWebStyles.chartHeader) }) { Text("By trigger") }
+            val breakdown = stats.triggerBreakdown
+            if (breakdown.isEmpty()) {
+                Div(attrs = { classes(SmokeWebStyles.helperText) }) {
+                    Text("No tagged cigarettes in this period yet. Tag what each one was related to and the breakdown shows up here.")
+                }
+            } else {
+                val max = breakdown.first().count.coerceAtLeast(1)
+                breakdown.forEach { entry ->
+                    Div(attrs = { attr("style", "display:flex;flex-direction:column;gap:4px;") }) {
+                        Div(attrs = { attr("style", "display:flex;justify-content:space-between;") }) {
+                            Span { Text(entry.label) }
+                            Span(attrs = { attr("style", "font-weight:700;") }) { Text(entry.count.toString()) }
+                        }
+                        Div(attrs = { attr("style", "height:6px;border-radius:999px;background:var(--sa-color-surfaceVariant);overflow:hidden;") }) {
+                            Div(attrs = {
+                                val pct = (entry.count * 100 / max)
+                                attr("style", "height:6px;width:$pct%;border-radius:999px;background:var(--sa-color-primary);")
+                            }) {}
+                        }
                     }
                 }
             }

--- a/features/stats/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/stats/presentation/web/StatsWebScreen.kt
+++ b/features/stats/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/stats/presentation/web/StatsWebScreen.kt
@@ -194,17 +194,21 @@ private fun StatsWebContent(
                 Div(attrs = {
                     attr("style", "display:grid;grid-template-columns:1.6fr 1fr;gap:16px;align-items:start;")
                 }) {
+                    val averageSummary = averageSummaryFor(currentPeriod, stats, selectedDate)
+                    // Only a single day shows a raw total; for week/month/year a big cumulative
+                    // number (e.g. "1000 cigarettes") is discouraging, so lead with the daily average.
+                    val isDay = currentPeriod == StatsPeriod.DAY
                     SurfaceCard {
                         Div(attrs = { attr("style", "display:flex;flex-direction:column;gap:12px;min-height:0;") }) {
                             Div(attrs = { attr("style", "font-size:11px;font-weight:700;letter-spacing:0.18em;text-transform:uppercase;color:var(--sa-color-secondary);") }) {
-                                Text("Total Frequency")
+                                Text(if (isDay) "Total Frequency" else averageSummary.title)
                             }
                             Div(attrs = { attr("style", "display:flex;align-items:flex-end;gap:10px;") }) {
                                 Div(attrs = { attr("style", "font-size:48px;font-weight:800;line-height:1;color:var(--sa-color-primary);") }) {
-                                    Text(currentPeriod.totalLabel(stats))
+                                    Text(if (isDay) currentPeriod.totalLabel(stats) else averageSummary.value.formatOneDecimal())
                                 }
                                 Div(attrs = { attr("style", "font-size:14px;color:var(--sa-color-secondary);margin-bottom:6px;") }) {
-                                    Text("Cigarettes")
+                                    Text(if (isDay) "Cigarettes" else averageSummary.supporting)
                                 }
                             }
                             Div(attrs = { attr("style", "font-size:12px;font-weight:700;text-transform:uppercase;color:#7A4A04;") }) {
@@ -213,22 +217,23 @@ private fun StatsWebContent(
                         }
                     }
 
-                    val averageSummary = averageSummaryFor(currentPeriod, stats, selectedDate)
                     Div(attrs = { attr("style", "display:grid;grid-template-rows:auto auto;gap:16px;align-content:start;") }) {
-                        SurfaceCard {
-                            Div(attrs = {
-                                attr("style", "display:flex;flex-direction:column;gap:12px;min-height:0;background:var(--sa-color-primary);border-radius:22px;padding:20px;color:var(--sa-color-onPrimary);")
-                            }) {
-                                Div {
-                                    Div(attrs = { attr("style", "font-size:11px;font-weight:700;letter-spacing:0.18em;text-transform:uppercase;opacity:0.8;") }) {
-                                        Text(averageSummary.title)
+                        if (isDay) {
+                            SurfaceCard {
+                                Div(attrs = {
+                                    attr("style", "display:flex;flex-direction:column;gap:12px;min-height:0;background:var(--sa-color-primary);border-radius:22px;padding:20px;color:var(--sa-color-onPrimary);")
+                                }) {
+                                    Div {
+                                        Div(attrs = { attr("style", "font-size:11px;font-weight:700;letter-spacing:0.18em;text-transform:uppercase;opacity:0.8;") }) {
+                                            Text(averageSummary.title)
+                                        }
+                                        Div(attrs = { attr("style", "font-size:40px;font-weight:800;line-height:1;margin-top:8px;") }) {
+                                            Text(averageSummary.value.formatOneDecimal())
+                                        }
                                     }
-                                    Div(attrs = { attr("style", "font-size:40px;font-weight:800;line-height:1;margin-top:8px;") }) {
-                                        Text(averageSummary.value.formatOneDecimal())
+                                    Div(attrs = { attr("style", "font-size:13px;opacity:0.75;") }) {
+                                        Text(averageSummary.supporting)
                                     }
-                                }
-                                Div(attrs = { attr("style", "font-size:13px;opacity:0.75;") }) {
-                                    Text(averageSummary.supporting)
                                 }
                             }
                         }

--- a/libraries/preferences/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesEntity.kt
+++ b/libraries/preferences/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesEntity.kt
@@ -15,6 +15,8 @@ data class UserPreferencesEntity(
     val accountTier: String = AccountTier.Free.name,
     val activeGoalType: String? = null,
     val activeGoalMetricValue: Double? = null,
+    val customTriggers: List<String> = emptyList(),
+    val hiddenDefaultTriggers: List<String> = emptyList(),
 ) {
     fun toDomain(): UserPreferences = UserPreferences(
         packPrice = packPrice,
@@ -29,6 +31,8 @@ data class UserPreferencesEntity(
             type = activeGoalType,
             metricValue = activeGoalMetricValue,
         ),
+        customTriggers = customTriggers,
+        hiddenDefaultTriggers = hiddenDefaultTriggers.toSet(),
     )
 
     companion object {
@@ -43,5 +47,7 @@ data class UserPreferencesEntity(
         const val ACCOUNT_TIER = "accountTier"
         const val ACTIVE_GOAL_TYPE = "activeGoalType"
         const val ACTIVE_GOAL_METRIC_VALUE = "activeGoalMetricValue"
+        const val CUSTOM_TRIGGERS = "customTriggers"
+        const val HIDDEN_DEFAULT_TRIGGERS = "hiddenDefaultTriggers"
     }
 }

--- a/libraries/preferences/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImpl.kt
+++ b/libraries/preferences/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImpl.kt
@@ -91,6 +91,8 @@ private fun UserPreferences.toFirestorePayload(): Map<String, Any?> =
         UserPreferencesEntity.ACCOUNT_TIER to accountTier.name,
         UserPreferencesEntity.ACTIVE_GOAL_TYPE to activeGoal?.type?.name,
         UserPreferencesEntity.ACTIVE_GOAL_METRIC_VALUE to activeGoal?.metricValue,
+        UserPreferencesEntity.CUSTOM_TRIGGERS to customTriggers,
+        UserPreferencesEntity.HIDDEN_DEFAULT_TRIGGERS to hiddenDefaultTriggers.toList(),
     )
 
 private fun DocumentSnapshot.toUserPreferencesEntity(): UserPreferencesEntity? {
@@ -122,8 +124,14 @@ private fun DocumentSnapshot.toUserPreferencesEntity(): UserPreferencesEntity? {
             UserPreferencesEntity.ACTIVE_GOAL_METRIC_VALUE,
             LegacyUserPreferencesFields.ACTIVE_GOAL_METRIC_VALUE,
         )?.toDouble(),
+        customTriggers = stringListOrNull(UserPreferencesEntity.CUSTOM_TRIGGERS).orEmpty(),
+        hiddenDefaultTriggers = stringListOrNull(UserPreferencesEntity.HIDDEN_DEFAULT_TRIGGERS).orEmpty(),
     )
 }
+
+@Suppress("UNCHECKED_CAST")
+private fun DocumentSnapshot.stringListOrNull(field: String): List<String>? =
+    runCatching { get(field) as? List<String> }.getOrNull()
 
 private object LegacyUserPreferencesFields {
     const val PACK_PRICE = "a"

--- a/libraries/preferences/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesEntity.kt
+++ b/libraries/preferences/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesEntity.kt
@@ -17,6 +17,8 @@ data class UserPreferencesEntity(
     val accountTier: String = AccountTier.Free.name,
     val activeGoalType: String? = null,
     val activeGoalMetricValue: Double? = null,
+    val customTriggers: List<String> = emptyList(),
+    val hiddenDefaultTriggers: List<String> = emptyList(),
 ) {
     fun toDomain(): UserPreferences = UserPreferences(
         packPrice = packPrice,
@@ -31,6 +33,8 @@ data class UserPreferencesEntity(
             type = activeGoalType,
             metricValue = activeGoalMetricValue,
         ),
+        customTriggers = customTriggers,
+        hiddenDefaultTriggers = hiddenDefaultTriggers.toSet(),
     )
 
     companion object {
@@ -45,5 +49,7 @@ data class UserPreferencesEntity(
         const val ACCOUNT_TIER = "accountTier"
         const val ACTIVE_GOAL_TYPE = "activeGoalType"
         const val ACTIVE_GOAL_METRIC_VALUE = "activeGoalMetricValue"
+        const val CUSTOM_TRIGGERS = "customTriggers"
+        const val HIDDEN_DEFAULT_TRIGGERS = "hiddenDefaultTriggers"
     }
 }

--- a/libraries/preferences/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImpl.kt
+++ b/libraries/preferences/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImpl.kt
@@ -32,6 +32,8 @@ class UserPreferencesRepositoryImpl(
                 accountTier = preferences.accountTier.name,
                 activeGoalType = preferences.activeGoal?.type?.name,
                 activeGoalMetricValue = preferences.activeGoal?.metricValue,
+                customTriggers = preferences.customTriggers,
+                hiddenDefaultTriggers = preferences.hiddenDefaultTriggers.toList(),
             )
         )
     }
@@ -56,6 +58,8 @@ private fun DocumentSnapshot.toUserPreferencesEntity(): UserPreferencesEntity? {
         accountTier = getOrNull<String>(UserPreferencesEntity.ACCOUNT_TIER) ?: "Free",
         activeGoalType = getOrNull<String>(UserPreferencesEntity.ACTIVE_GOAL_TYPE),
         activeGoalMetricValue = numberOrNull(UserPreferencesEntity.ACTIVE_GOAL_METRIC_VALUE)?.toDouble(),
+        customTriggers = getOrNull<List<String>>(UserPreferencesEntity.CUSTOM_TRIGGERS).orEmpty(),
+        hiddenDefaultTriggers = getOrNull<List<String>>(UserPreferencesEntity.HIDDEN_DEFAULT_TRIGGERS).orEmpty(),
     )
 }
 

--- a/libraries/preferences/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/domain/UserPreferences.kt
+++ b/libraries/preferences/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/domain/UserPreferences.kt
@@ -10,6 +10,10 @@ data class UserPreferences(
     val currencySymbol: String = "€",
     val accountTier: AccountTier = AccountTier.Free,
     val activeGoal: SmokingGoal? = null,
+    /** User-created trigger tags (labels), shown alongside the built-in defaults. */
+    val customTriggers: List<String> = emptyList(),
+    /** Built-in trigger keys the user hid from the prompt. */
+    val hiddenDefaultTriggers: Set<String> = emptySet(),
 ) {
     val cigarettePrice: Double
         get() = if (cigarettesPerPack > 0) packPrice / cigarettesPerPack else 0.0

--- a/libraries/smokes/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeEntity.kt
+++ b/libraries/smokes/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeEntity.kt
@@ -5,15 +5,28 @@ package com.feragusper.smokeanalytics.libraries.smokes.data
  *
  * Schema (Android + Web):
  *  - timestampMillis: Double (epoch millis)
+ *  - latitude / longitude: Double? (optional location)
+ *  - triggers: List<String>? (predefined [com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeTrigger] keys)
+ *  - triggerNote: String? (free-text "Other")
+ *  - relationshipSkipped: Boolean? (true when the user said "no relation")
+ *
+ * The relationship fields are all optional, so documents written before this feature
+ * (and smokes added from the watch) load as untracked.
  */
 data class SmokeEntity(
     val timestampMillis: Double = 0.0,
     val latitude: Double? = null,
     val longitude: Double? = null,
+    val triggers: List<String>? = null,
+    val triggerNote: String? = null,
+    val relationshipSkipped: Boolean? = null,
 ) {
     object Fields {
         const val TIMESTAMP_MILLIS = "timestampMillis"
         const val LATITUDE = "latitude"
         const val LONGITUDE = "longitude"
+        const val TRIGGERS = "triggers"
+        const val TRIGGER_NOTE = "triggerNote"
+        const val RELATIONSHIP_SKIPPED = "relationshipSkipped"
     }
 }

--- a/libraries/smokes/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImpl.kt
+++ b/libraries/smokes/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImpl.kt
@@ -17,7 +17,6 @@ import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeCount
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeRelationship
-import com.feragusper.smokeanalytics.libraries.smokes.domain.model.noteOrNull
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.skippedFlag
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.smokeRelationshipFromFields
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.triggerKeys
@@ -254,7 +253,8 @@ class SmokeRepositoryImpl constructor(
     private fun relationshipPayload(relationship: SmokeRelationship): Map<String, Any?> =
         mapOf(
             SmokeEntity.Fields.TRIGGERS to relationship.triggerKeys(),
-            SmokeEntity.Fields.TRIGGER_NOTE to relationship.noteOrNull(),
+            // Legacy free-text note is folded into tags now; clear it on write.
+            SmokeEntity.Fields.TRIGGER_NOTE to null,
             SmokeEntity.Fields.RELATIONSHIP_SKIPPED to relationship.skippedFlag(),
         )
 

--- a/libraries/smokes/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImpl.kt
+++ b/libraries/smokes/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImpl.kt
@@ -16,6 +16,11 @@ import com.feragusper.smokeanalytics.libraries.smokes.data.SmokeRepositoryImpl.F
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeCount
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeRelationship
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.noteOrNull
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.skippedFlag
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.smokeRelationshipFromFields
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.triggerKeys
 import com.feragusper.smokeanalytics.libraries.smokes.domain.repository.SmokeRepository
 import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.FirebaseAuth
@@ -24,6 +29,7 @@ import com.google.firebase.firestore.FirebaseFirestoreException
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.Query.Direction
+import com.google.firebase.firestore.SetOptions
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withTimeout
@@ -48,9 +54,17 @@ class SmokeRepositoryImpl constructor(
     // We deliberately do not await the server acknowledgement, so adding/editing/deleting
     // a smoke works with no connection instead of timing out.
 
-    override suspend fun addSmoke(date: Instant, location: GeoPoint?) {
+    override suspend fun addSmoke(date: Instant, location: GeoPoint?): String =
         runFirestoreCall("add smoke", smokesPath()) {
-            smokesQuery().document().set(smokePayload(date, location))
+            val document = smokesQuery().document()
+            document.set(smokePayload(date, location))
+            document.id
+        }
+
+    override suspend fun setSmokeRelationship(id: String, relationship: SmokeRelationship) {
+        runFirestoreCall("set smoke relationship", "${smokesPath()}/$id") {
+            // Merge so the timestamp/location written when the smoke was logged are preserved.
+            smokesQuery().document(id).set(relationshipPayload(relationship), SetOptions.merge())
         }
     }
 
@@ -96,6 +110,7 @@ class SmokeRepositoryImpl constructor(
                     date = record.instant,
                     timeElapsedSincePreviousSmoke = record.instant.timeAfter(previousInstant),
                     location = record.location,
+                    relationship = record.relationship,
                 )
             }
         }
@@ -215,6 +230,17 @@ class SmokeRepositoryImpl constructor(
             id = id,
             instant = instant,
             location = getGeoPoint(),
+            relationship = getRelationship(),
+        )
+    }
+
+    private fun DocumentSnapshot.getRelationship(): SmokeRelationship {
+        @Suppress("UNCHECKED_CAST")
+        val triggers = get(SmokeEntity.Fields.TRIGGERS) as? List<String>
+        return smokeRelationshipFromFields(
+            triggers = triggers,
+            note = getString(SmokeEntity.Fields.TRIGGER_NOTE),
+            skipped = getBoolean(SmokeEntity.Fields.RELATIONSHIP_SKIPPED),
         )
     }
 
@@ -223,6 +249,13 @@ class SmokeRepositoryImpl constructor(
             SmokeEntity.Fields.TIMESTAMP_MILLIS to date.toEpochMilliseconds().toDouble(),
             SmokeEntity.Fields.LATITUDE to location?.latitude,
             SmokeEntity.Fields.LONGITUDE to location?.longitude,
+        )
+
+    private fun relationshipPayload(relationship: SmokeRelationship): Map<String, Any?> =
+        mapOf(
+            SmokeEntity.Fields.TRIGGERS to relationship.triggerKeys(),
+            SmokeEntity.Fields.TRIGGER_NOTE to relationship.noteOrNull(),
+            SmokeEntity.Fields.RELATIONSHIP_SKIPPED to relationship.skippedFlag(),
         )
 
     private companion object {
@@ -238,6 +271,7 @@ class SmokeRepositoryImpl constructor(
         val id: String,
         val instant: Instant,
         val location: GeoPoint?,
+        val relationship: SmokeRelationship = SmokeRelationship.Untracked,
     )
 
     private object LegacySmokeFields {

--- a/libraries/smokes/data/mobile/src/test/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImplTest.kt
+++ b/libraries/smokes/data/mobile/src/test/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImplTest.kt
@@ -165,6 +165,7 @@ class SmokeRepositoryImplTest {
             val documentRef = mockk<DocumentReference>()
 
             every { collectionReference.document() } returns documentRef
+            every { documentRef.id } returns "generated"
             every { documentRef.path } returns "$USERS/$uid/$SMOKES/generated"
             every { documentRef.set(capture(smokePayloadSlot)) } answers {
                 mockk<Task<Void>>().apply {
@@ -334,6 +335,9 @@ class SmokeRepositoryImplTest {
                 every { getDouble("a") } returns legacyTimestampMillis
                 every { getDouble("b") } returns null
                 every { getDouble("c") } returns null
+                every { this@apply.get(SmokeEntity.Fields.TRIGGERS) } returns null
+                every { getString(SmokeEntity.Fields.TRIGGER_NOTE) } returns null
+                every { getBoolean(SmokeEntity.Fields.RELATIONSHIP_SKIPPED) } returns null
             }
         }
 

--- a/libraries/smokes/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeEntity.kt
+++ b/libraries/smokes/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeEntity.kt
@@ -6,12 +6,20 @@ import kotlinx.serialization.Serializable
  * Represents a smoke entity.
  *
  * @property timestampMillis The timestamp of the smoke.
+ * @property latitude Optional latitude where the smoke was logged.
+ * @property longitude Optional longitude where the smoke was logged.
+ * @property triggers Predefined [com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeTrigger] keys.
+ * @property triggerNote Free-text "Other" trigger.
+ * @property relationshipSkipped True when the user declared the smoke had no trigger.
  */
 @Serializable
 data class SmokeEntity(
     val timestampMillis: Double = 0.0,
     val latitude: Double? = null,
     val longitude: Double? = null,
+    val triggers: List<String>? = null,
+    val triggerNote: String? = null,
+    val relationshipSkipped: Boolean? = null,
 ) {
 
     /**
@@ -21,5 +29,8 @@ data class SmokeEntity(
         const val TIMESTAMP_MILLIS = "timestampMillis"
         const val LATITUDE = "latitude"
         const val LONGITUDE = "longitude"
+        const val TRIGGERS = "triggers"
+        const val TRIGGER_NOTE = "triggerNote"
+        const val RELATIONSHIP_SKIPPED = "relationshipSkipped"
     }
 }

--- a/libraries/smokes/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImpl.kt
+++ b/libraries/smokes/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImpl.kt
@@ -12,7 +12,6 @@ import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeCount
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeRelationship
-import com.feragusper.smokeanalytics.libraries.smokes.domain.model.noteOrNull
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.skippedFlag
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.smokeRelationshipFromFields
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.triggerKeys
@@ -75,7 +74,8 @@ class SmokeRepositoryImpl(
                 latitude = location?.latitude,
                 longitude = location?.longitude,
                 triggers = relationship.triggerKeys().ifEmpty { null },
-                triggerNote = relationship.noteOrNull(),
+                // Legacy free-text note is folded into tags now; clear it on write.
+                triggerNote = null,
                 relationshipSkipped = relationship.skippedFlag(),
             )
         )

--- a/libraries/smokes/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImpl.kt
+++ b/libraries/smokes/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImpl.kt
@@ -11,6 +11,11 @@ import com.feragusper.smokeanalytics.libraries.architecture.domain.timeAfter
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeCount
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeRelationship
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.noteOrNull
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.skippedFlag
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.smokeRelationshipFromFields
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.triggerKeys
 import com.feragusper.smokeanalytics.libraries.smokes.domain.repository.SmokeRepository
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.auth.FirebaseAuth
@@ -45,12 +50,33 @@ class SmokeRepositoryImpl(
     /**
      * @see SmokeRepository.addSmoke
      */
-    override suspend fun addSmoke(date: Instant, location: GeoPoint?) {
+    override suspend fun addSmoke(date: Instant, location: GeoPoint?): String =
         smokesCollection().add(
             SmokeEntity(
                 timestampMillis = date.toEpochMilliseconds().toDouble(),
                 latitude = location?.latitude,
                 longitude = location?.longitude,
+            )
+        ).id
+
+    /**
+     * @see SmokeRepository.setSmokeRelationship
+     */
+    override suspend fun setSmokeRelationship(id: String, relationship: SmokeRelationship) {
+        // Re-set the full entity, preserving timestamp/location (mirrors editSmoke) and
+        // overwriting only the relationship fields.
+        val document = smokesCollection().document(id)
+        val snapshot = document.get()
+        val timestampMillis = snapshot.getOrNull<Double>(SmokeEntity.Fields.TIMESTAMP_MILLIS) ?: return
+        val location = snapshot.getGeoPoint()
+        document.set(
+            SmokeEntity(
+                timestampMillis = timestampMillis,
+                latitude = location?.latitude,
+                longitude = location?.longitude,
+                triggers = relationship.triggerKeys().ifEmpty { null },
+                triggerNote = relationship.noteOrNull(),
+                relationshipSkipped = relationship.skippedFlag(),
             )
         )
     }
@@ -125,6 +151,7 @@ class SmokeRepositoryImpl(
                 date = currentInstant,
                 timeElapsedSincePreviousSmoke = currentInstant.timeAfter(previousInstant),
                 location = document.getGeoPoint(),
+                relationship = document.getRelationship(),
             )
         }
     }
@@ -180,6 +207,13 @@ class SmokeRepositoryImpl(
         val longitude = getOrNull<Double>(SmokeEntity.Fields.LONGITUDE) ?: return null
         return GeoPoint(latitude = latitude, longitude = longitude)
     }
+
+    private fun DocumentSnapshot.getRelationship(): SmokeRelationship =
+        smokeRelationshipFromFields(
+            triggers = getOrNull<List<String>>(SmokeEntity.Fields.TRIGGERS),
+            note = getOrNull<String>(SmokeEntity.Fields.TRIGGER_NOTE),
+            skipped = getOrNull<Boolean>(SmokeEntity.Fields.RELATIONSHIP_SKIPPED),
+        )
 
     private inline fun <reified T> DocumentSnapshot.getOrNull(field: String): T? =
         try {

--- a/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/di/SmokesDomainModule.kt
+++ b/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/di/SmokesDomainModule.kt
@@ -5,6 +5,7 @@ import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.DeleteSmoke
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.EditSmokeUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.FetchSmokeStatsUseCase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.FetchSmokesUseCase
+import com.feragusper.smokeanalytics.libraries.smokes.domain.usecase.SetSmokeRelationshipUseCase
 import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
 
@@ -14,6 +15,7 @@ val smokesDomainModule = module {
     factoryOf(::EditSmokeUseCase)
     factoryOf(::DeleteSmokeUseCase)
     factoryOf(::FetchSmokesUseCase)
+    factoryOf(::SetSmokeRelationshipUseCase)
     // Explicit factory (not factoryOf): the constructor DSL would try to resolve
     // the defaulted TimeZone parameter from the graph, which isn't provided.
     factory { FetchSmokeStatsUseCase(smokeRepository = get()) }

--- a/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/Smoke.kt
+++ b/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/Smoke.kt
@@ -8,10 +8,14 @@ import kotlinx.datetime.Instant
  * @property id The id of the smoke.
  * @property date The date of the smoke.
  * @property timeElapsedSincePreviousSmoke The time elapsed since the previous smoke.
+ * @property location Where the smoke was logged, if location tracking was on.
+ * @property relationship What the smoke was related to (coffee, boredom, ...). Defaults
+ *   to [SmokeRelationship.Untracked] so existing/watch smokes keep working unchanged.
  */
 data class Smoke(
     val id: String,
     val date: Instant,
     val timeElapsedSincePreviousSmoke: Pair<Long, Long> = 0L to 0L,
     val location: GeoPoint? = null,
+    val relationship: SmokeRelationship = SmokeRelationship.Untracked,
 )

--- a/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeRelationship.kt
+++ b/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeRelationship.kt
@@ -1,0 +1,30 @@
+package com.feragusper.smokeanalytics.libraries.smokes.domain.model
+
+/**
+ * What a smoke was related to.
+ *
+ * A smoke starts as [Untracked]: smokes logged from the watch, or smokes whose
+ * prompt the user dismissed, have no relationship yet and are surfaced in the
+ * home reminder card. The user can then either tag it ([Tagged]) or declare it
+ * had no particular trigger ([Skipped]); both states stop the reminder.
+ */
+sealed interface SmokeRelationship {
+
+    /** Never answered — shown in the home reminder card. */
+    data object Untracked : SmokeRelationship
+
+    /** The user explicitly said this smoke had no particular trigger. */
+    data object Skipped : SmokeRelationship
+
+    /**
+     * The user attached one or more triggers, and optionally a free-text [note]
+     * (the "Other" option).
+     */
+    data class Tagged(
+        val triggers: Set<SmokeTrigger> = emptySet(),
+        val note: String? = null,
+    ) : SmokeRelationship
+
+    /** True while the smoke still needs the user's attention in the reminder card. */
+    val isPending: Boolean get() = this is Untracked
+}

--- a/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeRelationship.kt
+++ b/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeRelationship.kt
@@ -17,12 +17,11 @@ sealed interface SmokeRelationship {
     data object Skipped : SmokeRelationship
 
     /**
-     * The user attached one or more triggers, and optionally a free-text [note]
-     * (the "Other" option).
+     * The user attached one or more tags. [tags] holds trigger keys — built-in
+     * [SmokeTrigger] keys and/or custom tag strings.
      */
     data class Tagged(
-        val triggers: Set<SmokeTrigger> = emptySet(),
-        val note: String? = null,
+        val tags: Set<String> = emptySet(),
     ) : SmokeRelationship
 
     /** True while the smoke still needs the user's attention in the reminder card. */

--- a/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeRelationshipMapping.kt
+++ b/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeRelationshipMapping.kt
@@ -1,0 +1,40 @@
+package com.feragusper.smokeanalytics.libraries.smokes.domain.model
+
+/**
+ * Shared encode/decode between the persisted Firestore fields and [SmokeRelationship],
+ * so the mobile and web data modules stay in sync.
+ *
+ * Persisted fields:
+ *  - triggers: list of [SmokeTrigger.key] values
+ *  - note: free-text "Other"
+ *  - skipped: true when the user declared no relation
+ *
+ * Precedence on read: skipped → tagged (any trigger or note) → untracked.
+ */
+fun smokeRelationshipFromFields(
+    triggers: List<String>?,
+    note: String?,
+    skipped: Boolean?,
+): SmokeRelationship {
+    if (skipped == true) return SmokeRelationship.Skipped
+    val parsedTriggers = triggers.orEmpty().mapNotNull(SmokeTrigger::fromKey).toSet()
+    val cleanNote = note?.trim()?.takeIf { it.isNotEmpty() }
+    return if (parsedTriggers.isNotEmpty() || cleanNote != null) {
+        SmokeRelationship.Tagged(triggers = parsedTriggers, note = cleanNote)
+    } else {
+        SmokeRelationship.Untracked
+    }
+}
+
+/** The persisted `triggers` value for this relationship (empty unless [SmokeRelationship.Tagged]). */
+fun SmokeRelationship.triggerKeys(): List<String> = when (this) {
+    is SmokeRelationship.Tagged -> triggers.map { it.key }
+    else -> emptyList()
+}
+
+/** The persisted `triggerNote` value for this relationship. */
+fun SmokeRelationship.noteOrNull(): String? = (this as? SmokeRelationship.Tagged)
+    ?.note?.trim()?.takeIf { it.isNotEmpty() }
+
+/** The persisted `relationshipSkipped` flag for this relationship. */
+fun SmokeRelationship.skippedFlag(): Boolean = this is SmokeRelationship.Skipped

--- a/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeRelationshipMapping.kt
+++ b/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeRelationshipMapping.kt
@@ -5,11 +5,11 @@ package com.feragusper.smokeanalytics.libraries.smokes.domain.model
  * so the mobile and web data modules stay in sync.
  *
  * Persisted fields:
- *  - triggers: list of [SmokeTrigger.key] values
- *  - note: free-text "Other"
+ *  - triggers: list of tag keys (built-in [SmokeTrigger.key] values and/or custom strings)
+ *  - note: legacy free-text "Other" (older docs); folded into the tag set on read
  *  - skipped: true when the user declared no relation
  *
- * Precedence on read: skipped → tagged (any trigger or note) → untracked.
+ * Precedence on read: skipped → tagged (any tag) → untracked.
  */
 fun smokeRelationshipFromFields(
     triggers: List<String>?,
@@ -17,24 +17,22 @@ fun smokeRelationshipFromFields(
     skipped: Boolean?,
 ): SmokeRelationship {
     if (skipped == true) return SmokeRelationship.Skipped
-    val parsedTriggers = triggers.orEmpty().mapNotNull(SmokeTrigger::fromKey).toSet()
-    val cleanNote = note?.trim()?.takeIf { it.isNotEmpty() }
-    return if (parsedTriggers.isNotEmpty() || cleanNote != null) {
-        SmokeRelationship.Tagged(triggers = parsedTriggers, note = cleanNote)
-    } else {
-        SmokeRelationship.Untracked
+    val tags = buildSet {
+        triggers.orEmpty().forEach { tag -> tag.normalizedTag()?.let(::add) }
+        // Legacy docs stored the "Other" free text separately; treat it as a tag.
+        note.normalizedTag()?.let(::add)
     }
+    return if (tags.isNotEmpty()) SmokeRelationship.Tagged(tags = tags) else SmokeRelationship.Untracked
 }
 
 /** The persisted `triggers` value for this relationship (empty unless [SmokeRelationship.Tagged]). */
 fun SmokeRelationship.triggerKeys(): List<String> = when (this) {
-    is SmokeRelationship.Tagged -> triggers.map { it.key }
+    is SmokeRelationship.Tagged -> tags.toList()
     else -> emptyList()
 }
 
-/** The persisted `triggerNote` value for this relationship. */
-fun SmokeRelationship.noteOrNull(): String? = (this as? SmokeRelationship.Tagged)
-    ?.note?.trim()?.takeIf { it.isNotEmpty() }
-
 /** The persisted `relationshipSkipped` flag for this relationship. */
 fun SmokeRelationship.skippedFlag(): Boolean = this is SmokeRelationship.Skipped
+
+/** Trims a tag and discards blanks; tags are stored as-is (keys for defaults, labels for custom). */
+fun String?.normalizedTag(): String? = this?.trim()?.takeIf { it.isNotEmpty() }

--- a/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeStats.kt
+++ b/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeStats.kt
@@ -22,8 +22,17 @@ data class SmokeStats(
     val totalMonth: Int,
     val totalWeek: Int,
     val totalDay: Int,
-    val dailyAverage: Float
+    val dailyAverage: Float,
+    /** Tag → count over the selected period, ranked by count desc. */
+    val triggerBreakdown: List<TriggerCount> = emptyList(),
 ) {
+    /** A trigger and how many cigarettes in the period were tagged with it. */
+    data class TriggerCount(
+        val key: String,
+        val label: String,
+        val count: Int,
+    )
+
     enum class SelectionPeriod {
         DAY,
         WEEK,
@@ -146,6 +155,18 @@ data class SmokeStats(
             val totalDay = daySmokes.size
             val dailyAverage = if (daysInMonth > 0) totalMonth.toFloat() / daysInMonth else 0f
 
+            // Trigger breakdown over the smokes in the requested range (the use case fetches
+            // exactly the selected period), ranked by frequency.
+            val tagCounts = mutableMapOf<String, Int>()
+            smokes.forEach { smoke ->
+                (smoke.relationship as? SmokeRelationship.Tagged)?.tags?.forEach { tag ->
+                    tagCounts[tag] = (tagCounts[tag] ?: 0) + 1
+                }
+            }
+            val triggerBreakdown = tagCounts.entries
+                .sortedByDescending { it.value }
+                .map { TriggerCount(key = it.key, label = SmokeTrigger.labelFor(it.key), count = it.value) }
+
             return SmokeStats(
                 daily = dailyStats,
                 weekly = weeklyStats,
@@ -155,7 +176,8 @@ data class SmokeStats(
                 totalMonth = totalMonth,
                 totalWeek = totalWeek,
                 totalDay = totalDay,
-                dailyAverage = dailyAverage
+                dailyAverage = dailyAverage,
+                triggerBreakdown = triggerBreakdown,
             )
         }
 

--- a/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeTrigger.kt
+++ b/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeTrigger.kt
@@ -1,0 +1,26 @@
+package com.feragusper.smokeanalytics.libraries.smokes.domain.model
+
+/**
+ * A predefined context/trigger a smoke can be related to (coffee, boredom, etc.).
+ *
+ * [key] is the stable string persisted in Firestore — never rename a key without a
+ * migration, because existing documents store these values. The display label is
+ * resolved in the presentation layer so it can be localized.
+ */
+enum class SmokeTrigger(val key: String) {
+    COFFEE("coffee"),
+    ALCOHOL("alcohol"),
+    BOREDOM("boredom"),
+    ANXIETY("anxiety"),
+    STRESS("stress"),
+    AFTER_MEAL("after_meal"),
+    SOCIAL("social"),
+    BREAK("break"),
+    DRIVING("driving"),
+    PHONE("phone");
+
+    companion object {
+        /** Resolves a persisted [key] back to a [SmokeTrigger], ignoring unknown values. */
+        fun fromKey(key: String): SmokeTrigger? = entries.firstOrNull { it.key == key }
+    }
+}

--- a/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeTrigger.kt
+++ b/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeTrigger.kt
@@ -1,26 +1,63 @@
 package com.feragusper.smokeanalytics.libraries.smokes.domain.model
 
 /**
- * A predefined context/trigger a smoke can be related to (coffee, boredom, etc.).
+ * The built-in seed catalog of smoke triggers. Tags are persisted and selected as plain
+ * string keys (see [SmokeRelationship.Tagged]); this enum only provides the default keys
+ * and their display labels, on top of which users add their own custom tags.
  *
- * [key] is the stable string persisted in Firestore — never rename a key without a
- * migration, because existing documents store these values. The display label is
- * resolved in the presentation layer so it can be localized.
+ * [key] is the stable string stored in Firestore — never rename a key without a migration.
  */
-enum class SmokeTrigger(val key: String) {
-    COFFEE("coffee"),
-    ALCOHOL("alcohol"),
-    BOREDOM("boredom"),
-    ANXIETY("anxiety"),
-    STRESS("stress"),
-    AFTER_MEAL("after_meal"),
-    SOCIAL("social"),
-    BREAK("break"),
-    DRIVING("driving"),
-    PHONE("phone");
+enum class SmokeTrigger(val key: String, val defaultLabel: String) {
+    COFFEE("coffee", "Coffee"),
+    ALCOHOL("alcohol", "Alcohol"),
+    BOREDOM("boredom", "Boredom"),
+    ANXIETY("anxiety", "Anxiety"),
+    STRESS("stress", "Stress"),
+    AFTER_MEAL("after_meal", "After a meal"),
+    SOCIAL("social", "Social"),
+    BREAK("break", "Break"),
+    DRIVING("driving", "Driving"),
+    PHONE("phone", "Phone");
 
     companion object {
-        /** Resolves a persisted [key] back to a [SmokeTrigger], ignoring unknown values. */
-        fun fromKey(key: String): SmokeTrigger? = entries.firstOrNull { it.key == key }
+        /** Default trigger options, in declaration order. */
+        fun defaultOptions(): List<TriggerOption> =
+            entries.map { TriggerOption(key = it.key, label = it.defaultLabel, isCustom = false) }
+
+        /** Display label for a persisted tag key: a default label if known, else the key itself. */
+        fun labelFor(key: String): String =
+            entries.firstOrNull { it.key == key }?.defaultLabel ?: key
+
+        /**
+         * The selectable trigger catalog: visible defaults (minus [hiddenDefaultKeys]) plus the
+         * user's [customTriggers]. Pure function so it can be built from preferences without
+         * coupling the preferences module to this one.
+         */
+        fun catalog(
+            customTriggers: List<String>,
+            hiddenDefaultKeys: Set<String> = emptySet(),
+        ): List<TriggerOption> {
+            val defaults = entries
+                .filter { it.key !in hiddenDefaultKeys }
+                .map { TriggerOption(key = it.key, label = it.defaultLabel, isCustom = false) }
+            val custom = customTriggers
+                .mapNotNull { it.trim().takeIf(String::isNotEmpty) }
+                .distinct()
+                .map { TriggerOption(key = it, label = it, isCustom = true) }
+            return defaults + custom
+        }
     }
 }
+
+/**
+ * A selectable trigger in the prompt / management catalog.
+ *
+ * @property key The persisted tag key (a [SmokeTrigger.key] for defaults, or the custom string).
+ * @property label Human-readable label.
+ * @property isCustom True for user-created tags (deletable), false for built-in defaults.
+ */
+data class TriggerOption(
+    val key: String,
+    val label: String,
+    val isCustom: Boolean,
+)

--- a/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/repository/SmokeRepository.kt
+++ b/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/repository/SmokeRepository.kt
@@ -3,6 +3,7 @@ package com.feragusper.smokeanalytics.libraries.smokes.domain.repository
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeCount
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeRelationship
 import kotlinx.datetime.Instant
 
 /**
@@ -14,8 +15,19 @@ interface SmokeRepository {
      * Adds a smoke.
      *
      * @param timestamp The timestamp of the smoke.
+     * @return The id of the newly created smoke, so callers can attach a relationship to it.
      */
-    suspend fun addSmoke(timestamp: Instant, location: GeoPoint? = null)
+    suspend fun addSmoke(timestamp: Instant, location: GeoPoint? = null): String
+
+    /**
+     * Sets (or clears) what a smoke was related to.
+     *
+     * Only the relationship fields are written; the timestamp and location are preserved.
+     *
+     * @param id The id of the smoke.
+     * @param relationship The relationship to persist.
+     */
+    suspend fun setSmokeRelationship(id: String, relationship: SmokeRelationship)
 
     /**
      * Fetches the smokes.

--- a/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/usecase/AddSmokeUseCase.kt
+++ b/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/usecase/AddSmokeUseCase.kt
@@ -10,10 +10,12 @@ class AddSmokeUseCase(
     private val smokeRepository: SmokeRepository,
 ) {
 
+    /**
+     * Logs a smoke and returns its id, so the caller can prompt for and attach a
+     * relationship to the freshly created smoke.
+     */
     suspend operator fun invoke(
         timestamp: Instant = Clock.System.now(),
         location: GeoPoint? = null,
-    ) {
-        smokeRepository.addSmoke(timestamp, location)
-    }
+    ): String = smokeRepository.addSmoke(timestamp, location)
 }

--- a/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/usecase/SetSmokeRelationshipUseCase.kt
+++ b/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/usecase/SetSmokeRelationshipUseCase.kt
@@ -1,0 +1,17 @@
+package com.feragusper.smokeanalytics.libraries.smokes.domain.usecase
+
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeRelationship
+import com.feragusper.smokeanalytics.libraries.smokes.domain.repository.SmokeRepository
+
+/**
+ * Sets what a smoke was related to — a set of triggers (optionally with an "Other"
+ * note), or [SmokeRelationship.Skipped] when the user declares it had no trigger.
+ */
+class SetSmokeRelationshipUseCase(
+    private val smokeRepository: SmokeRepository,
+) {
+
+    suspend operator fun invoke(id: String, relationship: SmokeRelationship) {
+        smokeRepository.setSmokeRelationship(id, relationship)
+    }
+}

--- a/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeRelationshipMappingTest.kt
+++ b/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeRelationshipMappingTest.kt
@@ -60,6 +60,19 @@ class SmokeRelationshipMappingTest {
     }
 
     @Test
+    fun `GIVEN relationships THEN only Untracked is pending`() {
+        assertEquals(true, SmokeRelationship.Untracked.isPending)
+        assertEquals(false, SmokeRelationship.Skipped.isPending)
+        assertEquals(false, SmokeRelationship.Tagged(setOf("coffee")).isPending)
+    }
+
+    @Test
+    fun `GIVEN a key THEN labelFor resolves defaults and passes through unknown`() {
+        assertEquals("Coffee", SmokeTrigger.labelFor("coffee"))
+        assertEquals("my custom tag", SmokeTrigger.labelFor("my custom tag"))
+    }
+
+    @Test
     fun `GIVEN the catalog with custom triggers THEN defaults and custom are combined`() {
         val catalog = SmokeTrigger.catalog(
             customTriggers = listOf("Gaming", "coffee"),

--- a/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeRelationshipMappingTest.kt
+++ b/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeRelationshipMappingTest.kt
@@ -30,39 +30,44 @@ class SmokeRelationshipMappingTest {
     }
 
     @Test
-    fun `GIVEN known triggers and note THEN it maps to Tagged ignoring unknown keys`() {
+    fun `GIVEN tags and a legacy note THEN all are folded into the tag set`() {
         val relationship = smokeRelationshipFromFields(
-            triggers = listOf("coffee", "alcohol", "not_a_real_key"),
+            triggers = listOf("coffee", "my custom tag"),
             note = " after lunch ",
             skipped = false,
         )
         assertEquals(
-            SmokeRelationship.Tagged(
-                triggers = setOf(SmokeTrigger.COFFEE, SmokeTrigger.ALCOHOL),
-                note = "after lunch",
-            ),
+            SmokeRelationship.Tagged(tags = setOf("coffee", "my custom tag", "after lunch")),
             relationship,
         )
     }
 
     @Test
     fun `GIVEN a Tagged relationship THEN the persisted fields round-trip`() {
-        val original = SmokeRelationship.Tagged(
-            triggers = setOf(SmokeTrigger.BOREDOM, SmokeTrigger.PHONE),
-            note = "scrolling",
-        )
+        val original = SmokeRelationship.Tagged(tags = setOf("boredom", "Phone scroll"))
         val restored = smokeRelationshipFromFields(
             triggers = original.triggerKeys(),
-            note = original.noteOrNull(),
+            note = null,
             skipped = original.skippedFlag(),
         )
         assertEquals(original, restored)
     }
 
     @Test
-    fun `GIVEN Skipped THEN it exposes the skipped flag and no triggers`() {
+    fun `GIVEN Skipped THEN it exposes the skipped flag and no tags`() {
         assertEquals(true, SmokeRelationship.Skipped.skippedFlag())
         assertEquals(emptyList(), SmokeRelationship.Skipped.triggerKeys())
-        assertEquals(null, SmokeRelationship.Skipped.noteOrNull())
+    }
+
+    @Test
+    fun `GIVEN the catalog with custom triggers THEN defaults and custom are combined`() {
+        val catalog = SmokeTrigger.catalog(
+            customTriggers = listOf("Gaming", "coffee"),
+            hiddenDefaultKeys = setOf("phone"),
+        )
+        // Defaults minus hidden 'phone' (9), plus 2 custom.
+        assertEquals(9 + 2, catalog.size)
+        assertEquals(false, catalog.any { it.key == "phone" })
+        assertEquals(true, catalog.any { it.key == "Gaming" && it.isCustom })
     }
 }

--- a/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeRelationshipMappingTest.kt
+++ b/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeRelationshipMappingTest.kt
@@ -1,0 +1,68 @@
+package com.feragusper.smokeanalytics.libraries.smokes.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SmokeRelationshipMappingTest {
+
+    @Test
+    fun `GIVEN no fields THEN it maps to Untracked`() {
+        assertEquals(
+            SmokeRelationship.Untracked,
+            smokeRelationshipFromFields(triggers = null, note = null, skipped = null),
+        )
+    }
+
+    @Test
+    fun `GIVEN empty triggers and blank note THEN it maps to Untracked`() {
+        assertEquals(
+            SmokeRelationship.Untracked,
+            smokeRelationshipFromFields(triggers = emptyList(), note = "  ", skipped = false),
+        )
+    }
+
+    @Test
+    fun `GIVEN skipped flag THEN it maps to Skipped regardless of triggers`() {
+        assertEquals(
+            SmokeRelationship.Skipped,
+            smokeRelationshipFromFields(triggers = listOf("coffee"), note = "x", skipped = true),
+        )
+    }
+
+    @Test
+    fun `GIVEN known triggers and note THEN it maps to Tagged ignoring unknown keys`() {
+        val relationship = smokeRelationshipFromFields(
+            triggers = listOf("coffee", "alcohol", "not_a_real_key"),
+            note = " after lunch ",
+            skipped = false,
+        )
+        assertEquals(
+            SmokeRelationship.Tagged(
+                triggers = setOf(SmokeTrigger.COFFEE, SmokeTrigger.ALCOHOL),
+                note = "after lunch",
+            ),
+            relationship,
+        )
+    }
+
+    @Test
+    fun `GIVEN a Tagged relationship THEN the persisted fields round-trip`() {
+        val original = SmokeRelationship.Tagged(
+            triggers = setOf(SmokeTrigger.BOREDOM, SmokeTrigger.PHONE),
+            note = "scrolling",
+        )
+        val restored = smokeRelationshipFromFields(
+            triggers = original.triggerKeys(),
+            note = original.noteOrNull(),
+            skipped = original.skippedFlag(),
+        )
+        assertEquals(original, restored)
+    }
+
+    @Test
+    fun `GIVEN Skipped THEN it exposes the skipped flag and no triggers`() {
+        assertEquals(true, SmokeRelationship.Skipped.skippedFlag())
+        assertEquals(emptyList(), SmokeRelationship.Skipped.triggerKeys())
+        assertEquals(null, SmokeRelationship.Skipped.noteOrNull())
+    }
+}

--- a/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeStatsTest.kt
+++ b/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeStatsTest.kt
@@ -259,4 +259,32 @@ class SmokeStatsTest {
         assertEquals("Average per awake hour so far", summary.supporting)
         assertEquals(0.6, summary.value)
     }
+
+    @Test
+    fun `GIVEN tagged smokes WHEN from is called THEN triggerBreakdown is ranked and labelled`() {
+        val smokes = listOf(
+            Smoke("1", Instant.parse("2023-03-01T10:00:00Z"), relationship = SmokeRelationship.Tagged(setOf("coffee", "stress"))),
+            Smoke("2", Instant.parse("2023-03-02T10:00:00Z"), relationship = SmokeRelationship.Tagged(setOf("coffee"))),
+            Smoke("3", Instant.parse("2023-03-03T10:00:00Z"), relationship = SmokeRelationship.Tagged(setOf("my custom tag"))),
+            Smoke("4", Instant.parse("2023-03-04T10:00:00Z"), relationship = SmokeRelationship.Skipped),
+            Smoke("5", Instant.parse("2023-03-05T10:00:00Z")), // Untracked
+        )
+
+        val breakdown = SmokeStats.from(
+            smokes = smokes,
+            year = 2023,
+            month = 3,
+            day = null,
+            timeZone = tz,
+            now = Instant.parse("2023-03-31T00:00:00Z"),
+        ).triggerBreakdown
+
+        // coffee (2) first, then stress and the custom tag (1 each). Skipped/Untracked excluded.
+        assertEquals(3, breakdown.size)
+        assertEquals("coffee", breakdown.first().key)
+        assertEquals(2, breakdown.first().count)
+        // Built-in keys resolve to their default label; custom tags keep their own string.
+        assertEquals("Coffee", breakdown.first().label)
+        assertEquals("my custom tag", breakdown.first { it.key == "my custom tag" }.label)
+    }
 }

--- a/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/usecase/AddSmokeUseCaseTest.kt
+++ b/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/usecase/AddSmokeUseCaseTest.kt
@@ -3,6 +3,7 @@ package com.feragusper.smokeanalytics.libraries.smokes.domain.usecase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeCount
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeRelationship
 import com.feragusper.smokeanalytics.libraries.smokes.domain.repository.SmokeRepository
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
@@ -55,10 +56,13 @@ class AddSmokeUseCaseTest {
         var lastAddedSmoke: Instant? = null
             private set
 
-        override suspend fun addSmoke(timestamp: Instant, location: GeoPoint?) {
+        override suspend fun addSmoke(timestamp: Instant, location: GeoPoint?): String {
             addSmokeCalls++
             lastAddedSmoke = timestamp
+            return "fake-smoke-id"
         }
+
+        override suspend fun setSmokeRelationship(id: String, relationship: SmokeRelationship) = Unit
 
         override suspend fun editSmoke(id: String, timestamp: Instant, location: GeoPoint?) = Unit
         override suspend fun deleteSmoke(id: String) = Unit

--- a/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/usecase/DeleteSmokeUseCaseTest.kt
+++ b/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/usecase/DeleteSmokeUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.feragusper.smokeanalytics.libraries.smokes.domain.usecase
 
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeRelationship
 import com.feragusper.smokeanalytics.libraries.smokes.domain.repository.SmokeRepository
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
@@ -45,7 +46,8 @@ private class FakeSmokeRepository : SmokeRepository {
         lastDeletedSmokeId = id
     }
 
-    override suspend fun addSmoke(timestamp: Instant, location: GeoPoint?) = Unit
+    override suspend fun addSmoke(timestamp: Instant, location: GeoPoint?): String = "fake-id"
+    override suspend fun setSmokeRelationship(id: String, relationship: SmokeRelationship) = Unit
     override suspend fun editSmoke(id: String, timestamp: Instant, location: GeoPoint?) = Unit
     override suspend fun fetchSmokes(start: Instant?, end: Instant?): List<Smoke> =
         emptyList()

--- a/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/usecase/EditSmokeUseCaseTest.kt
+++ b/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/usecase/EditSmokeUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.feragusper.smokeanalytics.libraries.smokes.domain.usecase
 
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeRelationship
 import com.feragusper.smokeanalytics.libraries.smokes.domain.repository.SmokeRepository
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
@@ -50,7 +51,8 @@ class EditSmokeUseCaseTest {
             lastEditedSmokeDate = timestamp
         }
 
-        override suspend fun addSmoke(timestamp: Instant, location: GeoPoint?) = Unit
+        override suspend fun addSmoke(timestamp: Instant, location: GeoPoint?): String = "fake-id"
+        override suspend fun setSmokeRelationship(id: String, relationship: SmokeRelationship) = Unit
         override suspend fun deleteSmoke(id: String) = Unit
         override suspend fun fetchSmokes(start: Instant?, end: Instant?): List<Smoke> =
             emptyList()

--- a/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/usecase/FetchSmokeStatsUseCaseTest.kt
+++ b/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/usecase/FetchSmokeStatsUseCaseTest.kt
@@ -4,6 +4,7 @@ import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeCount
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeStats
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeRelationship
 import com.feragusper.smokeanalytics.libraries.smokes.domain.repository.SmokeRepository
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
@@ -98,7 +99,8 @@ class FetchSmokeStatsUseCaseTest {
             end: Instant?
         ): List<Smoke> = smokesToReturn
 
-        override suspend fun addSmoke(timestamp: Instant, location: GeoPoint?) = Unit
+        override suspend fun addSmoke(timestamp: Instant, location: GeoPoint?): String = "fake-id"
+        override suspend fun setSmokeRelationship(id: String, relationship: SmokeRelationship) = Unit
         override suspend fun editSmoke(id: String, timestamp: Instant, location: GeoPoint?) = Unit
         override suspend fun deleteSmoke(id: String) = Unit
         override suspend fun fetchSmokeCount(dayStartHour: Int, manualDayStartEpochMillis: Long?): SmokeCount {

--- a/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/usecase/FetchSmokesUseCaseTest.kt
+++ b/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/usecase/FetchSmokesUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.feragusper.smokeanalytics.libraries.smokes.domain.usecase
 
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeRelationship
 import com.feragusper.smokeanalytics.libraries.smokes.domain.repository.SmokeRepository
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
@@ -60,7 +61,8 @@ class FetchSmokesUseCaseTest {
             return fetchSmokesResult
         }
 
-        override suspend fun addSmoke(timestamp: Instant, location: GeoPoint?) = Unit
+        override suspend fun addSmoke(timestamp: Instant, location: GeoPoint?): String = "fake-id"
+        override suspend fun setSmokeRelationship(id: String, relationship: SmokeRelationship) = Unit
         override suspend fun editSmoke(id: String, timestamp: Instant, location: GeoPoint?) = Unit
         override suspend fun deleteSmoke(id: String) = Unit
         override suspend fun fetchSmokeCount(dayStartHour: Int, manualDayStartEpochMillis: Long?) = error("Not needed for this test")

--- a/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/usecase/SetSmokeRelationshipUseCaseTest.kt
+++ b/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/usecase/SetSmokeRelationshipUseCaseTest.kt
@@ -1,0 +1,46 @@
+package com.feragusper.smokeanalytics.libraries.smokes.domain.usecase
+
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeRelationship
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeTrigger
+import com.feragusper.smokeanalytics.libraries.smokes.domain.repository.SmokeRepository
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SetSmokeRelationshipUseCaseTest {
+
+    @Test
+    fun `GIVEN an id and relationship WHEN invoked THEN it forwards them to the repository`() = runTest {
+        val repository = FakeSmokeRepository()
+        val useCase = SetSmokeRelationshipUseCase(repository)
+        val relationship = SmokeRelationship.Tagged(triggers = setOf(SmokeTrigger.COFFEE), note = "morning")
+
+        useCase("smoke-1", relationship)
+
+        assertEquals("smoke-1", repository.lastId)
+        assertEquals(relationship, repository.lastRelationship)
+    }
+
+    private class FakeSmokeRepository : SmokeRepository {
+        var lastId: String? = null
+            private set
+        var lastRelationship: SmokeRelationship? = null
+            private set
+
+        override suspend fun addSmoke(timestamp: Instant, location: GeoPoint?): String = "id"
+
+        override suspend fun setSmokeRelationship(id: String, relationship: SmokeRelationship) {
+            lastId = id
+            lastRelationship = relationship
+        }
+
+        override suspend fun editSmoke(id: String, timestamp: Instant, location: GeoPoint?) = Unit
+        override suspend fun deleteSmoke(id: String) = Unit
+        override suspend fun fetchSmokes(start: Instant?, end: Instant?): List<Smoke> = emptyList()
+        override suspend fun fetchSmokeCount(dayStartHour: Int, manualDayStartEpochMillis: Long?) =
+            error("Not needed for this test")
+    }
+}

--- a/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/usecase/SetSmokeRelationshipUseCaseTest.kt
+++ b/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/usecase/SetSmokeRelationshipUseCaseTest.kt
@@ -3,7 +3,6 @@ package com.feragusper.smokeanalytics.libraries.smokes.domain.usecase
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.Smoke
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeRelationship
-import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeTrigger
 import com.feragusper.smokeanalytics.libraries.smokes.domain.repository.SmokeRepository
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
@@ -16,7 +15,7 @@ class SetSmokeRelationshipUseCaseTest {
     fun `GIVEN an id and relationship WHEN invoked THEN it forwards them to the repository`() = runTest {
         val repository = FakeSmokeRepository()
         val useCase = SetSmokeRelationshipUseCase(repository)
-        val relationship = SmokeRelationship.Tagged(triggers = setOf(SmokeTrigger.COFFEE), note = "morning")
+        val relationship = SmokeRelationship.Tagged(tags = setOf("coffee", "morning"))
 
         useCase("smoke-1", relationship)
 

--- a/libraries/wear/data/src/main/java/com/feragusper/smokeanalytics/libraries/wear/data/WearLocationCodec.kt
+++ b/libraries/wear/data/src/main/java/com/feragusper/smokeanalytics/libraries/wear/data/WearLocationCodec.kt
@@ -1,0 +1,26 @@
+package com.feragusper.smokeanalytics.libraries.wear.data
+
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
+
+/**
+ * Encodes/decodes a location into the Wear message payload (`MessageClient.sendMessage` data).
+ * Smokes are added from the watch tile, which runs in the phone's background where the phone
+ * can't get a location fix — so the watch captures its own GPS and ships the coordinates here.
+ *
+ * Format: `"lat;lng"` UTF-8. Null/blank means no location was available on the watch.
+ */
+object WearLocationCodec {
+
+    fun encode(latitude: Double, longitude: Double): ByteArray =
+        "$latitude;$longitude".encodeToByteArray()
+
+    fun decode(data: ByteArray?): GeoPoint? {
+        val raw = data?.decodeToString()?.trim().orEmpty()
+        if (raw.isEmpty()) return null
+        val parts = raw.split(";")
+        if (parts.size != 2) return null
+        val lat = parts[0].toDoubleOrNull() ?: return null
+        val lng = parts[1].toDoubleOrNull() ?: return null
+        return GeoPoint(latitude = lat, longitude = lng)
+    }
+}

--- a/libraries/wear/data/src/main/java/com/feragusper/smokeanalytics/libraries/wear/data/WearSyncManagerImpl.kt
+++ b/libraries/wear/data/src/main/java/com/feragusper/smokeanalytics/libraries/wear/data/WearSyncManagerImpl.kt
@@ -66,11 +66,14 @@ class WearSyncManagerImpl(
             )
         }
 
-        override suspend fun handleWearRequest(path: String) {
+        override suspend fun handleWearRequest(path: String, data: ByteArray?) {
             when (path) {
                 WearPaths.REQUEST_SMOKES -> syncWithWear()
                 WearPaths.ADD_SMOKE -> {
-                    smokeRepository.addSmoke(Clock.System.now(), captureLocation())
+                    // Prefer the location the watch captured (the phone is in the background here
+                    // and can't get a fix); fall back to a phone capture for older watch builds.
+                    val location = WearLocationCodec.decode(data) ?: captureLocation()
+                    smokeRepository.addSmoke(Clock.System.now(), location)
                     syncWithWear()
                 }
                 else -> Timber.w("Ignoring unknown Wear request: $path")
@@ -126,12 +129,12 @@ class WearSyncManagerImpl(
          *
          * @param path The communication path to the mobile app.
          */
-        override suspend fun sendRequestToMobile(path: String) {
+        override suspend fun sendRequestToMobile(path: String, data: ByteArray?) {
             Timber.d("sendRequestToMobile")
             val nodes = getConnectedNodes()
             nodes.forEach { nodeId ->
                 Timber.d("sendRequestToMobile: sending request to node $nodeId")
-                sendMessageToNode(nodeId, path)
+                sendMessageToNode(nodeId, path, data)
             }
         }
 
@@ -207,11 +210,11 @@ class WearSyncManagerImpl(
          * @param nodeId The ID of the node (wearable device) to send the message to.
          * @param path The communication path for the message.
          */
-        private suspend fun sendMessageToNode(nodeId: String, path: String) =
+        private suspend fun sendMessageToNode(nodeId: String, path: String, data: ByteArray?) =
             withContext(dispatcherProvider.io()) {
                 Timber.d("sendMessageToNode")
                 suspendCancellableCoroutine { continuation ->
-                    messageClient.sendMessage(nodeId, path, null)
+                    messageClient.sendMessage(nodeId, path, data)
                         .addOnSuccessListener {
                             Timber.d("sendMessageToNode: message sent successfully")
                             continuation.resume(Unit)

--- a/libraries/wear/data/src/test/java/com/feragusper/smokeanalytics/libraries/wear/data/WearLocationCodecTest.kt
+++ b/libraries/wear/data/src/test/java/com/feragusper/smokeanalytics/libraries/wear/data/WearLocationCodecTest.kt
@@ -1,0 +1,37 @@
+package com.feragusper.smokeanalytics.libraries.wear.data
+
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.GeoPoint
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class WearLocationCodecTest {
+
+    @Test
+    fun `GIVEN coordinates WHEN encoded and decoded THEN they round-trip`() {
+        val encoded = WearLocationCodec.encode(latitude = 12.34, longitude = -56.78)
+        assertEquals(GeoPoint(latitude = 12.34, longitude = -56.78), WearLocationCodec.decode(encoded))
+    }
+
+    @Test
+    fun `GIVEN null data WHEN decoded THEN it returns null`() {
+        assertNull(WearLocationCodec.decode(null))
+    }
+
+    @Test
+    fun `GIVEN blank data WHEN decoded THEN it returns null`() {
+        assertNull(WearLocationCodec.decode("   ".encodeToByteArray()))
+    }
+
+    @Test
+    fun `GIVEN malformed data WHEN decoded THEN it returns null`() {
+        assertNull(WearLocationCodec.decode("not-a-coordinate".encodeToByteArray()))
+        assertNull(WearLocationCodec.decode("12.34".encodeToByteArray()))
+        assertNull(WearLocationCodec.decode("12.34;abc".encodeToByteArray()))
+    }
+
+    @Test
+    fun `GIVEN coordinates WHEN encoded THEN the format is lat semicolon lng`() {
+        assertEquals("1.5;2.5", WearLocationCodec.encode(latitude = 1.5, longitude = 2.5).decodeToString())
+    }
+}

--- a/libraries/wear/data/src/test/java/com/feragusper/smokeanalytics/libraries/wear/data/WearSyncManagerImplTest.kt
+++ b/libraries/wear/data/src/test/java/com/feragusper/smokeanalytics/libraries/wear/data/WearSyncManagerImplTest.kt
@@ -78,7 +78,7 @@ class WearSyncManagerImplTest {
             coEvery { locationCaptureService.captureCurrentLocation() } returns
                 Coordinate(latitude = 12.34, longitude = 56.78)
 
-            mobile.handleWearRequest(WearPaths.ADD_SMOKE)
+            mobile.handleWearRequest(WearPaths.ADD_SMOKE, data = null)
 
             coVerify {
                 smokeRepository.addSmoke(any(), GeoPoint(latitude = 12.34, longitude = 56.78))
@@ -97,7 +97,7 @@ class WearSyncManagerImplTest {
                     providerEnabled = false,
                 )
 
-            mobile.handleWearRequest(WearPaths.ADD_SMOKE)
+            mobile.handleWearRequest(WearPaths.ADD_SMOKE, data = null)
 
             coVerify { smokeRepository.addSmoke(any(), null) }
             coVerify(exactly = 0) { locationCaptureService.captureCurrentLocation() }
@@ -115,7 +115,7 @@ class WearSyncManagerImplTest {
                     providerEnabled = false,
                 )
 
-            mobile.handleWearRequest(WearPaths.ADD_SMOKE)
+            mobile.handleWearRequest(WearPaths.ADD_SMOKE, data = null)
 
             coVerify { smokeRepository.addSmoke(any(), null) }
             coVerify(exactly = 0) { locationCaptureService.captureCurrentLocation() }

--- a/libraries/wear/domain/src/main/java/com/feragusper/smokeanalytics/libraries/wear/domain/WearSyncManager.kt
+++ b/libraries/wear/domain/src/main/java/com/feragusper/smokeanalytics/libraries/wear/domain/WearSyncManager.kt
@@ -24,7 +24,7 @@ sealed interface WearSyncManager {
          * @param path The communication path.
          * @param data Optional payload (e.g. watch-captured location for an add).
          */
-        suspend fun handleWearRequest(path: String, data: ByteArray? = null)
+        suspend fun handleWearRequest(path: String, data: ByteArray?)
     }
 
     /**
@@ -37,7 +37,7 @@ sealed interface WearSyncManager {
          * @param path The communication path for the request.
          * @param data Optional payload (e.g. watch-captured location for an add).
          */
-        suspend fun sendRequestToMobile(path: String, data: ByteArray? = null)
+        suspend fun sendRequestToMobile(path: String, data: ByteArray?)
 
         /**
          * Listens for data updates from the mobile app and processes them.

--- a/libraries/wear/domain/src/main/java/com/feragusper/smokeanalytics/libraries/wear/domain/WearSyncManager.kt
+++ b/libraries/wear/domain/src/main/java/com/feragusper/smokeanalytics/libraries/wear/domain/WearSyncManager.kt
@@ -20,8 +20,11 @@ sealed interface WearSyncManager {
 
         /**
          * Handles a message sent by a Wear OS device.
+         *
+         * @param path The communication path.
+         * @param data Optional payload (e.g. watch-captured location for an add).
          */
-        suspend fun handleWearRequest(path: String)
+        suspend fun handleWearRequest(path: String, data: ByteArray? = null)
     }
 
     /**
@@ -32,8 +35,9 @@ sealed interface WearSyncManager {
          * Sends a request from the Wear OS device to the mobile app.
          *
          * @param path The communication path for the request.
+         * @param data Optional payload (e.g. watch-captured location for an add).
          */
-        suspend fun sendRequestToMobile(path: String)
+        suspend fun sendRequestToMobile(path: String, data: ByteArray? = null)
 
         /**
          * Listens for data updates from the mobile app and processes them.

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-product.version=0.19
+product.version=1.0


### PR DESCRIPTION
## Release 1.0 — first production release

First stable production release. Promotes the Android + Wear apps from **early testing** to the **production** Play Store track, and bumps the product version to **1.0** (single source of truth in `version.properties`).

Derived versions:
- **Android:** `1.0.<gitCode>`
- **Web:** `1.0+web.<gitCode>`

### Changes
- **release(1.0):** `product.version` `0.19` → `1.0`; fastlane now publishes the mobile + wear AABs to the `production` track (was `beta`).
- **refactor(devtools):** DevTools no longer ships in release builds (debug-only via variant-specific Koin module).
- **feat(smokes): track what each smoke was related to** — after logging a cigarette, mobile + web prompt for its trigger/context (multi-select chips: coffee, alcohol, boredom, anxiety, stress, after-meal, social, break, driving, phone — plus an "Other" free-text). A home reminder card lists smokes still missing a relationship (logged from the watch, or dismissed prompts) within a 30-day window and lets you tag or skip them. Watch smokes stay untracked and surface in the card. Backward compatible: existing/legacy smokes load as untracked.
- **feat(smokes): manageable trigger tags + analytics** — trigger tags are now a curatable catalog (built-in defaults + your own custom tags) managed from **Settings → Manage triggers** (hide/show defaults, add/remove custom). The smoke prompt chips come from that catalog (with inline ad-hoc tags), and **Stats** gains a "By trigger" breakdown ranked for the selected period. Backward compatible: existing enum-key + note smokes still load as tags.
- **feat(home):** the "vs last month" trend card is colour-coded by direction (green = less, red = more, neutral = flat), leads with a plain-language headline, and shows how many cigarettes more/fewer so far.

### Production-readiness audit
Release build was already prod-hardened:
- ✅ R8 minify + resource shrinking on release
- ✅ Release signing from keystore
- ✅ Cleartext traffic disabled + network-security config
- ✅ Minimal permissions (INTERNET + location for Maps)
- ✅ Timber planted only in `BuildConfig.DEBUG`
- ✅ Play Store deploy is manual (`workflow_dispatch`) — no accidental auto-publish
- ✅ Web ships separate prod Firebase config, prod favicon, and prod hosting target

Follow-ups (non-blocking): consider a staged production rollout for the first release instead of 100%; "all pending" relationship list is a 30-day in-memory scan (Firestore can't query absent fields) — deeper history would need a migration/flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
