### PR TITLE
Release: 1.4.1 — localized dates/tabs & pinned web sidebar

### DIFF
--- a/apps/mobile/src/main/java/com/feragusper/smokeanalytics/MainShellDestinations.kt
+++ b/apps/mobile/src/main/java/com/feragusper/smokeanalytics/MainShellDestinations.kt
@@ -40,6 +40,7 @@ import com.feragusper.smokeanalytics.features.settings.presentation.navigation.S
 import com.feragusper.smokeanalytics.features.stats.presentation.StatsView
 import com.feragusper.smokeanalytics.features.stats.presentation.StatsViewModel
 import com.feragusper.smokeanalytics.features.stats.presentation.mvi.compose.HeaderNavigation
+import com.feragusper.smokeanalytics.features.stats.presentation.R as StatsR
 import com.feragusper.smokeanalytics.features.stats.presentation.mvi.compose.StatsViewState
 import com.feragusper.smokeanalytics.features.stats.presentation.navigation.StatsNavigator
 import com.feragusper.smokeanalytics.map.MapMobileRoute
@@ -133,11 +134,7 @@ fun AnalyticsMobileDestination(
                     Tab(
                         selected = currentPeriod == period,
                         onClick = { currentPeriod = period },
-                        text = {
-                            Text(
-                                period.name.lowercase().replaceFirstChar { it.uppercase() },
-                            )
-                        },
+                        text = { Text(stringResource(period.tabLabelRes())) },
                     )
                 }
             }
