### PR TITLE
Release: 1.1.0 — trigger icons, pie breakdown & prompt stabilization

### DIFF
--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/HomeViewModel.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/HomeViewModel.kt
@@ -216,8 +216,10 @@ class HomeViewModel constructor(
             }
 
             is AddSmokeSuccess -> {
-                // Re-fetch so the new smoke shows up, and open the relationship prompt for it.
-                intents().trySend(HomeIntent.FetchSmokes)
+                // Silently re-fetch so the new smoke shows up. A full FetchSmokes here put the
+                // home into its loading skeleton behind the relationship prompt, which read as
+                // "something is happening" while the user was just picking a tag.
+                intents().trySend(HomeIntent.RefreshFetchSmokes)
                 previous.copy(
                     displayLoading = false,
                     displayRefreshLoading = false,
@@ -227,8 +229,8 @@ class HomeViewModel constructor(
             }
 
             HomeResult.RelationshipUpdated -> {
-                // Relationship saved/skipped: refresh the pending list and close the prompt.
-                intents().trySend(HomeIntent.FetchSmokes)
+                // Relationship saved/skipped: silently refresh the pending list and close the prompt.
+                intents().trySend(HomeIntent.RefreshFetchSmokes)
                 previous.copy(relationshipPromptSmokeId = null)
             }
 

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
@@ -129,7 +129,8 @@ data class HomeViewState(
     internal val cravingCelebration: CravingCelebration? = null,
     internal val pendingRelationshipSmokes: List<Smoke> = emptyList(),
     internal val relationshipPromptSmokeId: String? = null,
-    internal val availableTriggers: List<TriggerOption> = emptyList(),
+    /** Null until the first fetch resolves — the prompt shows a loading state meanwhile. */
+    internal val availableTriggers: List<TriggerOption>? = null,
 ) : MVIViewState<HomeIntent> {
 
     internal val lastSmokeTimeLabel: String?

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/RelationshipComponents.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/RelationshipComponents.kt
@@ -214,7 +214,7 @@ internal fun RelationshipPromptSheet(
                                     selectedKeys + option.key
                                 }
                             },
-                            label = { Text(option.label) },
+                            label = { Text(option.display) },
                         )
                     }
                 }

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/RelationshipComponents.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/RelationshipComponents.kt
@@ -6,11 +6,7 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.ime
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.padding
@@ -167,10 +163,12 @@ internal fun RelationshipPromptSheet(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                // Lift content above the keyboard (and nav bar) so the text field stays fully
-                // visible and interactive when the IME is open; scroll if space gets tight.
-                .padding(WindowInsets.ime.union(WindowInsets.navigationBars).asPaddingValues())
+                // The sheet's dialog window already resizes when the IME opens — do NOT add
+                // ime padding here too (double-applying pushed the content out of the sheet
+                // entirely). Scrolling is enough: the sheet shrinks, content scrolls, and the
+                // focused text field is auto-scrolled into view.
                 .verticalScroll(rememberScrollState())
+                .navigationBarsPadding()
                 .padding(horizontal = 24.dp)
                 .padding(bottom = 24.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/RelationshipComponents.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/RelationshipComponents.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
@@ -38,7 +39,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.feragusper.smokeanalytics.libraries.design.compose.CombinedPreviews
 import com.feragusper.smokeanalytics.libraries.design.compose.theme.SmokeAnalyticsTheme
-import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeTrigger
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.TriggerOption
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.normalizedTag
 import kotlinx.datetime.Instant
@@ -138,23 +138,22 @@ internal fun Instant.toPendingTriggerLabel(timeZone: TimeZone = TimeZone.current
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun RelationshipPromptSheet(
-    availableTriggers: List<TriggerOption>,
+    availableTriggers: List<TriggerOption>?,
     dateLabel: String? = null,
     onSave: (tags: Set<String>) -> Unit,
     onSkip: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    // Chips come from the catalog (defaults + custom). The user can also type an ad-hoc
-    // tag, which is added to the chip row for this smoke.
-    val catalog = remember(availableTriggers) {
-        if (availableTriggers.isEmpty()) SmokeTrigger.defaultOptions() else availableTriggers
-    }
+    // Freeze the catalog the moment it's loaded (keyed on loaded-ness, not the list) so
+    // chips don't pop in mid-dialog when a background refresh lands; while it's still
+    // null the sheet shows a loading indicator instead of a partial default list.
+    val catalog = remember(availableTriggers != null) { availableTriggers }
     var adHoc by remember { mutableStateOf(listOf<TriggerOption>()) }
     var selectedKeys by remember { mutableStateOf(emptySet<String>()) }
     var draft by remember { mutableStateOf("") }
 
-    val options = catalog + adHoc.filter { extra -> catalog.none { it.key == extra.key } }
+    val options = catalog?.plus(adHoc.filter { extra -> catalog.none { it.key == extra.key } })
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -190,23 +189,34 @@ internal fun RelationshipPromptSheet(
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            FlowRow(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                options.forEach { option ->
-                    FilterChip(
-                        selected = option.key in selectedKeys,
-                        onClick = {
-                            selectedKeys = if (option.key in selectedKeys) {
-                                selectedKeys - option.key
-                            } else {
-                                selectedKeys + option.key
-                            }
-                        },
-                        label = { Text(option.label) },
-                    )
+            if (options == null) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 12.dp),
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.size(28.dp))
+                }
+            } else {
+                FlowRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    options.forEach { option ->
+                        FilterChip(
+                            selected = option.key in selectedKeys,
+                            onClick = {
+                                selectedKeys = if (option.key in selectedKeys) {
+                                    selectedKeys - option.key
+                                } else {
+                                    selectedKeys + option.key
+                                }
+                            },
+                            label = { Text(option.label) },
+                        )
+                    }
                 }
             }
             OutlinedTextField(

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
@@ -237,6 +237,7 @@ class HomeProcessHolder constructor(
                         availableTriggers = SmokeTrigger.catalog(
                             customTriggers = preferences.customTriggers,
                             hiddenDefaultKeys = preferences.hiddenDefaultTriggers,
+                            iconOverrides = preferences.triggerIcons,
                         ),
                     )
                 )

--- a/features/home/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/home/presentation/HomeViewModelTest.kt
+++ b/features/home/presentation/mobile/src/test/java/com/feragusper/smokeanalytics/features/home/presentation/HomeViewModelTest.kt
@@ -36,6 +36,7 @@ class HomeViewModelTest {
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
         every { processHolder.processIntent(HomeIntent.FetchSmokes) } returns intentResults
+        every { processHolder.processIntent(HomeIntent.RefreshFetchSmokes) } returns intentResults
         viewModel = HomeViewModel(processHolder)
     }
 

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeViewState.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeViewState.kt
@@ -60,7 +60,8 @@ data class HomeViewState(
     val cravingCelebration: CravingCelebration? = null,
     val pendingRelationshipSmokes: List<Smoke> = emptyList(),
     val relationshipPromptSmokeId: String? = null,
-    val availableTriggers: List<TriggerOption> = emptyList(),
+    /** Null until the first fetch resolves — the prompt shows a loading state meanwhile. */
+    val availableTriggers: List<TriggerOption>? = null,
 ) {
 
     /**

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/RelationshipComponentsWeb.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/RelationshipComponentsWeb.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.setValue
 import com.feragusper.smokeanalytics.libraries.design.GhostButton
 import com.feragusper.smokeanalytics.libraries.design.PrimaryButton
 import com.feragusper.smokeanalytics.libraries.design.SmokeWebStyles
-import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeTrigger
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.TriggerOption
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.normalizedTag
 import org.jetbrains.compose.web.attributes.InputType
@@ -78,15 +77,16 @@ internal fun RelationshipReminderCardWeb(
  */
 @Composable
 internal fun RelationshipPromptDialogWeb(
-    availableTriggers: List<TriggerOption>,
+    availableTriggers: List<TriggerOption>?,
     dateLabel: String?,
     onSave: (tags: Set<String>) -> Unit,
     onSkip: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val options = remember(availableTriggers) {
-        if (availableTriggers.isEmpty()) SmokeTrigger.defaultOptions() else availableTriggers
-    }
+    // Freeze the catalog the moment it's loaded (keyed on loaded-ness, not the list) so
+    // chips don't pop in mid-dialog when a background refresh lands; while null the dialog
+    // shows a loading row instead of a partial default list.
+    val options = remember(availableTriggers != null) { availableTriggers }
     var selectedKeys by remember { mutableStateOf(emptySet<String>()) }
     var draft by remember { mutableStateOf("") }
 
@@ -124,7 +124,9 @@ internal fun RelationshipPromptDialogWeb(
             }
             P { Text("Tag what triggered this cigarette, or skip if it was nothing in particular.") }
 
-            Div(
+            if (options == null) {
+                Div(attrs = { classes(SmokeWebStyles.helperText) }) { Text("Loading your tags…") }
+            } else Div(
                 attrs = {
                     style {
                         property("display", "flex")

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/RelationshipComponentsWeb.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/RelationshipComponentsWeb.kt
@@ -157,7 +157,7 @@ internal fun RelationshipPromptDialogWeb(
                                 }
                             }
                         }
-                    ) { Text(option.label) }
+                    ) { Text(option.display) }
                 }
             }
 

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeWebStore.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/mvi/HomeWebStore.kt
@@ -171,12 +171,14 @@ class HomeWebStore(
             }
 
             is HomeResult.AddSmokeSuccess -> {
-                send(HomeIntent.FetchSmokes)
+                // Silent refresh: a full FetchSmokes swapped the page to its loading skeleton
+                // behind the relationship prompt.
+                send(HomeIntent.RefreshFetchSmokes)
                 previous.copy(relationshipPromptSmokeId = result.smokeId)
             }
 
             HomeResult.RelationshipUpdated -> {
-                send(HomeIntent.FetchSmokes)
+                send(HomeIntent.RefreshFetchSmokes)
                 previous.copy(relationshipPromptSmokeId = null)
             }
 

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/process/HomeProcessHolder.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/process/HomeProcessHolder.kt
@@ -229,6 +229,7 @@ class HomeProcessHolder(
                             availableTriggers = SmokeTrigger.catalog(
                                 customTriggers = preferences.customTriggers,
                                 hiddenDefaultKeys = preferences.hiddenDefaultTriggers,
+                                iconOverrides = preferences.triggerIcons,
                             ),
                         )
                     )

--- a/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/mvi/compose/SettingsViewState.kt
+++ b/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/mvi/compose/SettingsViewState.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -49,6 +50,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.testTag
@@ -1155,9 +1157,14 @@ private fun ManageTriggersSection(
             val visible = option.key !in preferences.hiddenDefaultTriggers
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
+                TriggerIconField(
+                    icon = preferences.triggerIcons[option.key] ?: option.icon.orEmpty(),
+                    enabled = enabled,
+                    onCommit = { icon -> onChange(preferences.withTriggerIcon(option.key, icon)) },
+                )
                 Text(text = option.label, modifier = Modifier.weight(1f))
                 Switch(
                     checked = visible,
@@ -1183,9 +1190,14 @@ private fun ManageTriggersSection(
             preferences.customTriggers.forEach { tag ->
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
+                    TriggerIconField(
+                        icon = preferences.triggerIcons[tag].orEmpty(),
+                        enabled = enabled,
+                        onCommit = { icon -> onChange(preferences.withTriggerIcon(tag, icon)) },
+                    )
                     Text(text = tag, modifier = Modifier.weight(1f))
                     TextButton(
                         onClick = { onChange(preferences.copy(customTriggers = preferences.customTriggers - tag)) },
@@ -1215,3 +1227,33 @@ private fun ManageTriggersSection(
         )
     }
 }
+
+/** Small per-row editor for a trigger's emoji; commits when the field loses focus. */
+@Composable
+private fun TriggerIconField(
+    icon: String,
+    enabled: Boolean,
+    onCommit: (String) -> Unit,
+) {
+    var draft by remember(icon) { mutableStateOf(icon) }
+    OutlinedTextField(
+        value = draft,
+        onValueChange = { draft = it.take(MAX_TRIGGER_ICON_LENGTH) },
+        modifier = Modifier
+            .width(64.dp)
+            .onFocusChanged { state ->
+                if (!state.isFocused && draft.trim() != icon) onCommit(draft.trim())
+            },
+        singleLine = true,
+        enabled = enabled,
+    )
+}
+
+/** Sets/clears the emoji for a trigger key (blank clears the override). */
+private fun UserPreferences.withTriggerIcon(key: String, icon: String): UserPreferences =
+    copy(
+        triggerIcons = if (icon.isBlank()) triggerIcons - key else triggerIcons + (key to icon),
+    )
+
+// Emoji can span several UTF-16 units (e.g. family emoji); cap generously.
+private const val MAX_TRIGGER_ICON_LENGTH = 16

--- a/features/settings/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/settings/presentation/web/SettingsWebScreen.kt
+++ b/features/settings/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/settings/presentation/web/SettingsWebScreen.kt
@@ -653,8 +653,13 @@ private fun ManageTriggersPanelWeb(
             Div(attrs = { classes(SmokeWebStyles.helperText) }) { Text("Built-in") }
             SmokeTrigger.defaultOptions().forEach { option ->
                 val visible = option.key !in preferences.hiddenDefaultTriggers
-                Div(attrs = { attr("style", "display:flex;align-items:center;justify-content:space-between;gap:8px;") }) {
-                    Span { Text(option.label) }
+                Div(attrs = { attr("style", "display:flex;align-items:center;gap:10px;") }) {
+                    TriggerIconInputWeb(
+                        icon = preferences.triggerIcons[option.key] ?: option.icon.orEmpty(),
+                        enabled = !displayLoading,
+                        onCommit = { icon -> onChange(preferences.withTriggerIcon(option.key, icon)) },
+                    )
+                    Span(attrs = { attr("style", "flex:1;") }) { Text(option.label) }
                     GhostButton(
                         text = if (visible) "Hide" else "Show",
                         enabled = !displayLoading,
@@ -673,8 +678,13 @@ private fun ManageTriggersPanelWeb(
             if (preferences.customTriggers.isNotEmpty()) {
                 Div(attrs = { classes(SmokeWebStyles.helperText) }) { Text("Your tags") }
                 preferences.customTriggers.forEach { tag ->
-                    Div(attrs = { attr("style", "display:flex;align-items:center;justify-content:space-between;gap:8px;") }) {
-                        Span { Text(tag) }
+                    Div(attrs = { attr("style", "display:flex;align-items:center;gap:10px;") }) {
+                        TriggerIconInputWeb(
+                            icon = preferences.triggerIcons[tag].orEmpty(),
+                            enabled = !displayLoading,
+                            onCommit = { icon -> onChange(preferences.withTriggerIcon(tag, icon)) },
+                        )
+                        Span(attrs = { attr("style", "flex:1;") }) { Text(tag) }
                         GhostButton(
                             text = "Remove",
                             enabled = !displayLoading,
@@ -713,3 +723,45 @@ private fun ManageTriggersPanelWeb(
         }
     }
 }
+
+/** Small per-row editor for a trigger's emoji; commits on change (blur/enter). */
+@Composable
+private fun TriggerIconInputWeb(
+    icon: String,
+    enabled: Boolean,
+    onCommit: (String) -> Unit,
+) {
+    var draft by remember(icon) { mutableStateOf(icon) }
+    Input(
+        type = InputType.Text,
+        attrs = {
+            value(draft)
+            if (!enabled) disabled()
+            onInput { draft = it.value.take(MAX_TRIGGER_ICON_LENGTH) }
+            onChange {
+                val trimmed = draft.trim()
+                if (trimmed != icon) onCommit(trimmed)
+            }
+            attr("aria-label", "Trigger icon")
+            style {
+                property("width", "44px")
+                property("text-align", "center")
+                property("box-sizing", "border-box")
+                property("padding", "6px 4px")
+                property("background", "var(--sa-color-surface-strong)")
+                property("color", "var(--sa-color-onSurface)")
+                property("border", "1px solid var(--sa-color-outline)")
+                property("border-radius", "8px")
+            }
+        },
+    )
+}
+
+/** Sets/clears the emoji for a trigger key (blank clears the override). */
+private fun UserPreferences.withTriggerIcon(key: String, icon: String): UserPreferences =
+    copy(
+        triggerIcons = if (icon.isBlank()) triggerIcons - key else triggerIcons + (key to icon),
+    )
+
+// Emoji can span several UTF-16 units (e.g. family emoji); cap generously.
+private const val MAX_TRIGGER_ICON_LENGTH = 16

--- a/features/stats/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/stats/presentation/mvi/compose/StatsViewState.kt
+++ b/features/stats/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/stats/presentation/mvi/compose/StatsViewState.kt
@@ -10,9 +10,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.height
-import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -335,33 +339,75 @@ private fun TriggerBreakdownCard(stats: SmokeStats) {
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             } else {
-                val max = breakdown.first().count.coerceAtLeast(1)
-                breakdown.forEach { entry ->
-                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                        ) {
-                            Text(text = entry.label, style = MaterialTheme.typography.bodyMedium)
-                            Text(
-                                text = entry.count.toString(),
-                                style = MaterialTheme.typography.bodyMedium,
-                                fontWeight = FontWeight.Bold,
+                val total = breakdown.sumOf { it.count }.coerceAtLeast(1)
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Canvas(modifier = Modifier.size(140.dp)) {
+                        var startAngle = -90f
+                        breakdown.forEachIndexed { index, entry ->
+                            val sweep = entry.count.toFloat() / total * 360f
+                            drawArc(
+                                color = pieColors[index % pieColors.size],
+                                startAngle = startAngle,
+                                sweepAngle = sweep,
+                                useCenter = true,
                             )
+                            startAngle += sweep
                         }
-                        LinearProgressIndicator(
-                            progress = { entry.count.toFloat() / max },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(6.dp)
-                                .clip(RoundedCornerShape(999.dp)),
-                        )
+                    }
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        breakdown.forEachIndexed { index, entry ->
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Box(
+                                    modifier = Modifier
+                                        .size(10.dp)
+                                        .clip(CircleShape)
+                                        .background(pieColors[index % pieColors.size]),
+                                )
+                                Text(
+                                    text = entry.label,
+                                    modifier = Modifier.weight(1f),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                                Text(
+                                    text = "${entry.count} (${entry.count * 100 / total}%)",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    fontWeight = FontWeight.Bold,
+                                )
+                            }
+                        }
                     }
                 }
             }
         }
     }
 }
+
+// Teal ramp shared with the web pie so both platforms read the same.
+private val pieColors = listOf(
+    Color(0xFF006A6A),
+    Color(0xFF1D7B7B),
+    Color(0xFF3A8C8C),
+    Color(0xFF57A0A0),
+    Color(0xFF74B3B3),
+    Color(0xFF91C6C6),
+    Color(0xFFAED9D9),
+    Color(0xFF4A6363),
+    Color(0xFF6D8686),
+    Color(0xFF9AB0B0),
+)
 
 @Composable
 private fun SummaryCards(

--- a/features/stats/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/stats/presentation/web/StatsWebScreen.kt
+++ b/features/stats/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/stats/presentation/web/StatsWebScreen.kt
@@ -27,7 +27,6 @@ import org.jetbrains.compose.web.attributes.InputType
 import org.jetbrains.compose.web.attributes.disabled
 import org.jetbrains.compose.web.dom.Canvas
 import org.jetbrains.compose.web.dom.Div
-import org.jetbrains.compose.web.dom.Span
 import org.jetbrains.compose.web.dom.Input
 import org.jetbrains.compose.web.dom.Text
 
@@ -317,25 +316,82 @@ private fun TriggerBreakdownCardWeb(
                     Text("No tagged cigarettes in this period yet. Tag what each one was related to and the breakdown shows up here.")
                 }
             } else {
-                val max = breakdown.first().count.coerceAtLeast(1)
-                breakdown.forEach { entry ->
-                    Div(attrs = { attr("style", "display:flex;flex-direction:column;gap:4px;") }) {
-                        Div(attrs = { attr("style", "display:flex;justify-content:space-between;") }) {
-                            Span { Text(entry.label) }
-                            Span(attrs = { attr("style", "font-weight:700;") }) { Text(entry.count.toString()) }
-                        }
-                        Div(attrs = { attr("style", "height:6px;border-radius:999px;background:var(--sa-color-surface-strong);overflow:hidden;") }) {
-                            Div(attrs = {
-                                val pct = (entry.count * 100 / max)
-                                attr("style", "height:6px;width:$pct%;border-radius:999px;background:var(--sa-color-primary);")
-                            }) {}
-                        }
-                    }
+                Div(attrs = { attr("style", "max-width:420px;margin:0 auto;") }) {
+                    Canvas(attrs = {
+                        id(TRIGGER_PIE_CANVAS_ID)
+                        attr("width", "420")
+                        attr("height", "320")
+                    })
                 }
+                PieChartJs(
+                    canvasId = TRIGGER_PIE_CANVAS_ID,
+                    labels = breakdown.map { it.label },
+                    values = breakdown.map { it.count },
+                )
             }
         }
     }
 }
+
+private const val TRIGGER_PIE_CANVAS_ID = "trigger-breakdown-pie"
+
+@Composable
+private fun PieChartJs(
+    canvasId: String,
+    labels: List<String>,
+    values: List<Int>,
+) {
+    val chartHolder = remember { mutableStateOf<Chart?>(null) }
+
+    DisposableEffect(canvasId, labels, values) {
+        chartHolder.value?.destroy()
+
+        val ctx = canvas2dContext(canvasId)
+
+        val config = jsObject()
+        config["type"] = "pie"
+
+        val dataset = jsObject()
+        dataset["data"] = values.map { it as Number }.toTypedArray()
+        dataset["backgroundColor"] = PIE_COLORS
+        dataset["borderWidth"] = 1
+
+        val dataObj = jsObject()
+        dataObj["labels"] = labels.toTypedArray()
+        dataObj["datasets"] = arrayOf(dataset)
+        config["data"] = dataObj
+
+        val legend = jsObject()
+        legend["position"] = "right"
+        val plugins = jsObject()
+        plugins["legend"] = legend
+        val options = jsObject()
+        options["responsive"] = true
+        options["maintainAspectRatio"] = false
+        options["plugins"] = plugins
+        config["options"] = options
+
+        chartHolder.value = Chart(ctx, config)
+
+        onDispose {
+            chartHolder.value?.destroy()
+            chartHolder.value = null
+        }
+    }
+}
+
+private val PIE_COLORS = arrayOf(
+    "#006A6A",
+    "#1D7B7B",
+    "#3A8C8C",
+    "#57A0A0",
+    "#74B3B3",
+    "#91C6C6",
+    "#AED9D9",
+    "#4A6363",
+    "#6D8686",
+    "#9AB0B0",
+)
 
 private fun StatsPeriod.label(): String = when (this) {
     StatsPeriod.DAY -> "Day"

--- a/libraries/preferences/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesEntity.kt
+++ b/libraries/preferences/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesEntity.kt
@@ -17,6 +17,7 @@ data class UserPreferencesEntity(
     val activeGoalMetricValue: Double? = null,
     val customTriggers: List<String> = emptyList(),
     val hiddenDefaultTriggers: List<String> = emptyList(),
+    val triggerIcons: Map<String, String> = emptyMap(),
 ) {
     fun toDomain(): UserPreferences = UserPreferences(
         packPrice = packPrice,
@@ -33,6 +34,7 @@ data class UserPreferencesEntity(
         ),
         customTriggers = customTriggers,
         hiddenDefaultTriggers = hiddenDefaultTriggers.toSet(),
+        triggerIcons = triggerIcons,
     )
 
     companion object {
@@ -49,5 +51,6 @@ data class UserPreferencesEntity(
         const val ACTIVE_GOAL_METRIC_VALUE = "activeGoalMetricValue"
         const val CUSTOM_TRIGGERS = "customTriggers"
         const val HIDDEN_DEFAULT_TRIGGERS = "hiddenDefaultTriggers"
+        const val TRIGGER_ICONS = "triggerIcons"
     }
 }

--- a/libraries/preferences/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImpl.kt
+++ b/libraries/preferences/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImpl.kt
@@ -93,6 +93,7 @@ private fun UserPreferences.toFirestorePayload(): Map<String, Any?> =
         UserPreferencesEntity.ACTIVE_GOAL_METRIC_VALUE to activeGoal?.metricValue,
         UserPreferencesEntity.CUSTOM_TRIGGERS to customTriggers,
         UserPreferencesEntity.HIDDEN_DEFAULT_TRIGGERS to hiddenDefaultTriggers.toList(),
+        UserPreferencesEntity.TRIGGER_ICONS to triggerIcons,
     )
 
 private fun DocumentSnapshot.toUserPreferencesEntity(): UserPreferencesEntity? {
@@ -126,12 +127,17 @@ private fun DocumentSnapshot.toUserPreferencesEntity(): UserPreferencesEntity? {
         )?.toDouble(),
         customTriggers = stringListOrNull(UserPreferencesEntity.CUSTOM_TRIGGERS).orEmpty(),
         hiddenDefaultTriggers = stringListOrNull(UserPreferencesEntity.HIDDEN_DEFAULT_TRIGGERS).orEmpty(),
+        triggerIcons = stringMapOrNull(UserPreferencesEntity.TRIGGER_ICONS).orEmpty(),
     )
 }
 
 @Suppress("UNCHECKED_CAST")
 private fun DocumentSnapshot.stringListOrNull(field: String): List<String>? =
     runCatching { get(field) as? List<String> }.getOrNull()
+
+@Suppress("UNCHECKED_CAST")
+private fun DocumentSnapshot.stringMapOrNull(field: String): Map<String, String>? =
+    runCatching { get(field) as? Map<String, String> }.getOrNull()
 
 private object LegacyUserPreferencesFields {
     const val PACK_PRICE = "a"

--- a/libraries/preferences/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesEntity.kt
+++ b/libraries/preferences/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesEntity.kt
@@ -19,6 +19,7 @@ data class UserPreferencesEntity(
     val activeGoalMetricValue: Double? = null,
     val customTriggers: List<String> = emptyList(),
     val hiddenDefaultTriggers: List<String> = emptyList(),
+    val triggerIcons: Map<String, String> = emptyMap(),
 ) {
     fun toDomain(): UserPreferences = UserPreferences(
         packPrice = packPrice,
@@ -35,6 +36,7 @@ data class UserPreferencesEntity(
         ),
         customTriggers = customTriggers,
         hiddenDefaultTriggers = hiddenDefaultTriggers.toSet(),
+        triggerIcons = triggerIcons,
     )
 
     companion object {
@@ -51,5 +53,6 @@ data class UserPreferencesEntity(
         const val ACTIVE_GOAL_METRIC_VALUE = "activeGoalMetricValue"
         const val CUSTOM_TRIGGERS = "customTriggers"
         const val HIDDEN_DEFAULT_TRIGGERS = "hiddenDefaultTriggers"
+        const val TRIGGER_ICONS = "triggerIcons"
     }
 }

--- a/libraries/preferences/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImpl.kt
+++ b/libraries/preferences/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImpl.kt
@@ -34,6 +34,7 @@ class UserPreferencesRepositoryImpl(
                 activeGoalMetricValue = preferences.activeGoal?.metricValue,
                 customTriggers = preferences.customTriggers,
                 hiddenDefaultTriggers = preferences.hiddenDefaultTriggers.toList(),
+                triggerIcons = preferences.triggerIcons,
             )
         )
     }
@@ -60,6 +61,7 @@ private fun DocumentSnapshot.toUserPreferencesEntity(): UserPreferencesEntity? {
         activeGoalMetricValue = numberOrNull(UserPreferencesEntity.ACTIVE_GOAL_METRIC_VALUE)?.toDouble(),
         customTriggers = getOrNull<List<String>>(UserPreferencesEntity.CUSTOM_TRIGGERS).orEmpty(),
         hiddenDefaultTriggers = getOrNull<List<String>>(UserPreferencesEntity.HIDDEN_DEFAULT_TRIGGERS).orEmpty(),
+        triggerIcons = getOrNull<Map<String, String>>(UserPreferencesEntity.TRIGGER_ICONS).orEmpty(),
     )
 }
 

--- a/libraries/preferences/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/domain/UserPreferences.kt
+++ b/libraries/preferences/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/domain/UserPreferences.kt
@@ -14,6 +14,8 @@ data class UserPreferences(
     val customTriggers: List<String> = emptyList(),
     /** Built-in trigger keys the user hid from the prompt. */
     val hiddenDefaultTriggers: Set<String> = emptySet(),
+    /** Emoji per trigger key: overrides a built-in's default icon or gives a custom tag one. */
+    val triggerIcons: Map<String, String> = emptyMap(),
 ) {
     val cigarettePrice: Double
         get() = if (cigarettesPerPack > 0) packPrice / cigarettesPerPack else 0.0

--- a/libraries/smokes/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImpl.kt
+++ b/libraries/smokes/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImpl.kt
@@ -72,7 +72,10 @@ class SmokeRepositoryImpl constructor(
             val document = smokesQuery().document(id)
             // Default source: server when online, local cache when offline.
             val preservedLocation = location ?: document.get().await().getGeoPoint()
-            document.set(smokePayload(date, preservedLocation))
+            // Merge so the relationship fields survive: the async location attach after an
+            // add runs seconds later and a full set() here was wiping a tag/skip the user
+            // had already saved, putting the smoke back in the reminder card.
+            document.set(smokePayload(date, preservedLocation), SetOptions.merge())
         }
     }
 

--- a/libraries/smokes/data/mobile/src/test/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImplTest.kt
+++ b/libraries/smokes/data/mobile/src/test/java/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImplTest.kt
@@ -201,7 +201,8 @@ class SmokeRepositoryImplTest {
             every { documentRef.path } returns "$USERS/$uid/$SMOKES/$id"
             every { documentRef.get() } answers { taskOf(mockDocumentSnapshot(id, date)) }
 
-            every { documentRef.set(any<Map<String, Any?>>()) } answers {
+            // editSmoke merges (relationship fields must survive), so it's the 2-arg set.
+            every { documentRef.set(any<Map<String, Any?>>(), any()) } answers {
                 mockk<Task<Void>>().apply {
                     every { isComplete } returns true
                     every { isSuccessful } returns true

--- a/libraries/smokes/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImpl.kt
+++ b/libraries/smokes/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/data/SmokeRepositoryImpl.kt
@@ -85,10 +85,11 @@ class SmokeRepositoryImpl(
      * @see SmokeRepository.editSmoke
      */
     override suspend fun editSmoke(id: String, date: Instant, location: GeoPoint?) {
-        val preservedLocation = location ?: smokesCollection()
-            .document(id)
-            .get()
-            .getGeoPoint()
+        // Always read the existing doc: besides preserving the location when none is given,
+        // the relationship fields must survive an edit (a full set() without them was wiping
+        // a tag/skip the user had already saved).
+        val snapshot = smokesCollection().document(id).get()
+        val preservedLocation = location ?: snapshot.getGeoPoint()
 
         smokesCollection()
             .document(id)
@@ -97,6 +98,9 @@ class SmokeRepositoryImpl(
                     timestampMillis = date.toEpochMilliseconds().toDouble(),
                     latitude = preservedLocation?.latitude,
                     longitude = preservedLocation?.longitude,
+                    triggers = snapshot.getOrNull<List<String>>(SmokeEntity.Fields.TRIGGERS),
+                    triggerNote = snapshot.getOrNull<String>(SmokeEntity.Fields.TRIGGER_NOTE),
+                    relationshipSkipped = snapshot.getOrNull<Boolean>(SmokeEntity.Fields.RELATIONSHIP_SKIPPED),
                 )
             )
     }

--- a/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeTrigger.kt
+++ b/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeTrigger.kt
@@ -2,27 +2,32 @@ package com.feragusper.smokeanalytics.libraries.smokes.domain.model
 
 /**
  * The built-in seed catalog of smoke triggers. Tags are persisted and selected as plain
- * string keys (see [SmokeRelationship.Tagged]); this enum only provides the default keys
- * and their display labels, on top of which users add their own custom tags.
+ * string keys (see [SmokeRelationship.Tagged]); this enum only provides the default keys,
+ * display labels and icons, on top of which users add their own custom tags.
+ *
+ * Icons are emoji strings: they render identically on Android and web, persist as plain
+ * text, and stay user-editable (see `UserPreferences.triggerIcons`).
  *
  * [key] is the stable string stored in Firestore — never rename a key without a migration.
  */
-enum class SmokeTrigger(val key: String, val defaultLabel: String) {
-    COFFEE("coffee", "Coffee"),
-    ALCOHOL("alcohol", "Alcohol"),
-    BOREDOM("boredom", "Boredom"),
-    ANXIETY("anxiety", "Anxiety"),
-    STRESS("stress", "Stress"),
-    AFTER_MEAL("after_meal", "After a meal"),
-    SOCIAL("social", "Social"),
-    BREAK("break", "Break"),
-    DRIVING("driving", "Driving"),
-    PHONE("phone", "Phone");
+enum class SmokeTrigger(val key: String, val defaultLabel: String, val defaultIcon: String) {
+    COFFEE("coffee", "Coffee", "☕"),
+    ALCOHOL("alcohol", "Alcohol", "🍺"),
+    BOREDOM("boredom", "Boredom", "🥱"),
+    ANXIETY("anxiety", "Anxiety", "😰"),
+    STRESS("stress", "Stress", "😖"),
+    AFTER_MEAL("after_meal", "After a meal", "🍽️"),
+    SOCIAL("social", "Social", "👥"),
+    BREAK("break", "Break", "⏸️"),
+    DRIVING("driving", "Driving", "🚗"),
+    PHONE("phone", "Phone", "📱");
 
     companion object {
         /** Default trigger options, in declaration order. */
         fun defaultOptions(): List<TriggerOption> =
-            entries.map { TriggerOption(key = it.key, label = it.defaultLabel, isCustom = false) }
+            entries.map {
+                TriggerOption(key = it.key, label = it.defaultLabel, isCustom = false, icon = it.defaultIcon)
+            }
 
         /** Display label for a persisted tag key: a default label if known, else the key itself. */
         fun labelFor(key: String): String =
@@ -30,20 +35,32 @@ enum class SmokeTrigger(val key: String, val defaultLabel: String) {
 
         /**
          * The selectable trigger catalog: visible defaults (minus [hiddenDefaultKeys]) plus the
-         * user's [customTriggers]. Pure function so it can be built from preferences without
-         * coupling the preferences module to this one.
+         * user's [customTriggers]. [iconOverrides] (tag key → emoji) replaces the default icon
+         * of built-ins and gives custom tags one. Pure function so it can be built from
+         * preferences without coupling the preferences module to this one.
          */
         fun catalog(
             customTriggers: List<String>,
             hiddenDefaultKeys: Set<String> = emptySet(),
+            iconOverrides: Map<String, String> = emptyMap(),
         ): List<TriggerOption> {
+            fun iconFor(key: String, default: String?): String? =
+                iconOverrides[key]?.trim()?.takeIf { it.isNotEmpty() } ?: default
+
             val defaults = entries
                 .filter { it.key !in hiddenDefaultKeys }
-                .map { TriggerOption(key = it.key, label = it.defaultLabel, isCustom = false) }
+                .map {
+                    TriggerOption(
+                        key = it.key,
+                        label = it.defaultLabel,
+                        isCustom = false,
+                        icon = iconFor(it.key, it.defaultIcon),
+                    )
+                }
             val custom = customTriggers
                 .mapNotNull { it.trim().takeIf(String::isNotEmpty) }
                 .distinct()
-                .map { TriggerOption(key = it, label = it, isCustom = true) }
+                .map { TriggerOption(key = it, label = it, isCustom = true, icon = iconFor(it, null)) }
             return defaults + custom
         }
     }
@@ -55,9 +72,14 @@ enum class SmokeTrigger(val key: String, val defaultLabel: String) {
  * @property key The persisted tag key (a [SmokeTrigger.key] for defaults, or the custom string).
  * @property label Human-readable label.
  * @property isCustom True for user-created tags (deletable), false for built-in defaults.
+ * @property icon Emoji shown alongside the label, or null when the tag has none.
  */
 data class TriggerOption(
     val key: String,
     val label: String,
     val isCustom: Boolean,
-)
+    val icon: String? = null,
+) {
+    /** Chip/list text: "☕ Coffee" when an icon is set, plain label otherwise. */
+    val display: String get() = icon?.let { "$it $label" } ?: label
+}

--- a/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeRelationshipMappingTest.kt
+++ b/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeRelationshipMappingTest.kt
@@ -83,4 +83,31 @@ class SmokeRelationshipMappingTest {
         assertEquals(false, catalog.any { it.key == "phone" })
         assertEquals(true, catalog.any { it.key == "Gaming" && it.isCustom })
     }
+
+    @Test
+    fun `GIVEN icon overrides THEN they replace defaults and decorate custom tags`() {
+        val catalog = SmokeTrigger.catalog(
+            customTriggers = listOf("Gaming"),
+            iconOverrides = mapOf("coffee" to "🔥", "Gaming" to "🎮", "boredom" to "  "),
+        )
+        // Override replaces the built-in default icon.
+        assertEquals("🔥", catalog.first { it.key == "coffee" }.icon)
+        // Blank override falls back to the default icon.
+        assertEquals(SmokeTrigger.BOREDOM.defaultIcon, catalog.first { it.key == "boredom" }.icon)
+        // Untouched built-ins keep their default; custom tags get theirs from the override.
+        assertEquals(SmokeTrigger.ALCOHOL.defaultIcon, catalog.first { it.key == "alcohol" }.icon)
+        assertEquals("🎮", catalog.first { it.key == "Gaming" }.icon)
+    }
+
+    @Test
+    fun `GIVEN an option THEN display prefixes the icon when present`() {
+        assertEquals(
+            "🎮 Gaming",
+            TriggerOption(key = "Gaming", label = "Gaming", isCustom = true, icon = "🎮").display,
+        )
+        assertEquals(
+            "Gaming",
+            TriggerOption(key = "Gaming", label = "Gaming", isCustom = true, icon = null).display,
+        )
+    }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-product.version=1.0.4
+product.version=1.1.0

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-product.version=1.0.3
+product.version=1.0.4


### PR DESCRIPTION
## Release 1.1.0 — minor

Features + stabilization on top of 1.0.3.

Derived versions:
- **Android:** `1.1.0.<gitCode>`
- **Web:** `1.1.0+web.<gitCode>`

### Changes
- **feat(smokes): emoji icons on trigger tags, editable per tag** — built-ins get default emoji (☕ 🍺 🥱 …) shown in the prompt chips; Settings → Manage triggers lets you type any emoji per tag (built-in or custom), blank restores the default. Persisted in preferences, mobile + web.
- **feat(stats): trigger breakdown as a pie chart** — the "By trigger" analytics card now renders a pie (Compose Canvas on mobile with a legend incl. counts and share %; Chart.js pie on web), replacing the ranked bar list.
- **fix(home): relationship sheet went blank when the keyboard opened** — single native inset pass; sheet shrinks, content scrolls, focused field auto-scrolls into view.
- **fix(home): no loading behind the relationship prompt** — silent refetch after add/save/skip instead of the full loading skeleton. Mobile + web.
- **fix(home): stable tag chips in the prompt** — catalog frozen when the dialog opens (no mid-dialog pop-in); loading indicator until it's available. Mobile + web.
- **fix(smokes): "No relation" (and tags) no longer get wiped** — `editSmoke` now preserves relationship fields, so the async location attach can't erase a just-saved tag/skip.

After merge: deploy mobile + web from `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)