### PR TITLE
Re-cut 1.0 as 1.0.0 (full semver)

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-product.version=1.0
+product.version=1.0.0


### PR DESCRIPTION
The 1.0 production release shipped as **1.0.557** because `product.version` was two-part (`1.0`). It should be `1.0.0.<gitCode>`.

Sets `product.version=1.0.0` → production build versions as **Android 1.0.0.558** / **Web 1.0.0+web.558**. The new commit bumps gitCode (558 > the previous 557 upload), so Play's `versionCode` stays strictly increasing.

After merge: re-deploy mobile + web from `master` to replace 1.0.557 / 1.0+web.557.

🤖 Generated with [Claude Code](https://claude.com/claude-code)