@@ -240,4 +237,12 @@ private fun StatsMobileDestination(
 private enum class AnalyticsTab(val labelRes: Int) {
     Trends(R.string.map_tab_frequency),
     Map(R.string.map_tab_clusters),
+}
+
+/** Period tab labels for the Analytics shell; reuses the stats module's localized strings. */
+private fun StatsViewState.StatsPeriod.tabLabelRes(): Int = when (this) {
+    StatsViewState.StatsPeriod.DAY -> StatsR.string.stats_period_day
+    StatsViewState.StatsPeriod.WEEK -> StatsR.string.stats_period_week
+    StatsViewState.StatsPeriod.MONTH -> StatsR.string.stats_period_month
+    StatsViewState.StatsPeriod.YEAR -> StatsR.string.stats_period_year
 }

--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,6 +1,7 @@
 What's new:
 • Month names and day labels now show in your language across the archive and reminders.
 • The Analytics period tabs (Day / Week / Month / Year) are now translated.
+• Web: the sidebar now stays pinned while the page scrolls.
 • Small polish for a more consistent, fully localized experience.
 
 Notice more, smoke less.

--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,7 +1,6 @@
 What's new:
-• Full English & Spanish — every screen is now localized end to end.
-• Clearer Home: sharper goal status, craving support, and consistency streaks.
-• Analytics polish: daily-pace summaries and fully localized charts and labels.
-• Many small fixes for a calmer, more consistent experience.
+• Month names and day labels now show in your language across the archive and reminders.
+• The Analytics period tabs (Day / Week / Month / Year) are now translated.
+• Small polish for a more consistent, fully localized experience.
 
-Thanks for helping us make cutting down a little easier. Notice more, smoke less.
+Notice more, smoke less.

--- a/features/history/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/history/presentation/mvi/compose/HistoryViewState.kt
+++ b/features/history/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/history/presentation/mvi/compose/HistoryViewState.kt
@@ -55,6 +55,7 @@ import com.feragusper.smokeanalytics.libraries.smokes.presentation.compose.DateP
 import com.feragusper.smokeanalytics.libraries.smokes.presentation.compose.EmptySmokes
 import com.feragusper.smokeanalytics.libraries.smokes.presentation.compose.SwipeToDismissRow
 import com.valentinilk.shimmer.shimmer
+import androidx.compose.ui.platform.LocalLocale
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
@@ -547,12 +548,17 @@ private fun Instant.plusDays(days: Int, timeZone: TimeZone): Instant =
 private fun Instant.minusDays(days: Int, timeZone: TimeZone): Instant =
     plus(-days, DateTimeUnit.DAY, timeZone)
 
-private fun LocalDate.toUiMonthYear(): String {
-    val monthName = month.name.lowercase().replaceFirstChar { it.titlecase() }
-    return "$monthName $year"
+/** Month name in the user's language (e.g. "July" / "Julio"), title-cased for use as a heading. */
+@Composable
+private fun LocalDate.localizedMonthName(): String {
+    val locale = LocalLocale.current.platformLocale
+    return java.time.Month.of(monthNumber)
+        .getDisplayName(java.time.format.TextStyle.FULL, locale)
+        .replaceFirstChar { it.titlecase(locale) }
 }
 
-private fun LocalDate.toUiMonthDay(): String {
-    val monthName = month.name.lowercase().replaceFirstChar { it.titlecase() }
-    return "$monthName $dayOfMonth"
-}
+@Composable
+private fun LocalDate.toUiMonthYear(): String = "${localizedMonthName()} $year"
+
+@Composable
+private fun LocalDate.toUiMonthDay(): String = "${localizedMonthName()} $dayOfMonth"

--- a/features/history/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/history/presentation/HistoryWebScreen.kt
+++ b/features/history/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/history/presentation/HistoryWebScreen.kt
@@ -66,7 +66,7 @@ fun HistoryWebScreen(
                 state.displayLoading && state.smokes != null -> strings.refreshing
                 state.displayLoading -> strings.loading
                 state.error != null -> strings.needsAttention
-                else -> "${state.smokes?.size ?: 0} entries"
+                else -> strings.entriesCount(state.smokes?.size ?: 0)
             },
             badgeTone = when {
                 state.displayLoading -> StatusTone.Busy
@@ -175,7 +175,7 @@ private fun ArchiveCalendarCard(
             Div(attrs = { attr("style", "display:flex;justify-content:space-between;align-items:flex-end;gap:16px;") }) {
                 Div {
                     Div(attrs = { attr("style", "font-size:30px;font-weight:800;color:var(--sa-color-primary);") }) {
-                        Text(selectedLocalDate.toUiMonthYear())
+                        Text(selectedLocalDate.toUiMonthYear(strings))
                     }
                     Div(attrs = { attr("style", "font-size:13px;color:var(--sa-color-secondary);") }) {
                         Text(strings.dailyAverageUnits(monthCounts.averageOrZero().formatOneDecimal()))
@@ -233,7 +233,7 @@ private fun ArchiveCalendarCard(
             Div(attrs = { attr("style", "display:flex;justify-content:space-between;align-items:center;gap:16px;flex-wrap:wrap;") }) {
                 Div {
                     Div(attrs = { attr("style", "font-size:24px;font-weight:800;color:var(--sa-color-primary);") }) {
-                        Text(selectedLocalDate.toUiMonthDay())
+                        Text(selectedLocalDate.toUiMonthDay(strings))
                     }
                     Div(attrs = { attr("style", "font-size:13px;color:var(--sa-color-secondary);") }) {
                         Text(strings.dailyArchive)
@@ -422,15 +422,11 @@ private fun LocalDate.toUiDate(): String {
     return "$d/$m/$year"
 }
 
-private fun LocalDate.toUiMonthYear(): String {
-    val month = month.name.lowercase().replaceFirstChar { it.uppercase() }
-    return "$month $year"
-}
+private fun LocalDate.toUiMonthYear(strings: AppStrings): String =
+    "${strings.monthName(monthNumber)} $year"
 
-private fun LocalDate.toUiMonthDay(): String {
-    val month = month.name.lowercase().replaceFirstChar { it.uppercase() }
-    return "$month $dayOfMonth"
-}
+private fun LocalDate.toUiMonthDay(strings: AppStrings): String =
+    "${strings.monthName(monthNumber)} $dayOfMonth"
 
 private fun DayOfWeek.mondayBasedIndex(): Int = isoDayNumber - 1
 

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/HomeViewState.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.platform.LocalLocale
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import com.feragusper.smokeanalytics.features.home.presentation.R
@@ -174,6 +175,7 @@ data class HomeViewState(
         onFabConfigChanged: (Boolean, ElapsedTone, (() -> Unit)?) -> Unit,
         intent: (HomeIntent) -> Unit,
     ) {
+        val pendingLabelLocale = LocalLocale.current.platformLocale
         val pullToRefreshState = remember {
             object : PullToRefreshState {
                 private val anim = Animatable(0f, Float.VectorConverter)
@@ -247,7 +249,7 @@ data class HomeViewState(
                 cravingStats = cravingStats,
                 showCravingHint = showCravingHint,
                 pendingRelationshipSmokes = pendingRelationshipSmokes.map {
-                    PendingTriggerSmoke(id = it.id, label = it.date.toPendingTriggerLabel())
+                    PendingTriggerSmoke(id = it.id, label = it.date.toPendingTriggerLabel(pendingLabelLocale))
                 },
                 onOpenRelationship = { id -> intent(HomeIntent.OpenRelationshipPrompt(id)) },
                 intent = intent,
@@ -266,7 +268,7 @@ data class HomeViewState(
             val dateLabel = pendingRelationshipSmokes
                 .firstOrNull { it.id == promptSmokeId }
                 ?.date
-                ?.toPendingTriggerLabel()
+                ?.toPendingTriggerLabel(pendingLabelLocale)
             RelationshipPromptSheet(
                 availableTriggers = availableTriggers,
                 dateLabel = dateLabel,

--- a/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/RelationshipComponents.kt
+++ b/features/home/presentation/mobile/src/main/java/com/feragusper/smokeanalytics/features/home/presentation/mvi/compose/RelationshipComponents.kt
@@ -46,6 +46,7 @@ import com.feragusper.smokeanalytics.libraries.smokes.domain.model.TriggerOption
 import com.feragusper.smokeanalytics.libraries.smokes.domain.model.normalizedTag
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.isoDayNumber
 import kotlinx.datetime.toLocalDateTime
 
 /**
@@ -120,11 +121,16 @@ internal data class PendingTriggerSmoke(
 
 private const val MAX_PENDING_SHOWN = 8
 
-/** Human label for a pending smoke, e.g. "Mon Jun 24 · 14:30". */
-internal fun Instant.toPendingTriggerLabel(timeZone: TimeZone = TimeZone.currentSystemDefault()): String {
+/** Human label for a pending smoke in the user's language, e.g. "Mon Jun 24 · 14:30" / "lun jun 24 · 14:30". */
+internal fun Instant.toPendingTriggerLabel(
+    locale: java.util.Locale,
+    timeZone: TimeZone = TimeZone.currentSystemDefault(),
+): String {
     val dt = toLocalDateTime(timeZone)
-    val weekday = dt.dayOfWeek.name.lowercase().replaceFirstChar { it.uppercase() }.take(3)
-    val month = dt.month.name.lowercase().replaceFirstChar { it.uppercase() }.take(3)
+    val weekday = java.time.DayOfWeek.of(dt.dayOfWeek.isoDayNumber)
+        .getDisplayName(java.time.format.TextStyle.SHORT, locale)
+    val month = java.time.Month.of(dt.monthNumber)
+        .getDisplayName(java.time.format.TextStyle.SHORT, locale)
     val hour = dt.hour.toString().padStart(2, '0')
     val minute = dt.minute.toString().padStart(2, '0')
     return "$weekday $month ${dt.dayOfMonth} · $hour:$minute"

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/EditSmokeDateTimeHelpers.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/EditSmokeDateTimeHelpers.kt
@@ -1,9 +1,11 @@
 package com.feragusper.smokeanalytics.features.home.presentation.web
 
+import com.feragusper.smokeanalytics.libraries.design.i18n.AppStrings
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
+import kotlinx.datetime.isoDayNumber
 import kotlinx.datetime.toLocalDateTime
 
 internal fun Instant.toDateInputValue(timeZone: TimeZone): String {
@@ -21,11 +23,14 @@ internal fun Instant.toTimeInputValue(timeZone: TimeZone): String {
     return "$hour:$minute"
 }
 
-/** Human label for a pending smoke in the reminder card, e.g. "Mon Jun 24 · 14:30". */
-internal fun Instant.toPendingTriggerLabel(timeZone: TimeZone = TimeZone.currentSystemDefault()): String {
+/** Human label for a pending smoke in the reminder card, e.g. "Mon Jun 24 · 14:30" / "Lun Jun 24 · 14:30". */
+internal fun Instant.toPendingTriggerLabel(
+    strings: AppStrings,
+    timeZone: TimeZone = TimeZone.currentSystemDefault(),
+): String {
     val dt = toLocalDateTime(timeZone)
-    val weekday = dt.dayOfWeek.name.lowercase().replaceFirstChar { it.uppercase() }.take(3)
-    val month = dt.month.name.lowercase().replaceFirstChar { it.uppercase() }.take(3)
+    val weekday = strings.weekdayShort(dt.dayOfWeek.isoDayNumber)
+    val month = strings.monthShort(dt.monthNumber)
     val hour = dt.hour.toString().padStart(2, '0')
     val minute = dt.minute.toString().padStart(2, '0')
     return "$weekday $month ${dt.dayOfMonth} · $hour:$minute"

--- a/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeWebScreen.kt
+++ b/features/home/presentation/web/src/commonMain/kotlin/com/feragusper/smokeanalytics/features/home/presentation/web/HomeWebScreen.kt
@@ -214,7 +214,7 @@ fun HomeViewState.Render(
             if (pendingRelationshipSmokes.isNotEmpty()) {
                 RelationshipReminderCardWeb(
                     pending = pendingRelationshipSmokes.map {
-                        PendingTriggerSmoke(id = it.id, label = it.date.toPendingTriggerLabel())
+                        PendingTriggerSmoke(id = it.id, label = it.date.toPendingTriggerLabel(LocalStrings.current))
                     },
                     onOpen = { id -> onIntent(HomeIntent.OpenRelationshipPrompt(id)) },
                 )
@@ -252,7 +252,7 @@ fun HomeViewState.Render(
         val dateLabel = pendingRelationshipSmokes
             .firstOrNull { it.id == promptSmokeId }
             ?.date
-            ?.toPendingTriggerLabel()
+            ?.toPendingTriggerLabel(LocalStrings.current)
         RelationshipPromptDialogWeb(
             availableTriggers = availableTriggers,
             dateLabel = dateLabel,

--- a/gradle.properties
+++ b/gradle.properties
@@ -57,3 +57,6 @@ android.builtInKotlin=true
 # Configuration Cache — speeds up build by caching task graph
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.problems=warn
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true

--- a/libraries/design/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/libraries/design/SmokeWebStyles.kt
+++ b/libraries/design/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/libraries/design/SmokeWebStyles.kt
@@ -132,11 +132,23 @@ object SmokeWebStyles : StyleSheet() {
         flexDirection(FlexDirection.Column)
         gap(20.px)
         property("transition", "width var(--sa-transition-page), flex-basis var(--sa-transition-page), gap var(--sa-transition-page)")
+        // Pin the sidebar to the viewport so it stays in view while the (often long) main
+        // content scrolls. align-self stops it from stretching to the page height, which is
+        // what pushed the footer section far down with an empty gap in the middle.
+        property("align-self", "flex-start")
+        property("position", "sticky")
+        property("top", "24px")
+        property("height", "calc(100vh - 48px)")
+        property("overflow", "hidden")
 
         media(mediaMaxWidth(900.px)) {
             self {
                 property("width", "100%")
                 property("flex", "0 0 auto")
+                // On the stacked mobile layout the sidebar is a normal block, not pinned.
+                property("position", "static")
+                property("height", "auto")
+                property("overflow", "visible")
             }
         }
     }
@@ -192,12 +204,17 @@ object SmokeWebStyles : StyleSheet() {
         display(DisplayStyle.Flex)
         flexDirection(FlexDirection.Column)
         gap(8.px)
-        property("flex", "1 1 auto")
+        // Take only the height the items need, and scroll internally if the viewport is too
+        // short — the footer stays pinned at the bottom of the fixed-height sidebar.
+        property("flex", "0 1 auto")
+        property("min-height", "0")
+        property("overflow-y", "auto")
 
         media(mediaMaxWidth(900.px)) {
             self {
                 property("flex-wrap", "wrap")
                 flexDirection(FlexDirection.Row)
+                property("overflow-y", "visible")
             }
         }
     }

--- a/libraries/design/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/libraries/design/i18n/AppStrings.kt
+++ b/libraries/design/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/libraries/design/i18n/AppStrings.kt
@@ -215,6 +215,17 @@ open class AppStrings internal constructor() {
     open val statsSummaryAcrossElapsedYear: String = "Across elapsed days in the selected year"
     /** Maps a domain weekday/month abbreviation ("Mon".."Sun", "Jan".."Dec") to a localized label; other keys pass through. */
     open fun statsBucketLabel(key: String): String = key
+
+    // Calendar names. [month] is 1..12, [isoDay] is 1 (Monday)..7 (Sunday).
+    open fun monthName(month: Int): String = listOf(
+        "January", "February", "March", "April", "May", "June",
+        "July", "August", "September", "October", "November", "December",
+    )[month - 1]
+
+    open fun monthShort(month: Int): String = monthName(month).take(3)
+
+    open fun weekdayShort(isoDay: Int): String =
+        listOf("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")[isoDay - 1]
     open val needsAttention: String = "Needs attention"
     open val sessionRequired: String = "Session required"
     open val couldNotRefreshHome: String = "Could not refresh home"

--- a/libraries/design/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/libraries/design/i18n/SpanishStrings.kt
+++ b/libraries/design/web/src/jsMain/kotlin/com/feragusper/smokeanalytics/libraries/design/i18n/SpanishStrings.kt
@@ -208,6 +208,19 @@ object SpanishStrings : AppStrings() {
     override val statsSummaryAcrossElapsedMonth: String = "En los días transcurridos del mes seleccionado"
     override val statsSummaryAcrossYear: String = "En el año seleccionado"
     override val statsSummaryAcrossElapsedYear: String = "En los días transcurridos del año seleccionado"
+    override fun monthName(month: Int): String = listOf(
+        "Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio",
+        "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre",
+    )[month - 1]
+
+    override fun monthShort(month: Int): String = listOf(
+        "Ene", "Feb", "Mar", "Abr", "May", "Jun",
+        "Jul", "Ago", "Sep", "Oct", "Nov", "Dic",
+    )[month - 1]
+
+    override fun weekdayShort(isoDay: Int): String =
+        listOf("Lun", "Mar", "Mié", "Jue", "Vie", "Sáb", "Dom")[isoDay - 1]
+
     override fun statsBucketLabel(key: String): String = when (key) {
         "Mon" -> "Lun"; "Tue" -> "Mar"; "Wed" -> "Mié"; "Thu" -> "Jue"; "Fri" -> "Vie"; "Sat" -> "Sáb"; "Sun" -> "Dom"
         "Jan" -> "Ene"; "Feb" -> "Feb"; "Mar" -> "Mar"; "Apr" -> "Abr"; "May" -> "May"; "Jun" -> "Jun"

--- a/misc/store-assets/pending-es-419/es-419/changelogs/default.txt
+++ b/misc/store-assets/pending-es-419/es-419/changelogs/default.txt
@@ -1,6 +1,7 @@
 Novedades:
 • Los nombres de meses y días ahora aparecen en tu idioma en el archivo y los recordatorios.
 • Las pestañas de período en Analíticas (Día / Semana / Mes / Año) ahora están traducidas.
+• Web: la barra lateral ahora queda fija mientras la página hace scroll.
 • Pequeños ajustes para una experiencia más consistente y totalmente localizada.
 
 Notá más, fumá menos.

--- a/misc/store-assets/pending-es-419/es-419/changelogs/default.txt
+++ b/misc/store-assets/pending-es-419/es-419/changelogs/default.txt
@@ -1,7 +1,6 @@
 Novedades:
-• Español e inglés completos: cada pantalla ahora está traducida de punta a punta.
-• Inicio más claro: mejor estado del objetivo, apoyo ante las ganas y rachas de consistencia.
-• Analíticas pulidas: resúmenes de ritmo y gráficos y etiquetas totalmente en tu idioma.
-• Varios ajustes para una experiencia más tranquila y consistente.
+• Los nombres de meses y días ahora aparecen en tu idioma en el archivo y los recordatorios.
+• Las pestañas de período en Analíticas (Día / Semana / Mes / Año) ahora están traducidas.
+• Pequeños ajustes para una experiencia más consistente y totalmente localizada.
 
-Gracias por ayudarnos a hacer más fácil fumar menos.
+Notá más, fumá menos.

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-product.version=1.4.0
+product.version=1.4.1


### PR DESCRIPTION
## What

Patch release. Closes the last English leaks in the UI: text that came from enum names rendered straight to the screen (`Month.JULY` → "July", `StatsPeriod.WEEK` → "Week").

### Fixes (`5d8146e0`)
- **History archive (mobile + web)** — month heading and day label used `month.name.lowercase()`. The month name now comes from the user's locale (`java.time` on mobile, `AppStrings` on web).
- **Analytics period tabs (`apps/mobile`)** — the Analytics shell rendered its own `period.name.lowercase()` instead of the stats module's localized strings; now reuses `stats_period_*`. (The stats screen's own tabs were already localized in 1.4.0 — the shell had a duplicate copy.)
- **Home reminder date label (mobile + web)** — "Mon Jun 24 · 14:30" weekday/month abbreviations are now localized.
- **History web badge** — hardcoded `"N entries"` now uses `entriesCount()`.

Adds `monthName` / `monthShort` / `weekdayShort` to the shared web catalog (en + es).

Not changed on purpose: the map's period word (`MapWebScreen`) — the Spanish override ignores that parameter and English interpolates it correctly.

### Store
- `d…` Release notes refreshed to describe 1.4.1 (supply uploads the changelog on every deploy).

## Version
`1.4.0 → 1.4.1` (PATCH — fixes/polish only, no new features) per the release-hygiene policy.

## Verification
- Mobile: `compileProductionDebugKotlin` ✓, koverVerify (history + home) ✓
- Web: `compileKotlinJs` ✓
- Domain tests: home / goals / smokes ✓
- Swept the repo: no `month.name` / `dayOfWeek.name` leaks left

## Still pending (manual, not blocking)
- Enable **es-419** as a Play Console store language, then move `misc/store-assets/pending-es-419/es-419/` into `fastlane/metadata/android/` (supply fails on a non-activated locale).
- Rasterize `misc/store-assets/feature_graphic.svg` → 1024×500 PNG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Web sidebar (`efe054e4`)
The app shell is a flex row, so the sidebar stretched to the full height of the (long) main content — its footer section ended up far down the page with an empty gap, requiring a full-page scroll to reach. Now pinned like a normal app sidebar: `position: sticky; top; height: calc(100vh - 48px)`, `align-self: flex-start`; the nav list scrolls internally and the footer stays at the bottom. Stacked mobile (≤900px) layout unchanged.