### PR TITLE
Release: 1.2.0 — trigger management & pie share %

### DIFF
--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/process/HomeProcessHolder.kt
@@ -238,6 +238,7 @@ class HomeProcessHolder constructor(
                             customTriggers = preferences.customTriggers,
                             hiddenDefaultKeys = preferences.hiddenDefaultTriggers,
                             iconOverrides = preferences.triggerIcons,
+                            labelOverrides = preferences.triggerLabels,
                         ),
                     )
                 )

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/process/HomeProcessHolder.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/process/HomeProcessHolder.kt
@@ -230,6 +230,7 @@ class HomeProcessHolder(
                                 customTriggers = preferences.customTriggers,
                                 hiddenDefaultKeys = preferences.hiddenDefaultTriggers,
                                 iconOverrides = preferences.triggerIcons,
+                                labelOverrides = preferences.triggerLabels,
                             ),
                         )
                     )

--- a/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/mvi/compose/SettingsViewState.kt
+++ b/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/mvi/compose/SettingsViewState.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -18,7 +20,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -50,7 +51,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.testTag
@@ -68,6 +68,7 @@ import com.feragusper.smokeanalytics.libraries.design.compose.theme.SmokeAnalyti
 import com.feragusper.smokeanalytics.libraries.preferences.domain.AccountTier
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeTrigger
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.TriggerEmojiPalette
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.normalizedTag
 import com.valentinilk.shimmer.shimmer
 
