### PR TITLE
Release: 1.0.1 — relationship reminder polish

### DIFF
--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
@@ -216,12 +216,10 @@ data class HomeViewState(
                 activeCraving = activeCraving,
                 cravingStats = cravingStats,
                 showCravingHint = showCravingHint,
-                pendingRelationshipCount = pendingRelationshipSmokes.size,
-                onAddRelationship = {
-                    pendingRelationshipSmokes.firstOrNull()?.let {
-                        intent(HomeIntent.OpenRelationshipPrompt(it.id))
-                    }
+                pendingRelationshipSmokes = pendingRelationshipSmokes.map {
+                    PendingTriggerSmoke(id = it.id, label = it.date.toPendingTriggerLabel())
                 },
+                onOpenRelationship = { id -> intent(HomeIntent.OpenRelationshipPrompt(id)) },
                 intent = intent,
             )
         }
@@ -235,8 +233,13 @@ data class HomeViewState(
 
         val promptSmokeId = relationshipPromptSmokeId
         if (promptSmokeId != null) {
+            val dateLabel = pendingRelationshipSmokes
+                .firstOrNull { it.id == promptSmokeId }
+                ?.date
+                ?.toPendingTriggerLabel()
             RelationshipPromptSheet(
                 availableTriggers = availableTriggers,
+                dateLabel = dateLabel,
                 onSave = { tags -> intent(HomeIntent.SaveSmokeRelationship(promptSmokeId, tags)) },
                 onSkip = { intent(HomeIntent.SkipSmokeRelationship(promptSmokeId)) },
                 onDismiss = { intent(HomeIntent.DismissRelationshipPrompt) },
@@ -269,8 +272,8 @@ private fun HomeContent(
     activeCraving: Craving?,
     cravingStats: CravingStats?,
     showCravingHint: Boolean,
-    pendingRelationshipCount: Int,
-    onAddRelationship: () -> Unit,
+    pendingRelationshipSmokes: List<PendingTriggerSmoke>,
+    onOpenRelationship: (String) -> Unit,
     intent: (HomeIntent) -> Unit,
 ) {
     val hasLoadedContent = smokesPerDay != null || timeSinceLastCigarette != null || goalProgress != null
@@ -347,11 +350,11 @@ private fun HomeContent(
             )
         }
         if (!isLoading && hasLoadedContent) {
-            if (pendingRelationshipCount > 0) {
+            if (pendingRelationshipSmokes.isNotEmpty()) {
                 item {
                     RelationshipReminderCard(
-                        pendingCount = pendingRelationshipCount,
-                        onAdd = onAddRelationship,
+                        pending = pendingRelationshipSmokes,
+                        onOpen = onOpenRelationship,
                     )
                 }
             }

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/RelationshipComponents.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/RelationshipComponents.kt
@@ -39,16 +39,21 @@ import com.feragusper.smokeanalytics.libraries.design.compose.theme.SmokeAnalyti
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeTrigger
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.TriggerOption
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.normalizedTag
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 
 /**
  * Home card reminding the user that some smokes (logged from the watch, or whose prompt
- * was dismissed) still have no trigger. Tapping the CTA opens the prompt for the next one.
+ * was dismissed) still have no trigger. Each carries its own date/time so the user can recall
+ * what it was about and tag them one at a time — not all at once.
  */
 @Composable
 internal fun RelationshipReminderCard(
-    pendingCount: Int,
-    onAdd: () -> Unit,
+    pending: List<PendingTriggerSmoke>,
+    onOpen: (smokeId: String) -> Unit,
 ) {
+    val shown = pending.take(MAX_PENDING_SHOWN)
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.4f),
@@ -57,7 +62,7 @@ internal fun RelationshipReminderCard(
     ) {
         Column(
             modifier = Modifier.padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Text(
                 text = "What were these about?",
@@ -65,29 +70,63 @@ internal fun RelationshipReminderCard(
                 fontWeight = FontWeight.Bold,
             )
             Text(
-                text = if (pendingCount == 1) {
-                    "1 cigarette still needs a trigger"
+                text = if (pending.size == 1) {
+                    "1 cigarette still needs a trigger — tag it below."
                 } else {
-                    "$pendingCount cigarettes still need a trigger"
+                    "${pending.size} cigarettes still need a trigger — tag them one at a time."
                 },
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            Button(
-                onClick = onAdd,
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(18.dp),
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Edit,
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp),
+            shown.forEach { item ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = item.label,
+                        modifier = Modifier.weight(1f),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    TextButton(onClick = { onOpen(item.id) }) {
+                        Icon(
+                            imageVector = Icons.Filled.Edit,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp),
+                        )
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text("Add trigger")
+                    }
+                }
+            }
+            if (pending.size > shown.size) {
+                Text(
+                    text = "+${pending.size - shown.size} more",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text("Add trigger", fontWeight = FontWeight.Bold)
             }
         }
     }
+}
+
+/** A pending (untracked) smoke shown in the reminder card: its id and a date/time label. */
+internal data class PendingTriggerSmoke(
+    val id: String,
+    val label: String,
+)
+
+private const val MAX_PENDING_SHOWN = 8
+
+/** Human label for a pending smoke, e.g. "Mon Jun 24 · 14:30". */
+internal fun Instant.toPendingTriggerLabel(timeZone: TimeZone = TimeZone.currentSystemDefault()): String {
+    val dt = toLocalDateTime(timeZone)
+    val weekday = dt.dayOfWeek.name.lowercase().replaceFirstChar { it.uppercase() }.take(3)
+    val month = dt.month.name.lowercase().replaceFirstChar { it.uppercase() }.take(3)
+    val hour = dt.hour.toString().padStart(2, '0')
+    val minute = dt.minute.toString().padStart(2, '0')
+    return "$weekday $month ${dt.dayOfMonth} · $hour:$minute"
 }
 
 /**
@@ -98,6 +137,7 @@ internal fun RelationshipReminderCard(
 @Composable
 internal fun RelationshipPromptSheet(
     availableTriggers: List<TriggerOption>,
+    dateLabel: String? = null,
     onSave: (tags: Set<String>) -> Unit,
     onSkip: () -> Unit,
     onDismiss: () -> Unit,
@@ -131,6 +171,13 @@ internal fun RelationshipPromptSheet(
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold,
             )
+            dateLabel?.let {
+                Text(
+                    text = "Logged $it",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
             Text(
                 text = "Tag what triggered this cigarette, or skip if it was nothing in particular.",
                 style = MaterialTheme.typography.bodyMedium,
@@ -204,6 +251,12 @@ internal fun RelationshipPromptSheet(
 @Composable
 private fun RelationshipReminderCardPreview() {
     SmokeAnalyticsTheme {
-        RelationshipReminderCard(pendingCount = 3, onAdd = {})
+        RelationshipReminderCard(
+            pending = listOf(
+                PendingTriggerSmoke("1", "Mon Jun 24 · 14:30"),
+                PendingTriggerSmoke("2", "Mon Jun 24 · 09:05"),
+            ),
+            onOpen = {},
+        )
     }
 }

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/EditSmokeDateTimeHelpers.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/EditSmokeDateTimeHelpers.kt
@@ -21,6 +21,16 @@ internal fun Instant.toTimeInputValue(timeZone: TimeZone): String {
     return "$hour:$minute"
 }
 
+/** Human label for a pending smoke in the reminder card, e.g. "Mon Jun 24 · 14:30". */
+internal fun Instant.toPendingTriggerLabel(timeZone: TimeZone = TimeZone.currentSystemDefault()): String {
+    val dt = toLocalDateTime(timeZone)
+    val weekday = dt.dayOfWeek.name.lowercase().replaceFirstChar { it.uppercase() }.take(3)
+    val month = dt.month.name.lowercase().replaceFirstChar { it.uppercase() }.take(3)
+    val hour = dt.hour.toString().padStart(2, '0')
+    val minute = dt.minute.toString().padStart(2, '0')
+    return "$weekday $month ${dt.dayOfMonth} · $hour:$minute"
+}
+
 internal fun dateTimeInputsToInstant(
     dateValue: String,
     timeValue: String,

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeWebScreen.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeWebScreen.kt
@@ -186,12 +186,10 @@ fun HomeViewState.Render(
 
             if (pendingRelationshipSmokes.isNotEmpty()) {
                 RelationshipReminderCardWeb(
-                    pendingCount = pendingRelationshipSmokes.size,
-                    onAdd = {
-                        pendingRelationshipSmokes.firstOrNull()?.let {
-                            onIntent(HomeIntent.OpenRelationshipPrompt(it.id))
-                        }
+                    pending = pendingRelationshipSmokes.map {
+                        PendingTriggerSmoke(id = it.id, label = it.date.toPendingTriggerLabel())
                     },
+                    onOpen = { id -> onIntent(HomeIntent.OpenRelationshipPrompt(id)) },
                 )
             }
 
@@ -222,8 +220,13 @@ fun HomeViewState.Render(
 
     val promptSmokeId = relationshipPromptSmokeId
     if (promptSmokeId != null) {
+        val dateLabel = pendingRelationshipSmokes
+            .firstOrNull { it.id == promptSmokeId }
+            ?.date
+            ?.toPendingTriggerLabel()
         RelationshipPromptDialogWeb(
             availableTriggers = availableTriggers,
+            dateLabel = dateLabel,
             onSave = { tags -> onIntent(HomeIntent.SaveSmokeRelationship(promptSmokeId, tags)) },
             onSkip = { onIntent(HomeIntent.SkipSmokeRelationship(promptSmokeId)) },
             onDismiss = { onIntent(HomeIntent.DismissRelationshipPrompt) },

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/RelationshipComponentsWeb.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/RelationshipComponentsWeb.kt
@@ -5,6 +5,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import com.feragusper.smokeanalytics.libraries.design.GhostButton
+import com.feragusper.smokeanalytics.libraries.design.PrimaryButton
 import com.feragusper.smokeanalytics.libraries.design.SmokeWebStyles
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeTrigger
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.TriggerOption
@@ -15,39 +17,69 @@ import org.jetbrains.compose.web.dom.Div
 import org.jetbrains.compose.web.dom.H3
 import org.jetbrains.compose.web.dom.Input
 import org.jetbrains.compose.web.dom.P
+import org.jetbrains.compose.web.dom.Span
 import org.jetbrains.compose.web.dom.Text
 
+/** A pending (untracked) smoke shown in the reminder card: its id and a human date/time label. */
+internal data class PendingTriggerSmoke(
+    val id: String,
+    val label: String,
+)
+
+private const val MAX_PENDING_SHOWN = 8
+
 /**
- * Home card reminding the user that some smokes (logged from the watch, or whose prompt
- * was dismissed) still have no trigger. Tapping the CTA opens the prompt for the next one.
+ * Home card reminding the user that some smokes (logged from the watch, or whose prompt was
+ * dismissed) still have no trigger. Each one carries its own date/time so the user can recall
+ * what it was about and tag them one at a time — not all at once.
  */
 @Composable
 internal fun RelationshipReminderCardWeb(
-    pendingCount: Int,
-    onAdd: () -> Unit,
+    pending: List<PendingTriggerSmoke>,
+    onOpen: (smokeId: String) -> Unit,
 ) {
+    val shown = pending.take(MAX_PENDING_SHOWN)
     Div(attrs = { classes(SmokeWebStyles.card) }) {
         H3 { Text("What were these about?") }
         P {
             Text(
-                if (pendingCount == 1) {
-                    "1 cigarette still needs a trigger"
+                if (pending.size == 1) {
+                    "1 cigarette still needs a trigger — tag it below."
                 } else {
-                    "$pendingCount cigarettes still need a trigger"
+                    "${pending.size} cigarettes still need a trigger — tag them one at a time."
                 }
             )
         }
-        Button(attrs = { onClick { onAdd() } }) { Text("Add trigger") }
+        Div(attrs = { attr("style", "display:flex;flex-direction:column;gap:8px;margin-top:8px;") }) {
+            shown.forEach { item ->
+                Div(attrs = {
+                    attr(
+                        "style",
+                        "display:flex;align-items:center;justify-content:space-between;gap:12px;" +
+                            "padding:8px 0;border-top:1px solid var(--sa-color-surfaceVariant);",
+                    )
+                }) {
+                    Span(attrs = { attr("style", "font-size:14px;") }) { Text(item.label) }
+                    GhostButton(text = "Add trigger", onClick = { onOpen(item.id) })
+                }
+            }
+        }
+        if (pending.size > shown.size) {
+            Div(attrs = { classes(SmokeWebStyles.helperText) }) {
+                Text("+${pending.size - shown.size} more")
+            }
+        }
     }
 }
 
 /**
- * Modal asking what a smoke was related to: multi-select chips plus an "Other" free-text
- * field. The user can save, declare "no relation", or dismiss (the smoke stays untracked).
+ * Modal asking what a single smoke was related to. Shows which cigarette is being tagged
+ * (its date/time), multi-select chips, and an "Add a tag" field. Save / No relation / dismiss.
  */
 @Composable
 internal fun RelationshipPromptDialogWeb(
     availableTriggers: List<TriggerOption>,
+    dateLabel: String?,
     onSave: (tags: Set<String>) -> Unit,
     onSkip: () -> Unit,
     onDismiss: () -> Unit,
@@ -85,6 +117,9 @@ internal fun RelationshipPromptDialogWeb(
             }
         ) {
             H3 { Text("What was it related to?") }
+            dateLabel?.let {
+                Div(attrs = { classes(SmokeWebStyles.helperText) }) { Text("Logged $it") }
+            }
             P { Text("Tag what triggered this cigarette, or skip if it was nothing in particular.") }
 
             Div(
@@ -146,15 +181,15 @@ internal fun RelationshipPromptDialogWeb(
                     }
                 }
             ) {
-                Button(attrs = { onClick { onSkip() } }) { Text("No relation") }
-                Button(
-                    attrs = {
-                        onClick {
-                            val tags = selectedKeys + listOfNotNull(draft.normalizedTag())
-                            if (tags.isNotEmpty()) onSave(tags)
-                        }
-                    }
-                ) { Text("Save") }
+                GhostButton(text = "No relation", onClick = onSkip)
+                PrimaryButton(
+                    text = "Save",
+                    enabled = selectedKeys.isNotEmpty() || draft.normalizedTag() != null,
+                    onClick = {
+                        val tags = selectedKeys + listOfNotNull(draft.normalizedTag())
+                        if (tags.isNotEmpty()) onSave(tags)
+                    },
+                )
             }
         }
     }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-product.version=1.0
+product.version=1.1

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-product.version=1.1
+product.version=1.1.0

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-product.version=1.1.0
+product.version=1.0.1


### PR DESCRIPTION
## Release 1.0.1 — patch

Bugfix/polish tranche on top of 1.0.0.

Derived versions:
- **Android:** `1.0.1.<gitCode>`
- **Web:** `1.0.1+web.<gitCode>`

### Changes
- **fix(home): per-smoke relationship reminder with dates** — the "What were these about?" card now lists pending smokes individually, each with its date/time (e.g. `Mon Jun 24 · 14:30`) and its own "Add trigger" that opens the prompt for that specific cigarette (capped at 8 with "+N more"). The prompt shows which cigarette is being tagged. Each smoke is tagged on its own, not all untracked at once.
- **fix(web): style relationship buttons** — "Add trigger" / "No relation" / "Save" now use the design-system Ghost/Primary buttons instead of raw HTML buttons.
- **release(1.0.1):** `product.version` → `1.0.1` (patch; the earlier 1.1 bump was premature — no features landed this tranche).

Applied to both web and mobile.

After merge: deploy mobile + web from `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)