### PR TITLE
Release: 1.0.3 — relationship cutoff at July 1st

### DIFF
--- a/features/home/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/domain/RelationshipTracking.kt
+++ b/features/home/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/domain/RelationshipTracking.kt
@@ -3,8 +3,8 @@ package com.feragusper.smokeanalytics.features.home.domain
 import kotlinx.datetime.Instant
 
 /**
- * The relationship (trigger) prompt shipped mid-June 2026. Smokes logged before this date were
- * never offered the prompt, so they are not treated as "pending" — the reminder card doesn't nag
- * the user to tag their entire pre-feature history.
+ * Smokes logged before this date are not treated as "pending" — the reminder card doesn't nag
+ * the user to tag their pre-feature history. The prompt shipped mid-June 2026; the cutoff sits
+ * at July 1st so everything logged before the feature was actually in day-to-day use is exempt.
  */
-val RelationshipTrackingSince: Instant = Instant.parse("2026-06-15T00:00:00Z")
+val RelationshipTrackingSince: Instant = Instant.parse("2026-07-01T00:00:00Z")

--- a/features/home/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/features/home/domain/RelationshipTrackingTest.kt
+++ b/features/home/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/features/home/domain/RelationshipTrackingTest.kt
@@ -8,13 +8,13 @@ import kotlin.test.assertTrue
 class RelationshipTrackingTest {
 
     @Test
-    fun `cutoff is the feature launch date`() {
-        assertEquals(Instant.parse("2026-06-15T00:00:00Z"), RelationshipTrackingSince)
+    fun `cutoff is the relationship adoption date`() {
+        assertEquals(Instant.parse("2026-07-01T00:00:00Z"), RelationshipTrackingSince)
     }
 
     @Test
     fun `smokes before the cutoff are excluded from pending`() {
-        assertTrue(Instant.parse("2026-06-14T23:59:59Z") < RelationshipTrackingSince)
-        assertTrue(Instant.parse("2026-06-15T00:00:00Z") >= RelationshipTrackingSince)
+        assertTrue(Instant.parse("2026-06-30T23:59:59Z") < RelationshipTrackingSince)
+        assertTrue(Instant.parse("2026-07-01T00:00:00Z") >= RelationshipTrackingSince)
     }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-product.version=1.0.2
+product.version=1.0.3


### PR DESCRIPTION
## Release 1.0.3 — patch

Single fix on top of 1.0.2.

Derived versions:
- **Android:** `1.0.3.<gitCode>`
- **Web:** `1.0.3+web.<gitCode>`

### Changes
- **fix(home): relationship-pending cutoff moved to 2026-07-01** — smokes logged before July 1st 2026 no longer count as pending in the "What were these about?" reminder card (the mid-June cutoff still surfaced a couple of weeks of pre-adoption history). Shared domain constant; applies to mobile and web.

After merge: deploy mobile + web from `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)