@@ -1160,7 +1161,7 @@ private fun ManageTriggersSection(
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                TriggerIconField(
+                TriggerIconPicker(
                     icon = preferences.triggerIcons[option.key] ?: option.icon.orEmpty(),
                     enabled = enabled,
                     onCommit = { icon -> onChange(preferences.withTriggerIcon(option.key, icon)) },
@@ -1193,7 +1194,7 @@ private fun ManageTriggersSection(
                     horizontalArrangement = Arrangement.spacedBy(10.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    TriggerIconField(
+                    TriggerIconPicker(
                         icon = preferences.triggerIcons[tag].orEmpty(),
                         enabled = enabled,
                         onCommit = { icon -> onChange(preferences.withTriggerIcon(tag, icon)) },
@@ -1228,25 +1229,59 @@ private fun ManageTriggersSection(
     }
 }
 
-/** Small per-row editor for a trigger's emoji; commits when the field loses focus. */
+/** Per-row emoji picker for a trigger: tap the icon, choose from a curated grid. */
 @Composable
-private fun TriggerIconField(
+private fun TriggerIconPicker(
     icon: String,
     enabled: Boolean,
     onCommit: (String) -> Unit,
 ) {
-    var draft by remember(icon) { mutableStateOf(icon) }
-    OutlinedTextField(
-        value = draft,
-        onValueChange = { draft = it.take(MAX_TRIGGER_ICON_LENGTH) },
-        modifier = Modifier
-            .width(64.dp)
-            .onFocusChanged { state ->
-                if (!state.isFocused && draft.trim() != icon) onCommit(draft.trim())
+    var open by remember { mutableStateOf(false) }
+    TextButton(onClick = { open = true }, enabled = enabled) {
+        Text(
+            text = icon.ifBlank { "＋" },
+            style = MaterialTheme.typography.titleLarge,
+        )
+    }
+    if (open) {
+        AlertDialog(
+            onDismissRequest = { open = false },
+            title = { Text("Pick an icon") },
+            text = {
+                FlowRow(
+                    modifier = Modifier
+                        .heightIn(max = 320.dp)
+                        .verticalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    TriggerEmojiPalette.forEach { emoji ->
+                        Text(
+                            text = emoji,
+                            modifier = Modifier
+                                .clip(CircleShape)
+                                .clickable {
+                                    onCommit(emoji)
+                                    open = false
+                                }
+                                .padding(10.dp),
+                            style = MaterialTheme.typography.titleLarge,
+                        )
+                    }
+                }
             },
-        singleLine = true,
-        enabled = enabled,
-    )
+            confirmButton = {
+                // Clears the override: built-ins fall back to their default icon.
+                TextButton(onClick = {
+                    onCommit("")
+                    open = false
+                }) { Text("Reset") }
+            },
+            dismissButton = {
+                TextButton(onClick = { open = false }) { Text("Cancel") }
+            },
+        )
+    }
 }
 
 /** Sets/clears the emoji for a trigger key (blank clears the override). */
@@ -1254,6 +1289,3 @@ private fun UserPreferences.withTriggerIcon(key: String, icon: String): UserPref
     copy(
         triggerIcons = if (icon.isBlank()) triggerIcons - key else triggerIcons + (key to icon),
     )
-
-// Emoji can span several UTF-16 units (e.g. family emoji); cap generously.
-private const val MAX_TRIGGER_ICON_LENGTH = 16

--- a/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/mvi/compose/SettingsViewState.kt
+++ b/features/settings/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/settings/presentation/mvi/compose/SettingsViewState.kt
@@ -1154,32 +1154,27 @@ private fun ManageTriggersSection(
             style = MaterialTheme.typography.labelMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        SmokeTrigger.defaultOptions().forEach { option ->
-            val visible = option.key !in preferences.hiddenDefaultTriggers
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                TriggerIconPicker(
+        SmokeTrigger.defaultOptions()
+            .filter { it.key !in preferences.hiddenDefaultTriggers }
+            .forEach { option ->
+                TriggerRow(
                     icon = preferences.triggerIcons[option.key] ?: option.icon.orEmpty(),
+                    label = preferences.triggerLabels[option.key] ?: option.label,
                     enabled = enabled,
-                    onCommit = { icon -> onChange(preferences.withTriggerIcon(option.key, icon)) },
-                )
-                Text(text = option.label, modifier = Modifier.weight(1f))
-                Switch(
-                    checked = visible,
-                    enabled = enabled,
-                    onCheckedChange = { checked ->
-                        val hidden = if (checked) {
-                            preferences.hiddenDefaultTriggers - option.key
-                        } else {
-                            preferences.hiddenDefaultTriggers + option.key
-                        }
-                        onChange(preferences.copy(hiddenDefaultTriggers = hidden))
+                    onIconCommit = { icon -> onChange(preferences.withTriggerIcon(option.key, icon)) },
+                    onRename = { name -> onChange(preferences.withTriggerLabel(option.key, name)) },
+                    onRemove = {
+                        onChange(
+                            preferences.copy(hiddenDefaultTriggers = preferences.hiddenDefaultTriggers + option.key),
+                        )
                     },
                 )
             }
+        if (preferences.hiddenDefaultTriggers.isNotEmpty()) {
+            TextButton(
+                onClick = { onChange(preferences.copy(hiddenDefaultTriggers = emptySet())) },
+                enabled = enabled,
+            ) { Text("Restore removed defaults (${preferences.hiddenDefaultTriggers.size})") }
         }
 
         if (preferences.customTriggers.isNotEmpty()) {
@@ -1189,22 +1184,14 @@ private fun ManageTriggersSection(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             preferences.customTriggers.forEach { tag ->
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(10.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    TriggerIconPicker(
-                        icon = preferences.triggerIcons[tag].orEmpty(),
-                        enabled = enabled,
-                        onCommit = { icon -> onChange(preferences.withTriggerIcon(tag, icon)) },
-                    )
-                    Text(text = tag, modifier = Modifier.weight(1f))
-                    TextButton(
-                        onClick = { onChange(preferences.copy(customTriggers = preferences.customTriggers - tag)) },
-                        enabled = enabled,
-                    ) { Text("Remove") }
-                }
+                TriggerRow(
+                    icon = preferences.triggerIcons[tag].orEmpty(),
+                    label = preferences.triggerLabels[tag] ?: tag,
+                    enabled = enabled,
+                    onIconCommit = { icon -> onChange(preferences.withTriggerIcon(tag, icon)) },
+                    onRename = { name -> onChange(preferences.withTriggerLabel(tag, name)) },
+                    onRemove = { onChange(preferences.copy(customTriggers = preferences.customTriggers - tag)) },
+                )
             }
         }
 
@@ -1224,6 +1211,54 @@ private fun ManageTriggersSection(
                         draft = ""
                     }) { Text("Add") }
                 }
+            },
+        )
+    }
+}
+
+/** One trigger row: icon picker, (renamable) label, rename and remove actions. */
+@Composable
+private fun TriggerRow(
+    icon: String,
+    label: String,
+    enabled: Boolean,
+    onIconCommit: (String) -> Unit,
+    onRename: (String) -> Unit,
+    onRemove: () -> Unit,
+) {
+    var renaming by remember { mutableStateOf(false) }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        TriggerIconPicker(icon = icon, enabled = enabled, onCommit = onIconCommit)
+        Text(text = label, modifier = Modifier.weight(1f))
+        TextButton(onClick = { renaming = true }, enabled = enabled) { Text("Rename") }
+        TextButton(onClick = onRemove, enabled = enabled) { Text("Remove") }
+    }
+    if (renaming) {
+        var draft by remember { mutableStateOf(label) }
+        AlertDialog(
+            onDismissRequest = { renaming = false },
+            title = { Text("Rename trigger") },
+            text = {
+                OutlinedTextField(
+                    value = draft,
+                    onValueChange = { draft = it },
+                    singleLine = true,
+                    label = { Text("Name") },
+                    supportingText = { Text("Leave empty to restore the original name.") },
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    onRename(draft.trim())
+                    renaming = false
+                }) { Text("Save") }
+            },
+            dismissButton = {
+                TextButton(onClick = { renaming = false }) { Text("Cancel") }
             },
         )
     }
@@ -1288,4 +1323,10 @@ private fun TriggerIconPicker(
 private fun UserPreferences.withTriggerIcon(key: String, icon: String): UserPreferences =
     copy(
         triggerIcons = if (icon.isBlank()) triggerIcons - key else triggerIcons + (key to icon),
+    )
+
+/** Renames a trigger without touching the key stored on smokes (blank clears the override). */
+private fun UserPreferences.withTriggerLabel(key: String, label: String): UserPreferences =
+    copy(
+        triggerLabels = if (label.isBlank()) triggerLabels - key else triggerLabels + (key to label),
     )

--- a/features/settings/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/settings/presentation/web/SettingsWebScreen.kt
+++ b/features/settings/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/settings/presentation/web/SettingsWebScreen.kt
@@ -653,46 +653,41 @@ private fun ManageTriggersPanelWeb(
     SurfaceCard {
         Div(attrs = { attr("style", "display:flex;flex-direction:column;gap:12px;") }) {
             Div(attrs = { classes(SmokeWebStyles.helperText) }) { Text("Built-in") }
-            SmokeTrigger.defaultOptions().forEach { option ->
-                val visible = option.key !in preferences.hiddenDefaultTriggers
-                Div(attrs = { attr("style", "display:flex;align-items:center;gap:10px;") }) {
-                    TriggerIconInputWeb(
+            SmokeTrigger.defaultOptions()
+                .filter { it.key !in preferences.hiddenDefaultTriggers }
+                .forEach { option ->
+                    TriggerRowWeb(
                         icon = preferences.triggerIcons[option.key] ?: option.icon.orEmpty(),
+                        label = preferences.triggerLabels[option.key] ?: option.label,
                         enabled = !displayLoading,
-                        onCommit = { icon -> onChange(preferences.withTriggerIcon(option.key, icon)) },
-                    )
-                    Span(attrs = { attr("style", "flex:1;") }) { Text(option.label) }
-                    GhostButton(
-                        text = if (visible) "Hide" else "Show",
-                        enabled = !displayLoading,
-                        onClick = {
-                            val hidden = if (visible) {
-                                preferences.hiddenDefaultTriggers + option.key
-                            } else {
-                                preferences.hiddenDefaultTriggers - option.key
-                            }
-                            onChange(preferences.copy(hiddenDefaultTriggers = hidden))
+                        onIconCommit = { icon -> onChange(preferences.withTriggerIcon(option.key, icon)) },
+                        onRename = { name -> onChange(preferences.withTriggerLabel(option.key, name)) },
+                        onRemove = {
+                            onChange(
+                                preferences.copy(hiddenDefaultTriggers = preferences.hiddenDefaultTriggers + option.key),
+                            )
                         },
                     )
                 }
+            if (preferences.hiddenDefaultTriggers.isNotEmpty()) {
+                GhostButton(
+                    text = "Restore removed defaults (${preferences.hiddenDefaultTriggers.size})",
+                    enabled = !displayLoading,
+                    onClick = { onChange(preferences.copy(hiddenDefaultTriggers = emptySet())) },
+                )
             }
 
             if (preferences.customTriggers.isNotEmpty()) {
                 Div(attrs = { classes(SmokeWebStyles.helperText) }) { Text("Your tags") }
                 preferences.customTriggers.forEach { tag ->
-                    Div(attrs = { attr("style", "display:flex;align-items:center;gap:10px;") }) {
-                        TriggerIconInputWeb(
-                            icon = preferences.triggerIcons[tag].orEmpty(),
-                            enabled = !displayLoading,
-                            onCommit = { icon -> onChange(preferences.withTriggerIcon(tag, icon)) },
-                        )
-                        Span(attrs = { attr("style", "flex:1;") }) { Text(tag) }
-                        GhostButton(
-                            text = "Remove",
-                            enabled = !displayLoading,
-                            onClick = { onChange(preferences.copy(customTriggers = preferences.customTriggers - tag)) },
-                        )
-                    }
+                    TriggerRowWeb(
+                        icon = preferences.triggerIcons[tag].orEmpty(),
+                        label = preferences.triggerLabels[tag] ?: tag,
+                        enabled = !displayLoading,
+                        onIconCommit = { icon -> onChange(preferences.withTriggerIcon(tag, icon)) },
+                        onRename = { name -> onChange(preferences.withTriggerLabel(tag, name)) },
+                        onRemove = { onChange(preferences.copy(customTriggers = preferences.customTriggers - tag)) },
+                    )
                 }
             }
 
@@ -817,4 +812,60 @@ private fun TriggerIconInputWeb(
 private fun UserPreferences.withTriggerIcon(key: String, icon: String): UserPreferences =
     copy(
         triggerIcons = if (icon.isBlank()) triggerIcons - key else triggerIcons + (key to icon),
+    )
+
+/** One trigger row: icon picker, (renamable) label with inline edit, remove action. */
+@Composable
+private fun TriggerRowWeb(
+    icon: String,
+    label: String,
+    enabled: Boolean,
+    onIconCommit: (String) -> Unit,
+    onRename: (String) -> Unit,
+    onRemove: () -> Unit,
+) {
+    var renaming by remember { mutableStateOf(false) }
+    var draft by remember(label) { mutableStateOf(label) }
+
+    Div(attrs = { attr("style", "display:flex;align-items:center;gap:10px;") }) {
+        TriggerIconInputWeb(icon = icon, enabled = enabled, onCommit = onIconCommit)
+        if (renaming) {
+            Input(
+                type = InputType.Text,
+                attrs = {
+                    value(draft)
+                    onInput { draft = it.value }
+                    attr("placeholder", "Leave empty to restore the original name")
+                    style {
+                        property("flex", "1")
+                        property("box-sizing", "border-box")
+                        property("padding", "6px 8px")
+                        property("background", "var(--sa-color-surface-strong)")
+                        property("color", "var(--sa-color-onSurface)")
+                        property("border", "1px solid var(--sa-color-outline)")
+                        property("border-radius", "8px")
+                    }
+                },
+            )
+            PrimaryButton(
+                text = "Save",
+                enabled = enabled,
+                onClick = {
+                    onRename(draft.trim())
+                    renaming = false
+                },
+            )
+            GhostButton(text = "Cancel", onClick = { renaming = false })
+        } else {
+            Span(attrs = { attr("style", "flex:1;") }) { Text(label) }
+            GhostButton(text = "Rename", enabled = enabled, onClick = { renaming = true })
+            GhostButton(text = "Remove", enabled = enabled, onClick = onRemove)
+        }
+    }
+}
+
+/** Renames a trigger without touching the key stored on smokes (blank clears the override). */
+private fun UserPreferences.withTriggerLabel(key: String, label: String): UserPreferences =
+    copy(
+        triggerLabels = if (label.isBlank()) triggerLabels - key else triggerLabels + (key to label),
     )

--- a/features/settings/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/settings/presentation/web/SettingsWebScreen.kt
+++ b/features/settings/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/settings/presentation/web/SettingsWebScreen.kt
@@ -19,7 +19,9 @@ import com.feragusper.smokeanalytics.libraries.design.SmokeWebStyles
 import com.feragusper.smokeanalytics.libraries.design.SurfaceCard
 import com.feragusper.smokeanalytics.libraries.preferences.domain.UserPreferences
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.SmokeTrigger
+import com.feragusper.smokeanalytics.libraries.smokes.domain.model.TriggerEmojiPalette
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.normalizedTag
+import org.jetbrains.compose.web.dom.Button
 import kotlinx.coroutines.launch
 import kotlin.math.abs
 import kotlin.math.roundToInt
@@ -731,30 +733,84 @@ private fun TriggerIconInputWeb(
     enabled: Boolean,
     onCommit: (String) -> Unit,
 ) {
-    var draft by remember(icon) { mutableStateOf(icon) }
-    Input(
-        type = InputType.Text,
-        attrs = {
-            value(draft)
-            if (!enabled) disabled()
-            onInput { draft = it.value.take(MAX_TRIGGER_ICON_LENGTH) }
-            onChange {
-                val trimmed = draft.trim()
-                if (trimmed != icon) onCommit(trimmed)
+    var open by remember { mutableStateOf(false) }
+
+    Div(attrs = { attr("style", "position:relative;") }) {
+        Button(
+            attrs = {
+                if (!enabled) disabled()
+                onClick { open = !open }
+                attr("aria-label", "Pick trigger icon")
+                style {
+                    property("width", "44px")
+                    property("height", "36px")
+                    property("text-align", "center")
+                    property("cursor", "pointer")
+                    property("font-size", "18px")
+                    property("background", "var(--sa-color-surface-strong)")
+                    property("color", "var(--sa-color-onSurface)")
+                    property("border", "1px solid var(--sa-color-outline)")
+                    property("border-radius", "8px")
+                }
             }
-            attr("aria-label", "Trigger icon")
-            style {
-                property("width", "44px")
-                property("text-align", "center")
-                property("box-sizing", "border-box")
-                property("padding", "6px 4px")
-                property("background", "var(--sa-color-surface-strong)")
-                property("color", "var(--sa-color-onSurface)")
-                property("border", "1px solid var(--sa-color-outline)")
-                property("border-radius", "8px")
+        ) { Text(icon.ifBlank { "＋" }) }
+
+        if (open) {
+            // Transparent backdrop: click anywhere outside closes the picker.
+            Div(attrs = {
+                attr("style", "position:fixed;inset:0;z-index:9998;")
+                onClick { open = false }
+            })
+            Div(attrs = {
+                attr(
+                    "style",
+                    "position:absolute;top:40px;left:0;z-index:9999;" +
+                        "background:var(--sa-color-surface);color:var(--sa-color-onSurface);" +
+                        "border:1px solid var(--sa-color-outline);border-radius:12px;" +
+                        "padding:10px;box-shadow:0 8px 24px rgba(0,0,0,0.25);" +
+                        "display:flex;flex-wrap:wrap;gap:4px;width:280px;max-height:240px;overflow-y:auto;",
+                )
+            }) {
+                TriggerEmojiPalette.forEach { emoji ->
+                    Button(
+                        attrs = {
+                            onClick {
+                                onCommit(emoji)
+                                open = false
+                            }
+                            style {
+                                property("font-size", "18px")
+                                property("padding", "6px")
+                                property("cursor", "pointer")
+                                property("background", "transparent")
+                                property("border", "none")
+                                property("border-radius", "8px")
+                            }
+                        }
+                    ) { Text(emoji) }
+                }
+                Button(
+                    attrs = {
+                        onClick {
+                            // Clears the override: built-ins fall back to their default icon.
+                            onCommit("")
+                            open = false
+                        }
+                        style {
+                            property("width", "100%")
+                            property("margin-top", "6px")
+                            property("padding", "6px")
+                            property("cursor", "pointer")
+                            property("background", "transparent")
+                            property("color", "var(--sa-color-primary)")
+                            property("border", "1px solid var(--sa-color-outline)")
+                            property("border-radius", "8px")
+                        }
+                    }
+                ) { Text("Reset") }
             }
-        },
-    )
+        }
+    }
 }
 
 /** Sets/clears the emoji for a trigger key (blank clears the override). */
@@ -762,6 +818,3 @@ private fun UserPreferences.withTriggerIcon(key: String, icon: String): UserPref
     copy(
         triggerIcons = if (icon.isBlank()) triggerIcons - key else triggerIcons + (key to icon),
     )
-
-// Emoji can span several UTF-16 units (e.g. family emoji); cap generously.
-private const val MAX_TRIGGER_ICON_LENGTH = 16

--- a/features/stats/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/stats/presentation/mvi/compose/StatsViewState.kt
+++ b/features/stats/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/stats/presentation/mvi/compose/StatsViewState.kt
@@ -15,8 +15,19 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.sp
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.roundToInt
+import kotlin.math.sin
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -345,16 +356,39 @@ private fun TriggerBreakdownCard(stats: SmokeStats) {
                     horizontalArrangement = Arrangement.spacedBy(16.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
+                    val textMeasurer = rememberTextMeasurer()
                     Canvas(modifier = Modifier.size(140.dp)) {
                         var startAngle = -90f
                         breakdown.forEachIndexed { index, entry ->
                             val sweep = entry.count.toFloat() / total * 360f
+                            val sliceColor = pieColors[index % pieColors.size]
                             drawArc(
-                                color = pieColors[index % pieColors.size],
+                                color = sliceColor,
                                 startAngle = startAngle,
                                 sweepAngle = sweep,
                                 useCenter = true,
                             )
+                            // Print the share on slices wide enough to fit the label.
+                            if (sweep >= 30f) {
+                                val midRad = (startAngle + sweep / 2f) * (PI.toFloat() / 180f)
+                                val radius = size.minDimension / 2f * 0.62f
+                                val pct = (entry.count * 100f / total).roundToInt()
+                                val layout = textMeasurer.measure(
+                                    text = AnnotatedString("$pct%"),
+                                    style = TextStyle(
+                                        fontSize = 11.sp,
+                                        fontWeight = FontWeight.Bold,
+                                        color = if (sliceColor.luminance() > 0.5f) Color(0xFF10343A) else Color.White,
+                                    ),
+                                )
+                                drawText(
+                                    textLayoutResult = layout,
+                                    topLeft = Offset(
+                                        center.x + radius * cos(midRad) - layout.size.width / 2f,
+                                        center.y + radius * sin(midRad) - layout.size.height / 2f,
+                                    ),
+                                )
+                            }
                             startAngle += sweep
                         }
                     }

--- a/features/stats/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/stats/presentation/process/StatsProcessHolder.kt
+++ b/features/stats/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/stats/presentation/process/StatsProcessHolder.kt
@@ -73,6 +73,7 @@ class StatsProcessHolder constructor(
             periodType = period,
             dayStartHour = preferences.dayStartHour,
             bedtimeHour = preferences.bedtimeHour,
+            triggerLabelOverrides = preferences.triggerLabels,
         )
 
         // Emit the success result with the fetched statistics

--- a/features/stats/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/stats/presentation/web/StatsWebScreen.kt
+++ b/features/stats/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/stats/presentation/web/StatsWebScreen.kt
@@ -323,9 +323,11 @@ private fun TriggerBreakdownCardWeb(
                         attr("height", "320")
                     })
                 }
+                val total = breakdown.sumOf { it.count }.coerceAtLeast(1)
                 PieChartJs(
                     canvasId = TRIGGER_PIE_CANVAS_ID,
-                    labels = breakdown.map { it.label },
+                    // Bake the share into the legend label so every slice's % is visible.
+                    labels = breakdown.map { "${it.label} — ${it.count * 100 / total}%" },
                     values = breakdown.map { it.count },
                 )
             }

--- a/features/stats/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/stats/presentation/web/process/StatsProcessHolder.kt
+++ b/features/stats/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/stats/presentation/web/process/StatsProcessHolder.kt
@@ -27,6 +27,7 @@ class StatsProcessHolder(
             periodType = intent.period,
             dayStartHour = preferences.dayStartHour,
             bedtimeHour = preferences.bedtimeHour,
+            triggerLabelOverrides = preferences.triggerLabels,
         )
         emit(StatsResult.Success(stats))
     }.catch { e ->

--- a/libraries/preferences/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesEntity.kt
+++ b/libraries/preferences/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesEntity.kt
@@ -18,6 +18,7 @@ data class UserPreferencesEntity(
     val customTriggers: List<String> = emptyList(),
     val hiddenDefaultTriggers: List<String> = emptyList(),
     val triggerIcons: Map<String, String> = emptyMap(),
+    val triggerLabels: Map<String, String> = emptyMap(),
 ) {
     fun toDomain(): UserPreferences = UserPreferences(
         packPrice = packPrice,
@@ -35,6 +36,7 @@ data class UserPreferencesEntity(
         customTriggers = customTriggers,
         hiddenDefaultTriggers = hiddenDefaultTriggers.toSet(),
         triggerIcons = triggerIcons,
+        triggerLabels = triggerLabels,
     )
 
     companion object {
@@ -52,5 +54,6 @@ data class UserPreferencesEntity(
         const val CUSTOM_TRIGGERS = "customTriggers"
         const val HIDDEN_DEFAULT_TRIGGERS = "hiddenDefaultTriggers"
         const val TRIGGER_ICONS = "triggerIcons"
+        const val TRIGGER_LABELS = "triggerLabels"
     }
 }

--- a/libraries/preferences/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImpl.kt
+++ b/libraries/preferences/data/mobile/src/main/java/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImpl.kt
@@ -94,6 +94,7 @@ private fun UserPreferences.toFirestorePayload(): Map<String, Any?> =
         UserPreferencesEntity.CUSTOM_TRIGGERS to customTriggers,
         UserPreferencesEntity.HIDDEN_DEFAULT_TRIGGERS to hiddenDefaultTriggers.toList(),
         UserPreferencesEntity.TRIGGER_ICONS to triggerIcons,
+        UserPreferencesEntity.TRIGGER_LABELS to triggerLabels,
     )
 
 private fun DocumentSnapshot.toUserPreferencesEntity(): UserPreferencesEntity? {
@@ -128,6 +129,7 @@ private fun DocumentSnapshot.toUserPreferencesEntity(): UserPreferencesEntity? {
         customTriggers = stringListOrNull(UserPreferencesEntity.CUSTOM_TRIGGERS).orEmpty(),
         hiddenDefaultTriggers = stringListOrNull(UserPreferencesEntity.HIDDEN_DEFAULT_TRIGGERS).orEmpty(),
         triggerIcons = stringMapOrNull(UserPreferencesEntity.TRIGGER_ICONS).orEmpty(),
+        triggerLabels = stringMapOrNull(UserPreferencesEntity.TRIGGER_LABELS).orEmpty(),
     )
 }
 

--- a/libraries/preferences/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesEntity.kt
+++ b/libraries/preferences/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesEntity.kt
@@ -20,6 +20,7 @@ data class UserPreferencesEntity(
     val customTriggers: List<String> = emptyList(),
     val hiddenDefaultTriggers: List<String> = emptyList(),
     val triggerIcons: Map<String, String> = emptyMap(),
+    val triggerLabels: Map<String, String> = emptyMap(),
 ) {
     fun toDomain(): UserPreferences = UserPreferences(
         packPrice = packPrice,
@@ -37,6 +38,7 @@ data class UserPreferencesEntity(
         customTriggers = customTriggers,
         hiddenDefaultTriggers = hiddenDefaultTriggers.toSet(),
         triggerIcons = triggerIcons,
+        triggerLabels = triggerLabels,
     )
 
     companion object {
@@ -54,5 +56,6 @@ data class UserPreferencesEntity(
         const val CUSTOM_TRIGGERS = "customTriggers"
         const val HIDDEN_DEFAULT_TRIGGERS = "hiddenDefaultTriggers"
         const val TRIGGER_ICONS = "triggerIcons"
+        const val TRIGGER_LABELS = "triggerLabels"
     }
 }

--- a/libraries/preferences/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImpl.kt
+++ b/libraries/preferences/data/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/data/UserPreferencesRepositoryImpl.kt
@@ -35,6 +35,7 @@ class UserPreferencesRepositoryImpl(
                 customTriggers = preferences.customTriggers,
                 hiddenDefaultTriggers = preferences.hiddenDefaultTriggers.toList(),
                 triggerIcons = preferences.triggerIcons,
+                triggerLabels = preferences.triggerLabels,
             )
         )
     }
@@ -62,6 +63,7 @@ private fun DocumentSnapshot.toUserPreferencesEntity(): UserPreferencesEntity? {
         customTriggers = getOrNull<List<String>>(UserPreferencesEntity.CUSTOM_TRIGGERS).orEmpty(),
         hiddenDefaultTriggers = getOrNull<List<String>>(UserPreferencesEntity.HIDDEN_DEFAULT_TRIGGERS).orEmpty(),
         triggerIcons = getOrNull<Map<String, String>>(UserPreferencesEntity.TRIGGER_ICONS).orEmpty(),
+        triggerLabels = getOrNull<Map<String, String>>(UserPreferencesEntity.TRIGGER_LABELS).orEmpty(),
     )
 }
 

--- a/libraries/preferences/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/domain/UserPreferences.kt
+++ b/libraries/preferences/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/preferences/domain/UserPreferences.kt
@@ -16,6 +16,8 @@ data class UserPreferences(
     val hiddenDefaultTriggers: Set<String> = emptySet(),
     /** Emoji per trigger key: overrides a built-in's default icon or gives a custom tag one. */
     val triggerIcons: Map<String, String> = emptyMap(),
+    /** Display name per trigger key: renames a tag without changing the key stored on smokes. */
+    val triggerLabels: Map<String, String> = emptyMap(),
 ) {
     val cigarettePrice: Double
         get() = if (cigarettesPerPack > 0) packPrice / cigarettesPerPack else 0.0

--- a/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeStats.kt
+++ b/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeStats.kt
@@ -52,6 +52,7 @@ data class SmokeStats(
             dayStartHour: Int = 0,
             bedtimeHour: Int = 22,
             periodType: SelectionPeriod = SelectionPeriod.MONTH,
+            triggerLabelOverrides: Map<String, String> = emptyMap(),
         ): SmokeStats {
             val monthStart = LocalDate(year, month, 1)
             val nextMonthStart = monthStart.plus(DatePeriod(months = 1))
@@ -165,7 +166,14 @@ data class SmokeStats(
             }
             val triggerBreakdown = tagCounts.entries
                 .sortedByDescending { it.value }
-                .map { TriggerCount(key = it.key, label = SmokeTrigger.labelFor(it.key), count = it.value) }
+                .map {
+                    TriggerCount(
+                        key = it.key,
+                        label = triggerLabelOverrides[it.key]?.trim()?.takeIf(String::isNotEmpty)
+                            ?: SmokeTrigger.labelFor(it.key),
+                        count = it.value,
+                    )
+                }
 
             return SmokeStats(
                 daily = dailyStats,

--- a/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeTrigger.kt
+++ b/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeTrigger.kt
@@ -36,23 +36,29 @@ enum class SmokeTrigger(val key: String, val defaultLabel: String, val defaultIc
         /**
          * The selectable trigger catalog: visible defaults (minus [hiddenDefaultKeys]) plus the
          * user's [customTriggers]. [iconOverrides] (tag key → emoji) replaces the default icon
-         * of built-ins and gives custom tags one. Pure function so it can be built from
-         * preferences without coupling the preferences module to this one.
+         * of built-ins and gives custom tags one; [labelOverrides] (tag key → name) renames a
+         * tag without touching the key persisted on smokes, so history and analytics keep
+         * counting under the same key. Pure function so it can be built from preferences
+         * without coupling the preferences module to this one.
          */
         fun catalog(
             customTriggers: List<String>,
             hiddenDefaultKeys: Set<String> = emptySet(),
             iconOverrides: Map<String, String> = emptyMap(),
+            labelOverrides: Map<String, String> = emptyMap(),
         ): List<TriggerOption> {
             fun iconFor(key: String, default: String?): String? =
                 iconOverrides[key]?.trim()?.takeIf { it.isNotEmpty() } ?: default
+
+            fun labelFor(key: String, default: String): String =
+                labelOverrides[key]?.trim()?.takeIf { it.isNotEmpty() } ?: default
 
             val defaults = entries
                 .filter { it.key !in hiddenDefaultKeys }
                 .map {
                     TriggerOption(
                         key = it.key,
-                        label = it.defaultLabel,
+                        label = labelFor(it.key, it.defaultLabel),
                         isCustom = false,
                         icon = iconFor(it.key, it.defaultIcon),
                     )
@@ -60,7 +66,14 @@ enum class SmokeTrigger(val key: String, val defaultLabel: String, val defaultIc
             val custom = customTriggers
                 .mapNotNull { it.trim().takeIf(String::isNotEmpty) }
                 .distinct()
-                .map { TriggerOption(key = it, label = it, isCustom = true, icon = iconFor(it, null)) }
+                .map {
+                    TriggerOption(
+                        key = it,
+                        label = labelFor(it, it),
+                        isCustom = true,
+                        icon = iconFor(it, null),
+                    )
+                }
             return defaults + custom
         }
     }

--- a/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/TriggerEmojiPalette.kt
+++ b/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/TriggerEmojiPalette.kt
@@ -1,0 +1,18 @@
+package com.feragusper.smokeanalytics.libraries.smokes.domain.model
+
+/**
+ * Curated emoji options for the trigger icon picker (Settings → Manage triggers).
+ * Shared by mobile and web so both offer the same choices. Order matters: the
+ * built-in defaults come first, then common smoking-context emoji.
+ */
+val TriggerEmojiPalette: List<String> = listOf(
+    // Built-in defaults
+    "☕", "🍺", "🥱", "😰", "😖", "🍽️", "👥", "⏸️", "🚗", "📱",
+    // Drinks & food
+    "🍷", "🥃", "🧉", "🍔", "🍕", "🍰", "🫖",
+    // Moods
+    "😤", "😢", "😴", "🤯", "😡", "🥳", "😌", "🫠",
+    // Activities & places
+    "💼", "💻", "📺", "🎮", "🎵", "🏃", "🚶", "🛏️", "🚿", "🚌",
+    "🌧️", "☀️", "🌙", "⏰", "🎉", "🏠", "🏢", "📚", "☎️", "🧠",
+)

--- a/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/usecase/FetchSmokeStatsUseCase.kt
+++ b/libraries/smokes/domain/src/commonMain/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/usecase/FetchSmokeStatsUseCase.kt
@@ -21,6 +21,7 @@ class FetchSmokeStatsUseCase(
         periodType: PeriodType,
         dayStartHour: Int = 0,
         bedtimeHour: Int = 22,
+        triggerLabelOverrides: Map<String, String> = emptyMap(),
     ): SmokeStats {
         val (start, endExclusive) = when (periodType) {
             PeriodType.DAY -> {
@@ -72,6 +73,7 @@ class FetchSmokeStatsUseCase(
             dayStartHour = dayStartHour,
             bedtimeHour = bedtimeHour,
             periodType = periodType.toSmokeStatsPeriod(),
+            triggerLabelOverrides = triggerLabelOverrides,
         )
     }
 

--- a/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeRelationshipMappingTest.kt
+++ b/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeRelationshipMappingTest.kt
@@ -100,6 +100,19 @@ class SmokeRelationshipMappingTest {
     }
 
     @Test
+    fun `GIVEN label overrides THEN they rename built-ins and custom tags without changing keys`() {
+        val catalog = SmokeTrigger.catalog(
+            customTriggers = listOf("Gaming"),
+            labelOverrides = mapOf("coffee" to "Mate", "Gaming" to "Play", "boredom" to "  "),
+        )
+        assertEquals("Mate", catalog.first { it.key == "coffee" }.label)
+        assertEquals("Play", catalog.first { it.key == "Gaming" }.label)
+        // Blank override falls back to the original name; keys never change.
+        assertEquals(SmokeTrigger.BOREDOM.defaultLabel, catalog.first { it.key == "boredom" }.label)
+        assertEquals(true, catalog.any { it.key == "Gaming" })
+    }
+
+    @Test
     fun `GIVEN the emoji palette THEN it is distinct and covers every default icon`() {
         assertEquals(TriggerEmojiPalette.size, TriggerEmojiPalette.distinct().size)
         SmokeTrigger.entries.forEach { trigger ->

--- a/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeRelationshipMappingTest.kt
+++ b/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeRelationshipMappingTest.kt
@@ -100,6 +100,14 @@ class SmokeRelationshipMappingTest {
     }
 
     @Test
+    fun `GIVEN the emoji palette THEN it is distinct and covers every default icon`() {
+        assertEquals(TriggerEmojiPalette.size, TriggerEmojiPalette.distinct().size)
+        SmokeTrigger.entries.forEach { trigger ->
+            assertEquals(true, trigger.defaultIcon in TriggerEmojiPalette)
+        }
+    }
+
+    @Test
     fun `GIVEN an option THEN display prefixes the icon when present`() {
         assertEquals(
             "🎮 Gaming",

--- a/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeStatsTest.kt
+++ b/libraries/smokes/domain/src/commonTest/kotlin/com/feragusper/smokeanalytics/libraries/smokes/domain/model/SmokeStatsTest.kt
@@ -287,4 +287,24 @@ class SmokeStatsTest {
         assertEquals("Coffee", breakdown.first().label)
         assertEquals("my custom tag", breakdown.first { it.key == "my custom tag" }.label)
     }
+
+    @Test
+    fun `GIVEN label overrides WHEN from is called THEN the breakdown uses the renamed labels`() {
+        val smokes = listOf(
+            Smoke("1", Instant.parse("2023-03-01T10:00:00Z"), relationship = SmokeRelationship.Tagged(setOf("coffee"))),
+        )
+
+        val breakdown = SmokeStats.from(
+            smokes = smokes,
+            year = 2023,
+            month = 3,
+            day = null,
+            timeZone = tz,
+            now = Instant.parse("2023-03-31T00:00:00Z"),
+            triggerLabelOverrides = mapOf("coffee" to "Mate"),
+        ).triggerBreakdown
+
+        assertEquals("Mate", breakdown.first().label)
+        assertEquals("coffee", breakdown.first().key)
+    }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-product.version=1.1.1
+product.version=1.2.0

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-product.version=1.1.0
+product.version=1.1.1


### PR DESCRIPTION
## Release 1.2.0 — minor

Features on top of 1.1.0.

Derived versions:
- **Android:** `1.2.0.<gitCode>`
- **Web:** `1.2.0+web.<gitCode>`

### Changes
- **feat(settings): emoji picker for trigger icons** — tap a tag's icon in Settings → Manage triggers to choose from a curated emoji grid, with a Reset action that restores the built-in default. Shared palette so mobile (AlertDialog grid) and web (anchored popover) offer the same choices.
- **feat(settings): rename triggers & remove built-in defaults** — every trigger (built-in or custom) gets Rename + Remove. Rename is a label override: the key stored on smokes never changes, so history and the "By trigger" breakdown keep counting correctly. Removed built-ins can be brought back via "Restore removed defaults (N)".
- **feat(stats): share % on the trigger pie** — mobile prints the % on slices wide enough (legend keeps count + % for small ones); web bakes the % into the legend labels ("Coffee — 40%").

After merge: deploy mobile + web from `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)